### PR TITLE
Tablet responsive break point setting

### DIFF
--- a/settings/settings.php
+++ b/settings/settings.php
@@ -118,6 +118,7 @@ class SiteOrigin_Panels_Settings {
 
 		// The layout fields
 		$defaults['responsive'] = true;
+		$defaults['tablet-width'] = 1024;
 		$defaults['mobile-width'] = 780;
 		$defaults['margin-bottom'] = 30;
 		$defaults['margin-sides'] = 30;
@@ -239,6 +240,13 @@ class SiteOrigin_Panels_Settings {
 			'type' => 'checkbox',
 			'label' => __('Responsive Layout', 'siteorigin-panels'),
 			'description' => __('Collapse widgets, rows and columns on mobile devices.', 'siteorigin-panels'),
+		);
+
+		$fields['layout']['fields']['tablet-width'] = array(
+			'type' => 'number',
+			'unit' => 'px',
+			'label' => __('Tablet Width', 'siteorigin-panels'),
+			'description' => __('Device width, in pixels, to collapse into a tablet view .', 'siteorigin-panels'),
 		);
 
 		$fields['layout']['fields']['mobile-width'] = array(

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -700,6 +700,7 @@ function siteorigin_panels_generate_css($post_id, $panels_data = false){
 
 	// Get some of the default settings
 	$settings = siteorigin_panels_setting();
+	$panels_tablet_width = $settings['tablet-width'];
 	$panels_mobile_width = $settings['mobile-width'];
 	$panels_margin_bottom = $settings['margin-bottom'];
 
@@ -743,6 +744,11 @@ function siteorigin_panels_generate_css($post_id, $panels_data = false){
 		}
 
 		if ( $settings['responsive'] ) {
+			// Tablet Responsive
+			$css->add_cell_css($post_id, $gi, false, '', array(
+				'width' => '50%'
+			), $panels_tablet_width);
+
 			// Mobile Responsive
 			$css->add_cell_css($post_id, $gi, false, '', array(
 				'float' => 'none',
@@ -751,6 +757,9 @@ function siteorigin_panels_generate_css($post_id, $panels_data = false){
 
 			for ( $i = 0; $i < $cell_count; $i++ ) {
 				if ( $i != $cell_count - 1 ) {
+					$css->add_cell_css($post_id, $gi, $i, '', array(
+						'margin-bottom' => $panels_margin_bottom . 'px',
+					), $panels_tablet_width);
 					$css->add_cell_css($post_id, $gi, $i, '', array(
 						'margin-bottom' => $panels_margin_bottom . 'px',
 					), $panels_mobile_width);


### PR DESCRIPTION
Added tablet responsive setting, which defaults to 1024px and simply sets column widths to 50%.