### PR TITLE
Only unique HTML classes in the widget output

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -1155,9 +1155,11 @@ function siteorigin_panels_the_widget( $widget_info, $instance, $grid, $cell, $p
 	$id = 'panel-' . $post_id . '-' . $grid . '-' . $cell . '-' . $panel;
 
 	// Filter and sanitize the classes
-	$classes = apply_filters('siteorigin_panels_widget_classes', $classes, $widget, $instance, $widget_info);
+	$classes = apply_filters( 'siteorigin_panels_widget_classes', $classes, $widget, $instance, $widget_info );
 	$classes = explode( ' ', implode( ' ', $classes ) );
-	$classes = array_map('sanitize_html_class', $classes);
+	$classes = array_filter( $classes );
+	$classes = array_unique( $classes );
+	$classes = array_map( 'sanitize_html_class', $classes );
 
 	$title_html = siteorigin_panels_setting( 'title-html' );
 	if( strpos($title_html, '{{title}}') !== false ) {


### PR DESCRIPTION
Related to #95.

It is fixing a bug when 2 same HTML classes were outputted for the native WP widgets. Now the `$classes` array goes through the [array_unique](http://php.net/manual/en/function.array-unique.php) (and though array_filter to remove all falsey values from array).