### PR TITLE
Add loop check to prevent SiteOrigin Page Builder from running too soon

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -202,7 +202,7 @@ class SiteOrigin_Panels {
 	function filter_content( $content ) {
 		global $post;
 
-		if ( empty( $post ) ) {
+		if ( empty( $post ) && ! in_the_loop() ) {
 			return $content;
 		}
 		if ( ! apply_filters( 'siteorigin_panels_filter_content_enabled', true ) ) {


### PR DESCRIPTION
In certain situations, the SiteOrigin Page Builder (the_)content filter can be run outside of the loop. This can cause issues where certain plugins must be run only once. As a result, I've added a [in_the_loop()](https://codex.wordpress.org/Function_Reference/in_the_loop) check.

An example situation where this PR will help are the [Yoast Open Graph tags](https://github.com/siteorigin/so-widgets-bundle/issues/122). Yoast uses get_the_excerpt() to generate a description which in turn uses get_the_content(). This is done _way_ outside of the header which can cause issues with the aforementioned use case.