### PR TITLE
Overwriting Page Builder Options

### DIFF
--- a/inc/options.php
+++ b/inc/options.php
@@ -35,7 +35,7 @@ function siteorigin_panels_setting($key = ''){
 		if( !empty($theme_settings) ) $theme_settings = $theme_settings[0];
 		else $theme_settings = array();
 
-		$settings = wp_parse_args( $theme_settings, apply_filters( 'siteorigin_panels_settings_defaults', array(
+		$settings = wp_parse_args( $current_settings, apply_filters( 'siteorigin_panels_settings_defaults', array(
 			'home-page' => false,
 			'home-page-default' => false,
 			'home-template' => 'home-panels.php',
@@ -52,7 +52,7 @@ function siteorigin_panels_setting($key = ''){
 			'animations' => true,
 			'inline-css' => true,
 		) ) );
-		$settings = wp_parse_args( $current_settings, $settings);
+		$settings = wp_parse_args( $theme_settings, $settings);
 
 		// Filter these settings
 		$settings = apply_filters('siteorigin_panels_settings', $settings);


### PR DESCRIPTION
I noticed that overwriting options using add_theme_support( 'siteorigin-panels') does not work. The above changes fixes this. I only replaced the order of $current_settings and $theme_settings, so that way the theme options are applied last.

I tested it on my theme and it works as intended.
