### PR TITLE
Control widget description by using selected field content

### DIFF
--- a/js/siteorigin-panels.js
+++ b/js/siteorigin-panels.js
@@ -2842,6 +2842,24 @@ module.exports = Backbone.Model.extend( {
 			// This means that the widget has told us which field it wants us to use as a title
 			if ( widgetData.panels_title === false ) {
 				return panelsOptions.widgets[this.get( 'class' )].description;
+			} else {
+				// Get every value and iterate the keys
+		        var values = this.get( 'values' );
+
+		        for ( var k in values ) {
+		            if( typeof values[k] !== 'object' ) {
+		                if ( values.hasOwnProperty( k ) && k == widgetData.panels_title ) {
+		                    return values[k];
+		                }
+		            } else {
+		                // If we are into a section, check inside keys too
+		                for( var j in values[k] ) {
+		                    if( values[k].hasOwnProperty( j ) && j == widgetData.panels_title ) {
+		                        return values[k][j];
+		                    }
+		                }
+		            }
+		        }
 			}
 		}
 


### PR DESCRIPTION
#232 I need this feature in my current work, so I used [solution](https://siteorigin.com/thread/how-can-i-control-the-widget-description-in-a-pagebuilder-grid/) proposed by @LuBevilacqua. It's a quickfix rather than full solution, but it does what it has to. According to comment in line 2842, previous code was incomplete.
