### PR TITLE
Make JS_SUFFIX constant overrideable

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -12,7 +12,9 @@ Donate link: http://siteorigin.com/page-builder/#donate
 */
 
 define('SITEORIGIN_PANELS_VERSION', 'dev');
-define('SITEORIGIN_PANELS_JS_SUFFIX', '');
+if ( ! defined('SITEORIGIN_PANELS_JS_SUFFIX' ) {
+	define('SITEORIGIN_PANELS_JS_SUFFIX', '');
+}
 define('SITEORIGIN_PANELS_BASE_FILE', __FILE__);
 
 // All the basic settings


### PR DESCRIPTION
Perhaps a bit of an edge case, but this checks to see whether the constant `SITEORIGIN_PANELS_JS_SUFFIX` is already defined, before defining it. 

This will allow developers to use non-minified scripts in local environments for debugging, without needing to run the `develop` branch of the plugin. Instead, they can define the constant as a blank string in their `wp-config.php` file. 

I looked and don't see any way this will interfere with the `gulpfile.js` release build script, but it may be a good idea to check.