### PR TITLE
Enable color picker settings for styles

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -159,8 +159,9 @@ function siteorigin_panels_render_style_field( $field, $current, $field_id ){
 			break;
 
 		case 'color' :
+			$settings = wp_json_encode( isset( $field['settings'] ) ? $field['settings'] : (object) array() );
 			?>
-			<input type="text" name="<?php echo esc_attr($field_name) ?>" value="<?php echo esc_attr( $current ) ?>" class="so-wp-color-field" />
+			<input type="text" name="<?php echo esc_attr($field_name) ?>" value="<?php echo esc_attr( $current ) ?>" data-settings="<?php echo esc_attr( $settings ); ?>" class="so-wp-color-field" />
 			<?php
 			break;
 

--- a/js/siteorigin-panels-styles.js
+++ b/js/siteorigin-panels-styles.js
@@ -85,7 +85,16 @@
 
             // Set up the color fields
             if(typeof $.fn.wpColorPicker !== 'undefined') {
-                this.$('.so-wp-color-field').wpColorPicker();
+                this.$('.so-wp-color-field').each(function(){
+                    var $s = $(this);
+                    var settings;
+
+                    try {
+                        settings = JSON.parse( $s.attr('data-settings') );
+                    } catch (e) {}
+
+                    $s.wpColorPicker( settings );
+                });
             }
 
             // Set up the image select fields


### PR DESCRIPTION
This pull request enables one to specify [color picker options](http://automattic.github.io/Iris/#options) by passing an associative array of `settings` to the color field. My specific use-case is to allow theme-specific color options (i.e. palettes) for the background color of a row. With these changes, I can accomplish this using the following snippet:

```php
<?php

function register_widget_row_fields( $fields ) {
	$background_colors = apply_filters( 'widget_row_background_colors', array() );
	if ( ! empty( $background_colors ) ) {
		$fields['background']['settings'] = array(
			'palettes' => $background_colors
		);
	}

	return $fields;
}
add_filter( 'siteorigin_panels_row_style_fields', 'register_widget_row_fields', 20 );
```