### PR TITLE
PB 3.0: Increase priority of main filter

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -33,7 +33,7 @@ class SiteOrigin_Panels {
 		add_action( 'admin_bar_menu', array( $this, 'admin_bar_menu' ), 100 );
 
 		// This is the main filter
-		add_filter( 'the_content', array( $this, 'filter_content' ) );
+		add_filter( 'the_content', array( $this, 'filter_content' ), 9 );
 		add_filter( 'body_class', array( $this, 'body_class' ) );
 
 		add_filter( 'siteorigin_panels_data', array( $this, 'process_panels_data' ), 5 );


### PR DESCRIPTION
As per #315 and [this Slack chat](https://siteorigin.slack.com/archives/plugins/p1475089831000049).

We should try using the higher than default priority for on the main content filter compatibility reasons.  Through my, admittedly limited, testing I wasn't able to run into any issues but as always it's possible issues may arise.