### PR TITLE
Changed the #content-panels anchor to look for the correct span after…

### DIFF
--- a/js/siteorigin-panels.js
+++ b/js/siteorigin-panels.js
@@ -1409,7 +1409,7 @@ String.prototype.panelsProcessTemplate = function(){
                     thisView.trigger('hide_builder');
                 } ).end()
                 .prepend(
-                $( '<a id="content-panels" class="hide-if-no-js wp-switch-editor switch-panels">' + metabox.find( 'h3.hndle span' ).html() + '</a>' )
+                $( '<a id="content-panels" class="hide-if-no-js wp-switch-editor switch-panels">' + metabox.find( '.hndle span' ).html() + '</a>' )
                     .click( function (e) {
                         // Switch to the Page Builder interface
                         e.preventDefault();


### PR DESCRIPTION
… WP 4.4 switched from using a h3 to a h2. This now places the correct text in the anchor (rather than 'undefined'). Also makes it more generic by not over qualifying the selector so should WP change headings again upstream, this shouldn't happen. Fixes #115.

I'm not entirely sure why the PR can't be merged automatically - it doesn't give me any more info. I've forked your repo and branched from master.