### PR TITLE
Allow panels_info to be passed to instance

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -947,12 +947,9 @@ function siteorigin_panels_render( $post_id = false, $enqueue_css = true, $panel
 			if( !empty($cell_style_wrapper) ) echo $cell_style_wrapper;
 
 			foreach ( $widgets as $pi => $widget_info ) {
-				$instance = $widget_info;
-				unset( $instance['panels_info'] );
-
 				// TODO this wrapper should go in the before/after widget arguments
 				$widget_style_wrapper = siteorigin_panels_start_style_wrapper( 'widget', array(), !empty( $widget_info['panels_info']['style'] ) ? $widget_info['panels_info']['style'] : array() );
-				siteorigin_panels_the_widget( $widget_info['panels_info'], $instance, $gi, $ci, $pi, $pi == 0, $pi == count( $widgets ) - 1, $post_id, $widget_style_wrapper );
+				siteorigin_panels_the_widget( $widget_info['panels_info'], $widget_info, $gi, $ci, $pi, $pi == 0, $pi == count( $widgets ) - 1, $post_id, $widget_style_wrapper );
 			}
 			if ( empty( $widgets ) ) echo '&nbsp;';
 


### PR DESCRIPTION
I assume there's some reasoning the `panels_info` has explicitly been unset from the instance, but I have a seemingly basic use case that is difficult to achieve given the current behavior. Using `get_less_variables`, I'd like to be able to pass the configured `font_color` to the LESS styles so that I can lighten or darken colors in the stylesheet based on the configured font color. The proposed changes make this possible by allowing me to access `$instance['panels_info']['style']['font_color']`. Otherwise, without explicitly calling to and iterating over the `panels_data` post meta, I can't imagine any way to use these configuration options.

Any suggestions for another approach I could be taking here?