### PR TITLE
Replace TinyMCE _.isUndefined()  check with a typeof

### DIFF
--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -689,7 +689,7 @@ module.exports = Backbone.View.extend( {
 	 */
 	updateEditorContent: function ( content ) {
 		// Switch back to the standard editor
-		if ( this.config.editorType !== 'tinymce' || typeof tinymce === 'undefined' || _.isNull( tinyMCE.get( "content" ) ) ) {
+		if ( this.config.editorType !== 'tinyMCE' || typeof tinymce === 'undefined' || _.isNull( tinyMCE.get( "content" ) ) ) {
 			var $editor = $( this.config.editorId );
 			$editor.val( content ).trigger( 'change' ).trigger( 'keyup' );
 		} else {
@@ -736,7 +736,7 @@ module.exports = Backbone.View.extend( {
 		var editorContent = '';
 		var editor;
 
-		if ( typeof tinymce !== 'undefined' ) {
+		if ( typeof tinyMCE !== 'undefined' ) {
 			editor = tinyMCE.get( 'content' );
 		}
 		if ( editor && _.isFunction( editor.getContent ) ) {

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -689,7 +689,7 @@ module.exports = Backbone.View.extend( {
 	 */
 	updateEditorContent: function ( content ) {
 		// Switch back to the standard editor
-		if ( this.config.editorType !== 'tinyMCE' || typeof tinymce === 'undefined' || _.isNull( tinyMCE.get( "content" ) ) ) {
+		if ( this.config.editorType !== 'tinyMCE' || typeof tinyMCE === 'undefined' || _.isNull( tinyMCE.get( "content" ) ) ) {
 			var $editor = $( this.config.editorId );
 			$editor.val( content ).trigger( 'change' ).trigger( 'keyup' );
 		} else {

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -689,7 +689,7 @@ module.exports = Backbone.View.extend( {
 	 */
 	updateEditorContent: function ( content ) {
 		// Switch back to the standard editor
-		if ( this.config.editorType !== 'tinymce' || _.isUndefined( tinyMCE ) || _.isNull( tinyMCE.get( "content" ) ) ) {
+		if ( this.config.editorType !== 'tinymce' || typeof tinymce === 'undefined' || _.isNull( tinyMCE.get( "content" ) ) ) {
 			var $editor = $( this.config.editorId );
 			$editor.val( content ).trigger( 'change' ).trigger( 'keyup' );
 		} else {
@@ -736,7 +736,7 @@ module.exports = Backbone.View.extend( {
 		var editorContent = '';
 		var editor;
 
-		if ( ! _.isUndefined( tinyMCE ) ) {
+		if ( typeof tinymce !== 'undefined' ) {
 			editor = tinyMCE.get( 'content' );
 		}
 		if ( editor && _.isFunction( editor.getContent ) ) {

--- a/js/siteorigin-panels/view/dialog.js
+++ b/js/siteorigin-panels/view/dialog.js
@@ -409,7 +409,7 @@ module.exports = Backbone.View.extend( {
 				else if ( $$.prop( 'tagName' ) === 'TEXTAREA' && $$.hasClass( 'wp-editor-area' ) ) {
 					// This is a TinyMCE editor, so we'll use the tinyMCE object to get the content
 					var editor = null;
-					if ( typeof tinymce !== 'undefined' ) {
+					if ( typeof tinyMCE !== 'undefined' ) {
 						editor = tinyMCE.get( $$.attr( 'id' ) );
 					}
 

--- a/js/siteorigin-panels/view/dialog.js
+++ b/js/siteorigin-panels/view/dialog.js
@@ -409,7 +409,7 @@ module.exports = Backbone.View.extend( {
 				else if ( $$.prop( 'tagName' ) === 'TEXTAREA' && $$.hasClass( 'wp-editor-area' ) ) {
 					// This is a TinyMCE editor, so we'll use the tinyMCE object to get the content
 					var editor = null;
-					if ( ! _.isUndefined( tinyMCE ) ) {
+					if ( typeof tinymce !== 'undefined' ) {
 						editor = tinyMCE.get( $$.attr( 'id' ) );
 					}
 


### PR DESCRIPTION
_.isUndefined() returns a reference error if TinyMCE isn't set ([reference](https://github.com/jashkenas/underscore/issues/250)). This means that if the visual editor is disabled (which can be done via the user profile) SiteOrigin Page Builder won't save any changes. Changing _.isUndefined() to a typeof check resolves this issue and allows the user to continue using SiteOrigin Page Builder.
