### PR TITLE
Fix for compatibility issues with Yoast SEO.

### DIFF
--- a/js/siteorigin-panels.js
+++ b/js/siteorigin-panels.js
@@ -1980,24 +1980,37 @@ String.prototype.panelsProcessTemplate = function(){
                             $(this).replaceWith(c);
                         });
                         content = t.html();
-
-                        // Set the content of the editor
-                        if( typeof tinyMCE === 'undefined' || tinyMCE.get("content") === null ) {
-                            $('#content').val( content );
-                        }
-                        else {
-                            tinyMCE.get("content").setContent(content);
-                        }
-
-                        // Trigger a focusout (mainly for Yoast SEO)
-                        $('#content').focusout();
-                    }
+                        this.updateEditorContent(content);
+                    }.bind(this)
                 );
             }
 
             if( this.liveEditor !== false ) {
                 // Refresh the content of the builder
                 this.liveEditor.refreshPreview();
+            }
+        },
+
+        updateEditorContent:function (content, retry) {
+			retry = retry || 0;
+            if( typeof tinyMCE === 'undefined' || tinyMCE.get("content") === null ) {
+				// Retry 3 times in case TinyMCE just hasn't loaded properly yet.
+				if(retry < 3) {
+					setTimeout(function(){
+						this.updateEditorContent(content, ++retry);
+					}.bind(this), 200);
+				} else {
+					var contentArea = $('#content');
+					contentArea.val(content);
+					// Trigger a focusout (mainly for older versions of Yoast SEO)
+					contentArea.focusout();
+				}
+            }
+            else {
+                var contentEd = tinyMCE.get("content");
+                contentEd.setContent(content);
+				// Trigger a change (mainly for newer versions of Yoast SEO) :/
+                contentEd.fire('change');
             }
         },
 
@@ -2369,7 +2382,7 @@ String.prototype.panelsProcessTemplate = function(){
                 $('body').css({'overflow':'auto'});
                 $('body').scrollTop( this.bodyScrollTop );
             }
-            
+
             // Stop listen for keyboard keypresses.
             $(window).off('keyup', this.keyboardListen);
 
@@ -2378,12 +2391,12 @@ String.prototype.panelsProcessTemplate = function(){
 
             return false;
         },
-        
+
         /**
          * Keyboard events handler
          */
         keyboardListen: function(e) {
-        
+
             // [Esc] to close
             if (e.which === 27) {
                 $('.so-panels-dialog-wrapper .so-close').trigger('click');
@@ -4074,6 +4087,8 @@ jQuery( function($){
             .attachToEditor()
             .addLiveEditor( postId )
             .addHistoryBrowser();
+
+        builderView.handleContentChange();
 
         // When the form is submitted, update the panels data
         form.submit( function(e){


### PR DESCRIPTION
This immediately copies PB content across to the default TinyMCE editor if it's available and if not, retries 3 times with small delays. Additionally it fires a 'change' event when the content is changed, which should trigger Yoast SEO's handling of the content.