### PR TITLE
Fix regex to match text in all rows

### DIFF
--- a/inc/default-styles.php
+++ b/inc/default-styles.php
@@ -228,7 +228,7 @@ class SiteOrigin_Panels_Default_Styling {
 		}
 
 		if( !empty($args['row_css']) ){
-			preg_match_all('/(.+?):(.+?);?$/', $args['row_css'], $matches);
+			preg_match_all('/^(.+?):(.+?);?$/m', $args['row_css'], $matches);
 
 			if(!empty($matches[0])){
 				for($i = 0; $i < count($matches[0]); $i++) {
@@ -288,7 +288,7 @@ class SiteOrigin_Panels_Default_Styling {
 		}
 
 		if( !empty($args['widget_css']) ){
-			preg_match_all('/(.+?):(.+?);?$/', $args['widget_css'], $matches);
+			preg_match_all('/^(.+?):(.+?);?$/m', $args['widget_css'], $matches);
 
 			if(!empty($matches[0])){
 				for($i = 0; $i < count($matches[0]); $i++) {


### PR DESCRIPTION
Previously, the regex would only parse the css on the last line of the CSS Styles box.  Now, it parses every line.