### PR TITLE
Corrected post__not_in issue for additional field

### DIFF
--- a/widgets/basic.php
+++ b/widgets/basic.php
@@ -253,7 +253,11 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget{
 		global $siteorigin_panels_current_post;
 
 		if( !empty($siteorigin_panels_current_post) ){
-			if(!empty($query_args['post__not_in'])){
+			if( !empty( $query_args['post__not_in'] ) ){
+				if( !is_array( $query_args['post__not_in'] ) ){
+					$query_args['post__not_in'] = explode( ',', $query_args['post__not_in'] );
+					$query_args['post__not_in'] = array_map( 'intval', $query_args['post__not_in'] );
+				}
 				$query_args['post__not_in'][] = $siteorigin_panels_current_post;
 			}
 			else {


### PR DESCRIPTION
If a user adds post__not_in to the additional field it'll cause a fatal error as [this line](https://github.com/siteorigin/siteorigin-panels/blob/develop/widgets/basic.php#L257) doesn't account for strings.

How to replicate this issue:
- Add the following into the additional field: post__not_in=372

This will cause the following error: PHP Fatal error:  [] operator not supported for strings in D:\wamp\www\siteorigin\wp-content\plugins\siteorigin-panels\widgets\basic.php on line 257

Stack Trace:
> [01-Nov-2016 07:35:18 UTC] PHP   1. {main}() D:\wamp\www\siteorigin\index.php:0
> [01-Nov-2016 07:35:18 UTC] PHP   2. require() D:\wamp\www\siteorigin\index.php:17
> [01-Nov-2016 07:35:18 UTC] PHP   3. require_once() D:\wamp\www\siteorigin\wp-blog-header.php:19
> [01-Nov-2016 07:35:18 UTC] PHP   4. include() D:\wamp\www\siteorigin\wp-includes\template-loader.php:75
> [01-Nov-2016 07:35:18 UTC] PHP   5. get_header() D:\wamp\www\siteorigin\wp-content\themes\vantage\single.php:10
> [01-Nov-2016 07:35:18 UTC] PHP   6. locate_template() D:\wamp\www\siteorigin\wp-includes\general-template.php:45
> [01-Nov-2016 07:35:18 UTC] PHP   7. load_template() D:\wamp\www\siteorigin\wp-includes\template.php:531
> [01-Nov-2016 07:35:18 UTC] PHP   8. require_once() D:\wamp\www\siteorigin\wp-includes\template.php:572
> [01-Nov-2016 07:35:18 UTC] PHP   9. wp_head() D:\wamp\www\siteorigin\wp-content\themes\vantage\header.php:18
> [01-Nov-2016 07:35:18 UTC] PHP  10. do_action() D:\wamp\www\siteorigin\wp-includes\general-template.php:2555
> [01-Nov-2016 07:35:18 UTC] PHP  11. call_user_func_array:{D:\wamp\www\siteorigin\wp-includes\plugin.php:524}() D:\wamp\www\siteorigin\wp-includes\plugin.php:524
> [01-Nov-2016 07:35:18 UTC] PHP  12. WPSEO_Frontend->head() D:\wamp\www\siteorigin\wp-includes\plugin.php:524
> [01-Nov-2016 07:35:18 UTC] PHP  13. do_action() D:\wamp\www\siteorigin\wp-content\plugins\wordpress-seo\frontend\class-frontend.php:670
> [01-Nov-2016 07:35:18 UTC] PHP  14. call_user_func_array:{D:\wamp\www\siteorigin\wp-includes\plugin.php:524}() D:\wamp\www\siteorigin\wp-includes\plugin.php:524
> [01-Nov-2016 07:35:18 UTC] PHP  15. WPSEO_Twitter::get_instance() D:\wamp\www\siteorigin\wp-includes\plugin.php:524
> [01-Nov-2016 07:35:18 UTC] PHP  16. WPSEO_Twitter->__construct() D:\wamp\www\siteorigin\wp-content\plugins\wordpress-seo\frontend\class-twitter.php:629
> [01-Nov-2016 07:35:18 UTC] PHP  17. WPSEO_Twitter->twitter() D:\wamp\www\siteorigin\wp-content\plugins\wordpress-seo\frontend\class-twitter.php:45
> [01-Nov-2016 07:35:18 UTC] PHP  18. WPSEO_Twitter->description() D:\wamp\www\siteorigin\wp-content\plugins\wordpress-seo\frontend\class-twitter.php:55
> [01-Nov-2016 07:35:18 UTC] PHP  19. WPSEO_Twitter->single_description() D:\wamp\www\siteorigin\wp-content\plugins\wordpress-seo\frontend\class-twitter.php:156
> [01-Nov-2016 07:35:18 UTC] PHP  20. get_the_excerpt() D:\wamp\www\siteorigin\wp-content\plugins\wordpress-seo\frontend\class-twitter.php:198
> [01-Nov-2016 07:35:18 UTC] PHP  21. apply_filters() D:\wamp\www\siteorigin\wp-includes\post-template.php:397
> [01-Nov-2016 07:35:18 UTC] PHP  22. call_user_func_array:{D:\wamp\www\siteorigin\wp-includes\plugin.php:235}() D:\wamp\www\siteorigin\wp-includes\plugin.php:235
> [01-Nov-2016 07:35:18 UTC] PHP  23. wp_trim_excerpt() D:\wamp\www\siteorigin\wp-includes\plugin.php:235
> [01-Nov-2016 07:35:18 UTC] PHP  24. apply_filters() D:\wamp\www\siteorigin\wp-includes\formatting.php:3274
> [01-Nov-2016 07:35:18 UTC] PHP  25. call_user_func_array:{D:\wamp\www\siteorigin\wp-includes\plugin.php:235}() D:\wamp\www\siteorigin\wp-includes\plugin.php:235
> [01-Nov-2016 07:35:18 UTC] PHP  26. siteorigin_panels_filter_content() D:\wamp\www\siteorigin\wp-includes\plugin.php:235
> [01-Nov-2016 07:35:18 UTC] PHP  27. siteorigin_panels_render() D:\wamp\www\siteorigin\wp-content\plugins\siteorigin-panels\siteorigin-panels.php:912
> [01-Nov-2016 07:35:18 UTC] PHP  28. siteorigin_panels_the_widget() D:\wamp\www\siteorigin\wp-content\plugins\siteorigin-panels\siteorigin-panels.php:1130
> [01-Nov-2016 07:35:18 UTC] PHP  29. SiteOrigin_Panels_Widgets_PostLoop->widget() D:\wamp\www\siteorigin\wp-content\plugins\siteorigin-panels\siteorigin-panels.php:1298