### PR TITLE
Allow theme developers to add markup between panel-row-style and panel-grid-cell

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -815,6 +815,8 @@ function siteorigin_panels_render( $post_id = false, $enqueue_css = true, $panel
 		$siteorigin_panels_inline_css .= siteorigin_panels_generate_css($post_id, $panels_data);
 	}
 
+	echo apply_filters( 'siteorigin_panels_before_content', '', $panels_data['grids'][$gi] );
+
 	foreach ( $grids as $gi => $cells ) {
 
 		$grid_classes = apply_filters( 'siteorigin_panels_row_classes', array('panel-grid'), $panels_data['grids'][$gi] );
@@ -871,6 +873,9 @@ function siteorigin_panels_render( $post_id = false, $enqueue_css = true, $panel
 			if( !empty($cell_style_wrapper) ) echo '</div>';
 			echo '</div>';
 		}
+
+		echo apply_filters( 'siteorigin_panels_after_content', '', $panels_data['grids'][$gi] );
+
 		echo '</div>';
 
 		// Close the


### PR DESCRIPTION
### Goal of PR

We use the Foundation 5 in-house and the grid requires additional markup surrounding rows additionally to the existing `siteorigin_panels_after_row` and `siteorigin_panels_before_row` filters which are available. In particular, we need a filter between `siteorigin_panels_before_row` and the row content.

This PR proposes the addition of two new filters to support the above request and alters the existing panel output as shown below:

**Existing Panel Output**

```
.siteorigin_panels_before_row
    .panel-grid 
        .panel-row-style
                 { panel content }
       .close-panel-row-style
    .close-panel-grid
.siteorigin_panels_after_row
```

**Proposed Panel Output***

```
.siteorigin_panels_before_row
    .panel-grid 
        .panel-row-style
             .siteorigin_panels_before_content
                 { panel content }
            .siteorigin_panels_after_content
        .close-panel-row-style
    .close-panel-grid
.siteorigin_panels_after_row
```
## Filter Reference

`siteorigin_panels_before_content` : Add's markup between opening panel grid tag and row content
`siteorigin_panels_after_content` : Add's markup between row content and the closing panel grid tag
### Example usage:

```
/**
 * Adding wrapper rows to siteorigin panels
 */
function beyond_below_content( $data ) {
    is_front_page() ? $html = '<div class="row"><div class="small-12 columns">' : $html = '';

    return  $html;
}
add_filter( 'siteorigin_panels_before_content', 'beyond_below_content' );


function beyond_after_content( ) {
    is_front_page() ? $html = '</div></div>' : $html = '';

    return $html;
}
add_filter( 'siteorigin_panels_after_content', 'beyond_after_content' );
```
