### PR TITLE
For GH-137: live editor not working when `.widget` class not used.

### DIFF
--- a/js/siteorigin-panels-live-editor.js
+++ b/js/siteorigin-panels-live-editor.js
@@ -48,7 +48,7 @@
                     var ifc = $(this).contents();
 
                     // Lets find all the first level grids. This is to account for the Page Builder layout widget.
-                    ifc.find('.panel-grid .panel-grid-cell .so-panel.widget')
+                    ifc.find('.panel-grid .panel-grid-cell .so-panel')
                         .filter(function(){
                             // Filter to only include non nested
                             return $(this).parents('.widget_siteorigin-panels-builder').length == 0;
@@ -258,7 +258,7 @@
                     var getHoverWidget = function(){
                         // TODO this should target the #pl-x selector
                         return previewFrame.contents()
-                            .find('#pl-' + thisView.postId + ' .panel-grid .panel-grid-cell .widget')
+                            .find('#pl-' + thisView.postId + ' .panel-grid .panel-grid-cell .so-panel')
                             .filter(function(){
                                 // Filter to only include non nested
                                 return $(this).parents('.widget_siteorigin-panels-builder').length === 0;


### PR DESCRIPTION
Use `.so-panel` class to identify widget panels in live editor.