### PR TITLE
Allow themes and plugins interact with wpColorPicker Revamped PR #65

### DIFF
--- a/js/siteorigin-panels-styles.js
+++ b/js/siteorigin-panels-styles.js
@@ -85,7 +85,7 @@
 
             // Set up the color fields
             if(typeof $.fn.wpColorPicker !== 'undefined') {
-                this.$('.so-wp-color-field').wpColorPicker();
+                this.$('.so-wp-color-field').wpColorPicker(soPanelsOptions.wpColorPickerOptions);
             }
 
             // Set up the image select fields

--- a/js/siteorigin-panels-styles.js
+++ b/js/siteorigin-panels-styles.js
@@ -85,6 +85,9 @@
 
             // Set up the color fields
             if(typeof $.fn.wpColorPicker !== 'undefined') {
+                if (typeof(panelsOptions.wpColorPickerOptions.palettes) == 'object' && !jQuery.isArray(panelsOptions.wpColorPickerOptions.palettes)) {
+                    panelsOptions.wpColorPickerOptions.palettes = $.map(panelsOptions.wpColorPickerOptions.palettes, function(el) { return el; });
+                }
                 this.$('.so-wp-color-field').wpColorPicker(soPanelsOptions.wpColorPickerOptions);
             }
 

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -350,7 +350,8 @@ function siteorigin_panels_admin_enqueue_scripts($prefix) {
 				'silverlight_xap_url' => includes_url('js/plupload/plupload.silverlight.xap'),
 				'filter_title' => __('Page Builder layouts', 'siteorigin-panels'),
 				'error_message' => __('Error uploading or importing file.', 'siteorigin-panels'),
-			)
+			),
+			'wpColorPickerOptions' => apply_filters('siteorigin_panels_wpcolorpicker_options', array()),
 		));
 
 		if( $screen->base != 'widgets' ) {


### PR DESCRIPTION
Allow themes and plugins interact with wpColorPicker plugin settings. Useful in case of changing default color suggestions.