### PR TITLE
add grid and cell index to siteorigin_panels_row_cell_classes

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -1077,7 +1077,7 @@ function siteorigin_panels_render( $post_id = false, $enqueue_css = true, $panel
 
 		foreach ( $cells as $ci => $widgets ) {
 			// Themes can add their own styles to cells
-			$cell_classes = apply_filters( 'siteorigin_panels_row_cell_classes', array('panel-grid-cell'), $panels_data );
+			$cell_classes = apply_filters( 'siteorigin_panels_row_cell_classes', array('panel-grid-cell'), $panels_data, $gi, $ci );
 			$cell_attributes = apply_filters( 'siteorigin_panels_row_cell_attributes', array(
 				'class' => implode( ' ', $cell_classes ),
 				'id' => 'pgc-' . $post_id . '-' . ( !empty($grid_id) ? $grid_id : $gi )  . '-' . $ci


### PR DESCRIPTION
Adding grid-index and cell-index to the filter 'siteorigin_panels_row_cell_classes'. This makes it easy to access the corresponding panels_data of the current cell. Now one can add custom classes and it's possible to use Foundation or Bootstrap.

Example for using the filter with the additional arguments:

```
function foundation_row_cell_classes( $default_classes, $panels_data, $gi, $ci ) {

    $foundation_columns = array(
        '1' => '12',
        '2' => '6',
        '3' => '4',
        '4' => '3',
        '6' => '2',
        '12' => '1',
    );

    $cells_count = $panels_data['grids'][ $gi ]['cells'];

    $default_classes[] = 'large-'.$foundation_columns[ $cells_count ];
    $default_classes[] = 'columns';

    return $default_classes;
}
add_filter( 'siteorigin_panels_row_cell_classes', 'foundation_row_cell_classes', 10, 4 );
```
