### PR TITLE
Close widgets window with esc

### DIFF
--- a/js/siteorigin-panels.js
+++ b/js/siteorigin-panels.js
@@ -2061,6 +2061,9 @@ String.prototype.panelsProcessTemplate = function(){
             this.bodyScrollTop = $('body').scrollTop();
             $('body').css({'overflow':'hidden'});
 
+            // Start listen for keyboard keypresses.
+            $(window).on('keyup', this.keyboardListen);
+
             this.$el.show();
 
             // This triggers once everything is visible
@@ -2089,11 +2092,25 @@ String.prototype.panelsProcessTemplate = function(){
                 $('body').css({'overflow':'auto'});
                 $('body').scrollTop( this.bodyScrollTop );
             }
+            
+            // Stop listen for keyboard keypresses.
+            $(window).off('keyup', this.keyboardListen);
 
             // This triggers once everything is hidden
             this.trigger('close_dialog_complete');
 
             return false;
+        },
+        
+        /**
+         * Keyboard events handler
+         */
+        keyboardListen: function(e) {
+        
+            // [Esc] to close
+            if (e.which == 27) {
+                $('.so-panels-dialog-wrapper .so-close').trigger('click');
+            }
         },
 
         /**


### PR DESCRIPTION
Allow user to close widget adding window with [Esc] keyboard key. Also adding keyboard listener handler function. Actually the closing is not in the very elegant form but it is good start :)