### PR TITLE
Changed the #content-panels anchor to look for the correct span after…

### DIFF
--- a/js/siteorigin-panels.js
+++ b/js/siteorigin-panels.js
@@ -1409,7 +1409,7 @@ String.prototype.panelsProcessTemplate = function(){
                     thisView.trigger('hide_builder');
                 } ).end()
                 .prepend(
-                $( '<a id="content-panels" class="hide-if-no-js wp-switch-editor switch-panels">' + metabox.find( 'h3.hndle span' ).html() + '</a>' )
+                $( '<a id="content-panels" class="hide-if-no-js wp-switch-editor switch-panels">' + metabox.find( '.hndle span' ).html() + '</a>' )
                     .click( function (e) {
                         // Switch to the Page Builder interface
                         e.preventDefault();
@@ -2171,7 +2171,7 @@ String.prototype.panelsProcessTemplate = function(){
                 $('body').css({'overflow':'auto'});
                 $('body').scrollTop( this.bodyScrollTop );
             }
-            
+
             // Stop listen for keyboard keypresses.
             $(window).off('keyup', this.keyboardListen);
 
@@ -2180,12 +2180,12 @@ String.prototype.panelsProcessTemplate = function(){
 
             return false;
         },
-        
+
         /**
          * Keyboard events handler
          */
         keyboardListen: function(e) {
-        
+
             // [Esc] to close
             if (e.which === 27) {
                 $('.so-panels-dialog-wrapper .so-close').trigger('click');


### PR DESCRIPTION
… WP 4.4 switched from using a h3 to a h2. This now places the correct text in the anchor (rather than 'undefined'). Also makes it more generic by not over qualifying the selector so should WP change headings again upstream, this shouldn't happen. Fixes 115.