### PR TITLE
add hook to inject HTML before and after cell loop; fix #147

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -1027,6 +1027,8 @@ function siteorigin_panels_render( $post_id = false, $enqueue_css = true, $panel
 			$cells = array_reverse( $cells, true );
 		}
 
+		echo apply_filters( 'siteorigin_panels_before_cell_loop', '', $panels_data['grids'][$gi], $grid_attributes );
+
 		foreach ( $cells as $ci => $widgets ) {
 			// Themes can add their own styles to cells
 			$cell_classes = apply_filters( 'siteorigin_panels_row_cell_classes', array('panel-grid-cell'), $panels_data );
@@ -1054,6 +1056,8 @@ function siteorigin_panels_render( $post_id = false, $enqueue_css = true, $panel
 			if( !empty($cell_style_wrapper) ) echo '</div>';
 			echo '</div>';
 		}
+
+		echo apply_filters( 'siteorigin_panels_after_cell_loop', '', $panels_data['grids'][$gi], $grid_attributes );
 
 		echo '</div>';
 


### PR DESCRIPTION
There are hooks to add HTML content before and after row. But I want to wrap all cells with a div to apply extra styling. Adding those hooks will be great. I am submitting patch later.
