### PR TITLE
Fix for compatibility issues with Yoast SEO.

### DIFF
--- a/js/siteorigin-panels/main.js
+++ b/js/siteorigin-panels/main.js
@@ -116,6 +116,8 @@ jQuery( function($){
             .addLiveEditor( postId )
             .addHistoryBrowser();
 
+        builderView.handleContentChange();
+
         // When the form is submitted, update the panels data
         form.submit( function(e){
             // Refresh the data

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -579,13 +579,38 @@ module.exports = Backbone.View.extend( {
 
                     // Trigger a focusout (mainly for Yoast SEO)
                     $('#content').focusout();
-                }
+
+                    this.updateEditorContent(content);
+                }.bind(this)
             );
         }
 
         if( this.liveEditor !== false ) {
             // Refresh the content of the builder
             this.liveEditor.refreshPreview();
+        }
+    },
+
+    updateEditorContent:function (content, retry) {
+        retry = retry || 0;
+        if( typeof tinyMCE === 'undefined' || tinyMCE.get("content") === null ) {
+            // Retry 3 times in case TinyMCE just hasn't loaded properly yet.
+            if(retry < 3) {
+                setTimeout(function(){
+                    this.updateEditorContent(content, ++retry);
+                }.bind(this), 200);
+            } else {
+                var contentArea = $('#content');
+                contentArea.val(content);
+                // Trigger a focusout (mainly for older versions of Yoast SEO)
+                contentArea.focusout();
+            }
+        }
+        else {
+            var contentEd = tinyMCE.get("content");
+            contentEd.setContent(content);
+            // Trigger a change (mainly for newer versions of Yoast SEO) :/
+            contentEd.fire('change');
         }
     },
 

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -569,17 +569,6 @@ module.exports = Backbone.View.extend( {
                     });
                     content = t.html();
 
-                    // Set the content of the editor
-                    if( typeof tinyMCE === 'undefined' || tinyMCE.get("content") === null ) {
-                        $('#content').val( content );
-                    }
-                    else {
-                        tinyMCE.get("content").setContent(content);
-                    }
-
-                    // Trigger a focusout (mainly for Yoast SEO)
-                    $('#content').focusout();
-
                     this.updateEditorContent(content);
                 }.bind(this)
             );


### PR DESCRIPTION
Duplicate of this GH-143 but merging into feature/gulp-browserify branch.

This immediately copies PB content across to the default TinyMCE editor if it's available and if not, retries 3 times with small delays. Additionally it fires a 'change' event when the content is changed, which should trigger Yoast SEO's handling of the content.