### PR TITLE
Adding new hook for adding HTML before row

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -927,6 +927,9 @@ function siteorigin_panels_render( $post_id = false, $enqueue_css = true, $panel
 			echo $name.'="'.esc_attr($value).'" ';
 		}
 		echo '>';
+		
+		// This allows other themes and plugins to add html before the row, inside div element
+		echo apply_filters( 'siteorigin_panels_before_row_inside_grid', '', $panels_data['grids'][$gi], $grid_attributes );
 
 		$style_attributes = array();
 		if( !empty( $panels_data['grids'][$gi]['style']['class'] ) ) {


### PR DESCRIPTION
New filter 'siteorigin_panels_before_row_inside_grid' allows themes or plugins to add HTML at the beggining of each row, but inside panel-grid DIV element. This is usefull for corner ribbons as well as for other design elements.