### PR TITLE
Add a filter hook to change the existing classes

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -981,7 +981,7 @@ function siteorigin_panels_the_widget( $widget, $instance, $grid, $cell, $panel,
 
 	if( empty($post_id) ) $post_id = get_the_ID();
 
-	$classes = array( 'panel', 'widget' );
+	$classes = apply_filters( 'siteorigin_panels_widget_classes', array( 'panel', 'widget' ), $panels_data );
 	if ( !empty( $the_widget ) && !empty( $the_widget->id_base ) ) $classes[] = 'widget_' . $the_widget->id_base;
 	if ( $is_first ) $classes[] = 'panel-first-child';
 	if ( $is_last ) $classes[] = 'panel-last-child';


### PR DESCRIPTION
This filter hook allows theme developers to add or remove classes from the widgets using a filter hook. I used this in my personal theme to remove the default classes to allow for my own customization.
