### PR TITLE
Improved checking for home page in sidebars emulator

### DIFF
--- a/inc/sidebars-emulator.php
+++ b/inc/sidebars-emulator.php
@@ -66,7 +66,8 @@ class SiteOrigin_Panels_Sidebars_Emulator {
 		$post_id = url_to_postid( add_query_arg( false, false ) );
 		if( empty($post_id) ) {
 			// Maybe this is the home page
-			if( add_query_arg(false, false) == '/' && get_option('page_on_front') != 0 ) {
+			$home_url_parts = parse_url( trailingslashit( home_url() ) );
+			if( add_query_arg( false, false ) === $home_url_parts['path'] && get_option('page_on_front') != 0 ) {
 				$post_id = get_option( 'page_on_front' );
 			}
 		}


### PR DESCRIPTION
The check for the home page was too simplified before, working only when WP was installed on the domain root. If it was installed inside path, ie. `http://domain.com/path/to/wp/` or when using WP network with paths for sites (my use case) the check failed.

Improved with more robust check, using `home_url()` and native PHP function `parse_url()`.

Tested on WP network and single site.

Q: is this plugin PHP unit tested?