### PR TITLE
The "Insert" options are not visible

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1673,6 +1673,9 @@
 .wp-customizer .so-panels-dialog .so-right-sidebar {
   z-index: 500001;
 }
+.wp-customizer .so-panels-dialog .so-toolbar {
+  z-index: 500002;
+}
 .so-panels-live-editor > div {
   position: fixed;
   z-index: 99999;

--- a/css/admin.less
+++ b/css/admin.less
@@ -1778,6 +1778,9 @@
 	.so-overlay, .so-content, .so-title-bar, .so-toolbar, .so-left-sidebar, .so-right-sidebar {
 		z-index: 500001;
 	}
+	.so-toolbar {
+		z-index: 500002;
+	}
 }
 
 .so-panels-live-editor {


### PR DESCRIPTION
On "Import/Export" section the "Insert" button has 3 options that are not visible because the z-index `.so-toolbar` is equal with `so-content`. See the screenshot, it says all.

![screen-0003](https://cloud.githubusercontent.com/assets/1436534/22610522/78616df4-ea6e-11e6-9ad6-8f22ce549e64.png)