### PR TITLE
Add option to add a container to rows

### DIFF
--- a/css/front.css
+++ b/css/front.css
@@ -47,3 +47,17 @@
   display: table;
   clear: both;
 }
+.panel-row-container {
+  margin: 0 auto;
+  width: 100%;
+  zoom: 1;
+}
+.panel-row-container:before {
+  content: '';
+  display: block;
+}
+.panel-row-container:after {
+  content: '';
+  display: table;
+  clear: both;
+}

--- a/css/front.less
+++ b/css/front.less
@@ -24,3 +24,10 @@
 .panel-row-style {
 	.clearfix();
 }
+
+.panel-row-container {
+	zoom: 1;
+	margin: 0 auto;
+	width: 100%;
+	.clearfix();
+}

--- a/inc/default-styles.php
+++ b/inc/default-styles.php
@@ -105,6 +105,7 @@ class SiteOrigin_Panels_Default_Styling {
 			'group' => 'layout',
 			'options' => array(
 				'' => __('Standard', 'siteorigin-panels'),
+				'contained' => __('Contained', 'siteorigin-panels'),
 				'full' => __('Full Width', 'siteorigin-panels'),
 				'full-stretched' => __('Full Width Stretched', 'siteorigin-panels'),
 			),
@@ -257,7 +258,12 @@ class SiteOrigin_Panels_Default_Styling {
 
 	static function row_style_attributes( $attributes, $args ) {
 		if( !empty( $args['row_stretch'] ) ) {
-			$attributes['class'][] = 'siteorigin-panels-stretch';
+			if( $args['row_stretch'] === 'contained' ) {
+				$attributes['class'][] = 'siteorigin-panels-contained';
+			} else {
+				$attributes['class'][] = 'siteorigin-panels-stretch';
+			}
+
 			$attributes['data-stretch-type'] = $args['row_stretch'];
 			wp_enqueue_script('siteorigin-panels-front-styles');
 		}

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -126,6 +126,7 @@ class SiteOrigin_Panels_Settings {
 		$defaults['tablet-layout'] = false;
 		$defaults['tablet-width'] = 1024;
 		$defaults['mobile-width'] = 780;
+		$defaults['row-container-width'] = 860;
 		$defaults['margin-bottom'] = 30;
 		$defaults['margin-bottom-last-row'] = false;
 		$defaults['margin-sides'] = 30;
@@ -314,6 +315,13 @@ class SiteOrigin_Panels_Settings {
 			'unit' => 'px',
 			'label' => __('Mobile Width', 'siteorigin-panels'),
 			'description' => __('Device width, in pixels, to collapse into a mobile view.', 'siteorigin-panels'),
+		);
+
+		$fields['layout']['fields']['row-container-width'] = array(
+			'type' => 'number',
+			'unit' => 'px',
+			'label' => __('Row Container Width', 'siteorigin-panels'),
+			'description' => __('Max-width of row containers.', 'siteorigin-panels'),
 		);
 
 		$fields['layout']['fields']['margin-bottom'] = array(

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -830,6 +830,11 @@ function siteorigin_panels_generate_css($post_id, $panels_data = false){
 		'margin-bottom' => apply_filters('siteorigin_panels_css_cell_last_margin_bottom', '0px', $grid, $gi, $panels_data, $post_id)
 	));
 
+	// add max-width for row containers
+	$css->add_row_css($post_id, false, '.panel-row-container', array(
+		'max-width' => $settings['row-container-width'] . 'px'
+	));
+
 	if( $settings['responsive'] ) {
 		// Add CSS to prevent overflow on mobile resolution.
 		$css->add_row_css($post_id, false, '', array(
@@ -1094,6 +1099,10 @@ function siteorigin_panels_render( $post_id = false, $enqueue_css = true, $panel
 		$row_style_wrapper = siteorigin_panels_start_style_wrapper( 'row', $style_attributes, !empty($panels_data['grids'][$gi]['style']) ? $panels_data['grids'][$gi]['style'] : array() );
 		if( !empty($row_style_wrapper) ) echo $row_style_wrapper;
 
+		if( isset( $panels_data['grids'][$gi]['style']['row_stretch'] ) && $panels_data['grids'][$gi]['style']['row_stretch'] === 'contained' ) {
+			echo '<div class="panel-row-container">';
+		}
+
 		$collapse_order = !empty( $panels_data['grids'][$gi]['style']['collapse_order'] ) ? $panels_data['grids'][$gi]['style']['collapse_order'] : ( !is_rtl() ? 'left-top' : 'right-top' );
 
 		if( $collapse_order == 'right-top' ) {
@@ -1132,6 +1141,10 @@ function siteorigin_panels_render( $post_id = false, $enqueue_css = true, $panel
 
 			if( !empty($cell_style_wrapper) ) echo '</div>';
 			echo '</div>';
+		}
+
+		if( isset( $panels_data['grids'][$gi]['style']['row_stretch'] ) && $panels_data['grids'][$gi]['style']['row_stretch'] === 'contained' ) {
+			echo '</div>'; // /.panel-row-container
 		}
 
 		echo '</div>';


### PR DESCRIPTION
This adds an option in the Row Layout settings to 'Contained'. When this is selected, a container is placed inside the row so a max-width can be specified in the global Page Builder options. This is for rows that don't need content to stretch to full-width.

The default max-width is set to 860px, but can be configured in **Settings** > **Page Builder** > **Layout** > **Row Container Width**.

This may be a fix for the old #82 ticket.