### PR TITLE
PB 3.0: Add Fixed background support

### DIFF
--- a/inc/default-styles.php
+++ b/inc/default-styles.php
@@ -147,6 +147,7 @@ class SiteOrigin_Panels_Default_Styles {
 				'tile' => __('Tiled Image', 'siteorigin-panels'),
 				'cover' => __('Cover', 'siteorigin-panels'),
 				'center' => __('Centered, with original size', 'siteorigin-panels'),
+				'fixed' => __( 'Fixed', 'siteorigin-panels' ),
 				'parallax' => __('Parallax', 'siteorigin-panels'),
 				'parallax-original' => __('Parallax (Original Size)', 'siteorigin-panels'),
 			),
@@ -217,6 +218,7 @@ class SiteOrigin_Panels_Default_Styles {
 				'tile' => __('Tiled Image', 'siteorigin-panels'),
 				'cover' => __('Cover', 'siteorigin-panels'),
 				'center' => __('Centered, with original size', 'siteorigin-panels'),
+				'fixed' => __( 'Fixed', 'siteorigin-panels' ),
 				'parallax' => __('Parallax', 'siteorigin-panels'),
 				'parallax-original' => __('Parallax (Original Size)', 'siteorigin-panels'),
 			),
@@ -313,6 +315,9 @@ class SiteOrigin_Panels_Default_Styles {
 						case 'center':
 							$attributes['style'] .= 'background-position: center center; background-repeat: no-repeat;';
 							break;
+						case 'fixed':
+							$attributes['style'] .= 'background-attachment: fixed; background-size: cover;';
+							break;
 					}
 				}
 			}
@@ -389,6 +394,9 @@ class SiteOrigin_Panels_Default_Styles {
 							break;
 						case 'center':
 							$attributes['style'] .= 'background-position: center center; background-repeat: no-repeat;';
+							break;
+						case 'fixed':
+							$attributes['style'] .= 'background-attachment: fixed; background-size: cover;';
 							break;
 					}
 				}


### PR DESCRIPTION
Resolves #257

This is a commonly sought after background image display setting. It's commonly misunderstood as a parallax, which is typically the reason people don't like the Parallax - it's just them misunderstanding what it is. [Here's a comparison between fixed and parallax](http://alex.siteorigin.net/parallax-vs-fixed/).

Adding fixed images is such an easy thing there's little reason for us not to include it. Please note that unlike the #257 suggestion, I opted not to include fixed (original) as, in hindsight, I don't feel like it needs one.

Should fixed be moved to a different location in the image display background drop down? It's currently after center but before Parallax.

![](https://i.imgur.com/EWpY4JM.png)