### PR TITLE
Allow multi values

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -315,9 +315,24 @@ function siteorigin_panels_sanitize_style_fields($section, $styles){
 				$return[$k] = !empty( $styles[$k] );
 				break;
 			case 'measurement' :
-				preg_match('/([0-9\.,]+)(.*)/', $styles[$k], $match);
-				if( !empty($match[0]) && $match[0] != '' && !empty($match[2]) ) $return[$k] = $styles[$k];
-				else $return[$k] = '';
+				$measurements = array_map('preg_quote', siteorigin_panels_style_get_measurements_list() );
+				if (!empty($field['multiple'])) {
+					if (preg_match_all('/(?:([0-9\.,]+).*?(' . implode('|', $measurements) . ')+)/', $styles[$k], $match)) {
+						$return[$k] = $styles[$k];
+					}
+					else {
+						$return[$k] = '';
+					}
+				
+				}
+				else {
+					if (preg_match('/([0-9\.,]+).*?(' . implode('|', $measurements) . ')/', $styles[$k], $match)) {
+						$return[$k] = $match[1] . $match[2];
+					}
+					else {
+						$return[$k] = '';
+					}
+				}
 				break;
 			case 'select' :
 				if( !empty( $styles[$k] ) && in_array( $styles[$k], array_keys( $field['options'] ) ) ) {


### PR DESCRIPTION
Supports measurements values like '1 0' [em] wich will provide 1em 0em or so, if for field is set property multiple (example usage is paddings for widgets)

$fields['padding']['multiple'] = 1;