### PR TITLE
Improved interaction with post_content

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -857,8 +857,16 @@ class SiteOrigin_Panels_Admin {
 		);
 		$panels_data            = SiteOrigin_Panels_Styles_Admin::single()->sanitize_all( $panels_data );
 
-		define( 'SITEORIGIN_PANELS_DATABASE_RENDER', true );
-		echo SiteOrigin_Panels_Renderer::single()->render( intval( $_POST['post_id'] ), false, $panels_data );
+		$GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] = true;
+		$post_content = SiteOrigin_Panels_Renderer::single()->render( intval( $_POST['post_id'] ), false, $panels_data );
+		$post_css = file_get_contents( plugin_dir_path( __FILE__ ) . '../css/front.css' );
+		$post_css .= SiteOrigin_Panels_Renderer::single()->generate_css( intval( $_POST['post_id'] ), false, $panels_data );
+		$post_css = preg_replace( '/\s+/', ' ', $post_css );
+
+		echo '<style type="text/css">' . $post_css . '</style>';
+		echo $post_content;
+
+		unset( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] );
 
 		wp_die();
 	}

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -881,7 +881,7 @@ class SiteOrigin_Panels_Admin {
 
 		$GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] = true;
 
-		do_action( 'siteorigin_panels_setup_database_render' );
+		do_action( 'siteorigin_panels_setup_database_render', $_POST['post_id'] );
 		$post_content = SiteOrigin_Panels_Renderer::single()->render( intval( $_POST['post_id'] ), false, $panels_data );
 		echo SiteOrigin_Panels_Renderer::single()->render( intval( $_POST['post_id'] ), false, $panels_data );
 

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -179,7 +179,9 @@ class SiteOrigin_Panels_Admin {
 
 				// This gives other plugins the chance to
 				do_action( 'siteorigin_panels_setup_database_render', $post_id );
-				SiteOrigin_Panels_Post_Content::single();
+				$filters = SiteOrigin_Panels_Post_Content_Filters::single();
+				$filters->clear_filters();
+				$filters->setup_filters();
 
 				$post_content = SiteOrigin_Panels_Renderer::single()->render( $post_id, false, $panels_data, $layout_data );
 
@@ -883,8 +885,10 @@ class SiteOrigin_Panels_Admin {
 		$GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] = true;
 
 		do_action( 'siteorigin_panels_setup_database_render', $_POST['post_id'] );
-		SiteOrigin_Panels_Post_Content::single();
-		$post_content = SiteOrigin_Panels_Renderer::single()->render( intval( $_POST['post_id'] ), false, $panels_data );
+		$filters = SiteOrigin_Panels_Post_Content_Filters::single();
+		$filters->clear_filters();
+		$filters->setup_filters();
+
 		echo SiteOrigin_Panels_Renderer::single()->render( intval( $_POST['post_id'] ), false, $panels_data );
 
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] );

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -181,9 +181,9 @@ class SiteOrigin_Panels_Admin {
 				do_action( 'siteorigin_panels_setup_database_render', $post_id );
 				SiteOrigin_Panels_Post_Content::single();
 
-				$post_content = SiteOrigin_Panels_Renderer::single()->render( $post_id, false, $panels_data );
+				$post_content = SiteOrigin_Panels_Renderer::single()->render( $post_id, false, $panels_data, $layout_data );
 				$post_css = file_get_contents( plugin_dir_path( __FILE__ ) . '../css/front.css' );
-				$post_css .= SiteOrigin_Panels_Renderer::single()->generate_css( $post_id, false, $panels_data );
+				$post_css .= SiteOrigin_Panels_Renderer::single()->generate_css( $post_id, $panels_data, $layout_data );
 				$post_css = preg_replace( '/\s+/', ' ', $post_css );
 
 				$post_content .=  "\n\n" . '<style type="text/css" class="panels-style" data-panels-style-for-post="' . intval( $post_id ) . '">' . $post_css . '</style>';

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -182,7 +182,8 @@ class SiteOrigin_Panels_Admin {
 				SiteOrigin_Panels_Post_Content::single();
 
 				$post_content = SiteOrigin_Panels_Renderer::single()->render( $post_id, false, $panels_data, $layout_data );
-				$post_css = file_get_contents( plugin_dir_path( __FILE__ ) . '../css/front.css' );
+
+				$post_css = '@import url(' . SiteOrigin_Panels::front_css_url() . '); ';
 				$post_css .= SiteOrigin_Panels_Renderer::single()->generate_css( $post_id, $panels_data, $layout_data );
 				$post_css = preg_replace( '/\s+/', ' ', $post_css );
 

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -883,6 +883,7 @@ class SiteOrigin_Panels_Admin {
 		$GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] = true;
 
 		do_action( 'siteorigin_panels_setup_database_render', $_POST['post_id'] );
+		SiteOrigin_Panels_Post_Content::single();
 		$post_content = SiteOrigin_Panels_Renderer::single()->render( intval( $_POST['post_id'] ), false, $panels_data );
 		echo SiteOrigin_Panels_Renderer::single()->render( intval( $_POST['post_id'] ), false, $panels_data );
 

--- a/inc/post-content-filters.php
+++ b/inc/post-content-filters.php
@@ -6,19 +6,24 @@
  *
  * Class SiteOrigin_Panels_Post_Content
  */
-class SiteOrigin_Panels_Post_Content {
+class SiteOrigin_Panels_Post_Content_Filters {
 
 	public function __construct() {
-		// $this->clear_filters();
 
-		add_filter( 'siteorigin_panels_row_attributes', array( $this, 'row_attributes' ), 99, 2 );
-		add_filter( 'siteorigin_panels_cell_attributes', array( $this, 'cell_attributes' ), 99, 2 );
-		add_filter( 'siteorigin_panels_widget_attributes', array( $this, 'widget_attributes' ), 99, 2 );
 	}
 
 	public static function single() {
 		static $single;
 		return empty( $single ) ? $single = new self() : $single;
+	}
+
+	/**
+	 * Add filters that include data-* attributes on Page Builder divs
+	 */
+	public function setup_filters(){
+		add_filter( 'siteorigin_panels_row_attributes', array( $this, 'row_attributes' ), 99, 2 );
+		add_filter( 'siteorigin_panels_cell_attributes', array( $this, 'cell_attributes' ), 99, 2 );
+		add_filter( 'siteorigin_panels_widget_attributes', array( $this, 'widget_attributes' ), 99, 2 );
 	}
 
 	/**

--- a/inc/post-content.php
+++ b/inc/post-content.php
@@ -9,7 +9,12 @@
 class SiteOrigin_Panels_Post_Content {
 
 	public function __construct() {
+		// $this->clear_filters();
+		$this->setup_filters();
 
+		add_filter( 'siteorigin_panels_row_attributes', array( $this, 'row_attributes' ), 99, 2 );
+		add_filter( 'siteorigin_panels_cell_attributes', array( $this, 'cell_attributes' ), 99, 2 );
+		add_filter( 'siteorigin_panels_widget_attributes', array( $this, 'widget_attributes' ), 99, 4 );
 	}
 
 	public static function single() {
@@ -52,11 +57,47 @@ class SiteOrigin_Panels_Post_Content {
 	}
 
 	/**
-	 * Setup all the filters to add data attributes to the wrappers
+	 * Add the row data attributes
+	 *
+	 * @param $attributes
+	 * @param $row
+	 *
+	 * @return mixed
 	 */
-	public function setup_filters(){
-		add_filter( 'siteorigin_panels_row_attributes', array( $this, 'row_attributes' ) );
-		add_filter( 'siteorigin_panels_cell_attributes', array( $this, 'cell_attributes' ) );
-		add_filter( 'siteorigin_panels_widget_attributes', array( $this, 'widget_attributes' ) );
+	public function row_attributes( $attributes, $row ){
+		if( ! empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) return $attributes;
+
+		if( ! empty( $attributes['style'] ) ) {
+			$attributes[ 'data-style' ] = json_encode( $attributes['style'] );
+		}
 	}
+
+	/**
+	 * @param $attributes
+	 * @param $cell
+	 *
+	 * @return mixed
+	 */
+	public function cell_attributes( $attributes, $cell ){
+		if( ! empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) return $attributes;
+
+		if( ! empty( $attributes['style'] ) ) {
+			$attributes[ 'data-style' ] = json_encode( $attributes['style'] );
+		}
+	}
+
+	/**
+	 * @param $attributes
+	 * @param $widget
+	 *
+	 * @return mixed
+	 */
+	public function widget_attributes( $attributes, $widget ){
+		if( ! empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) return $attributes;
+
+		if( ! empty( $attributes['style'] ) ) {
+			$attributes[ 'data-style' ] = json_encode( $attributes['style'] );
+		}
+	}
+
 }

--- a/inc/post-content.php
+++ b/inc/post-content.php
@@ -10,11 +10,10 @@ class SiteOrigin_Panels_Post_Content {
 
 	public function __construct() {
 		// $this->clear_filters();
-		$this->setup_filters();
 
 		add_filter( 'siteorigin_panels_row_attributes', array( $this, 'row_attributes' ), 99, 2 );
 		add_filter( 'siteorigin_panels_cell_attributes', array( $this, 'cell_attributes' ), 99, 2 );
-		add_filter( 'siteorigin_panels_widget_attributes', array( $this, 'widget_attributes' ), 99, 4 );
+		add_filter( 'siteorigin_panels_widget_attributes', array( $this, 'widget_attributes' ), 99, 2 );
 	}
 
 	public static function single() {
@@ -65,11 +64,13 @@ class SiteOrigin_Panels_Post_Content {
 	 * @return mixed
 	 */
 	public function row_attributes( $attributes, $row ){
-		if( ! empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) return $attributes;
+		if( empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) return $attributes;
 
-		if( ! empty( $attributes['style'] ) ) {
-			$attributes[ 'data-style' ] = json_encode( $attributes['style'] );
+		if( ! empty( $row['style'] ) ) {
+			$attributes[ 'data-style' ] = json_encode( $row['style'] );
 		}
+
+		return $attributes;
 	}
 
 	/**
@@ -79,11 +80,15 @@ class SiteOrigin_Panels_Post_Content {
 	 * @return mixed
 	 */
 	public function cell_attributes( $attributes, $cell ){
-		if( ! empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) return $attributes;
+		if( empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) return $attributes;
 
-		if( ! empty( $attributes['style'] ) ) {
-			$attributes[ 'data-style' ] = json_encode( $attributes['style'] );
+		if( ! empty( $cell['style'] ) ) {
+			$attributes[ 'data-style' ] = json_encode( $cell['style'] );
 		}
+
+		$attributes[ 'data-weight' ] = $cell['weight'];
+
+		return $attributes;
 	}
 
 	/**
@@ -93,11 +98,13 @@ class SiteOrigin_Panels_Post_Content {
 	 * @return mixed
 	 */
 	public function widget_attributes( $attributes, $widget ){
-		if( ! empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) return $attributes;
+		if( empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) return $attributes;
 
-		if( ! empty( $attributes['style'] ) ) {
-			$attributes[ 'data-style' ] = json_encode( $attributes['style'] );
+		if( ! empty( $widget['style'] ) ) {
+			$attributes[ 'data-style' ] = json_encode( $widget['style'] );
 		}
+
+		return $attributes;
 	}
 
 }

--- a/inc/post-content.php
+++ b/inc/post-content.php
@@ -1,0 +1,62 @@
+<?php
+
+
+/**
+ * A class that handles generating the post content version of Page Builder content.
+ *
+ * Class SiteOrigin_Panels_Post_Content
+ */
+class SiteOrigin_Panels_Post_Content {
+
+	public function __construct() {
+
+	}
+
+	public static function single() {
+		static $single;
+		return empty( $single ) ? $single = new self() : $single;
+	}
+
+	/**
+	 * Clear filters so we get predictable HTML
+	 */
+	public function clear_filters(){
+		remove_all_filters( 'siteorigin_panels_data' );
+
+		remove_all_filters( 'siteorigin_panels_layout_classes' );
+		remove_all_filters( 'siteorigin_panels_layout_attributes' );
+
+		remove_all_filters( 'siteorigin_panels_before_content' );
+		remove_all_filters( 'siteorigin_panels_after_content' );
+
+		remove_all_filters( 'siteorigin_panels_render' );
+
+		// Remove all row wrapper filters
+		remove_all_filters( 'siteorigin_panels_row_classes' );
+		remove_all_filters( 'siteorigin_panels_row_attributes' );
+		remove_all_filters( 'siteorigin_panels_before_row' );
+		remove_all_filters( 'siteorigin_panels_after_row' );
+
+		// Remove all the cell wrapper filters
+		remove_all_filters( 'siteorigin_panels_cell_classes' );
+		remove_all_filters( 'siteorigin_panels_cell_attributes' );
+		remove_all_filters( 'siteorigin_panels_before_cell' );
+		remove_all_filters( 'siteorigin_panels_after_cell' );
+
+		// Remove all the widget wrapper filters
+		remove_all_filters( 'siteorigin_panels_widget_classes' );
+		remove_all_filters( 'siteorigin_panels_widget_attributes' );
+		remove_all_filters( 'siteorigin_panels_before_widget' );
+		remove_all_filters( 'siteorigin_panels_after_widget' );
+		remove_all_filters( 'siteorigin_panels_widget_args' );
+	}
+
+	/**
+	 * Setup all the filters to add data attributes to the wrappers
+	 */
+	public function setup_filters(){
+		add_filter( 'siteorigin_panels_row_attributes', array( $this, 'row_attributes' ) );
+		add_filter( 'siteorigin_panels_cell_attributes', array( $this, 'cell_attributes' ) );
+		add_filter( 'siteorigin_panels_widget_attributes', array( $this, 'widget_attributes' ) );
+	}
+}

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -385,8 +385,21 @@ class SiteOrigin_Panels_Renderer {
 			$after_title  = '</h3>';
 		}
 
+		// Attributes of the widget wrapper
+		$attributes = apply_filters( 'siteorigin_panels_widget_attributes', array(
+			'class' => implode( ' ', $classes ),
+			'id' => $id,
+			'data-index' => $widget_info['widget_index'],
+		) );
+
+		$before_widget = '<div ';
+		foreach( $attributes as $k => $v ) {
+			$before_widget .= esc_attr( $k ) . '="' . esc_attr( $v ) . '"';
+		}
+		$before_widget .= '>';
+
 		$args = array(
-			'before_widget' => '<div class="' . esc_attr( implode( ' ', $classes ) ) . '" id="' . $id . '" data-index="' . $widget_info['widget_index'] . '">',
+			'before_widget' => $before_widget,
 			'after_widget'  => '</div>',
 			'before_title'  => $before_title,
 			'after_title'   => $after_title,

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -39,10 +39,13 @@ class SiteOrigin_Panels_Renderer {
 	 *
 	 * @return string
 	 */
-	private function generate_css( $post_id, $layout_data, $panels_data ) {
+	public function generate_css( $post_id, $layout_data = false, $panels_data ) {
 		// Exit if we don't have panels data
-		if ( empty( $layout_data ) ) {
+		if ( empty( $layout_data ) && empty( $panels_data ) ) {
 			return;
+		}
+		if( empty( $layout_data ) ) {
+			$layout_data = $this->get_panels_layout_data( $panels_data );
 		}
 
 		// Get some of the default settings
@@ -514,7 +517,7 @@ class SiteOrigin_Panels_Renderer {
 	 *
 	 * @return array Hierarchical structure of rows => cells => widgets.
 	 */
-	private function get_panels_layout_data( $panels_data ) {
+	public function get_panels_layout_data( $panels_data ) {
 		$layout_data = array();
 
 		foreach ( $panels_data[ 'grids' ] as $grid ) {

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -34,12 +34,12 @@ class SiteOrigin_Panels_Renderer {
 	 * Generate the CSS for the page layout.
 	 *
 	 * @param $post_id
-	 * @param $layout_data
 	 * @param $panels_data
+	 * @param $layout_data
 	 *
 	 * @return string
 	 */
-	public function generate_css( $post_id, $layout_data = false, $panels_data ) {
+	public function generate_css( $post_id, $panels_data, $layout_data) {
 		// Exit if we don't have panels data
 		if ( empty( $layout_data ) && empty( $panels_data ) ) {
 			return;
@@ -75,8 +75,8 @@ class SiteOrigin_Panels_Renderer {
 
 			if(
 				$ri != count( $layout_data ) - 1 ||
-			    ! empty( $row[ 'style' ][ 'bottom_margin' ] ) ||
-			    ! empty( $panels_margin_bottom_last_row )
+				! empty( $row[ 'style' ][ 'bottom_margin' ] ) ||
+				! empty( $panels_margin_bottom_last_row )
 			) {
 				// Filter the bottom margin for this row with the arguments
 				$css->add_row_css( $post_id, $ri, '', array(
@@ -192,10 +192,11 @@ class SiteOrigin_Panels_Renderer {
 	 * @param int|string|bool $post_id The Post ID or 'home'.
 	 * @param bool $enqueue_css Should we also enqueue the layout CSS.
 	 * @param array|bool $panels_data Existing panels data. By default load from settings or post meta.
+	 * @param array $layout_data Reformatted panels_data that includes data about the render.
 	 *
 	 * @return string
 	 */
-	function render( $post_id = false, $enqueue_css = true, $panels_data = false ) {
+	function render( $post_id = false, $enqueue_css = true, $panels_data = false, & $layout_data = array() ) {
 
 		if ( empty( $post_id ) ) {
 			$post_id = get_the_ID();
@@ -223,7 +224,7 @@ class SiteOrigin_Panels_Renderer {
 			return '';
 		}
 
-		$panels_layout_data = $this->get_panels_layout_data( $panels_data );
+		$layout_data = $this->get_panels_layout_data( $panels_data );
 
 		ob_start();
 
@@ -238,7 +239,7 @@ class SiteOrigin_Panels_Renderer {
 
 		echo apply_filters( 'siteorigin_panels_before_content', '', $panels_data, $post_id );
 
-		foreach ( $panels_layout_data as $ri => & $row ) {
+		foreach ( $layout_data as $ri => & $row ) {
 			$this->render_row( $post_id, $ri, $row );
 		}
 
@@ -252,7 +253,7 @@ class SiteOrigin_Panels_Renderer {
 
 		if ( $enqueue_css && ! isset( $this->inline_css[ $post_id ] ) ) {
 			wp_enqueue_style( 'siteorigin-panels-front' );
-			$this->add_inline_css( $post_id, $this->generate_css( $post_id, $panels_layout_data, $panels_data ) );
+			$this->add_inline_css( $post_id, $this->generate_css( $post_id, $panels_data, $layout_data ) );
 		}
 
 		// Reset the current post

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -418,7 +418,12 @@ class SiteOrigin_Panels_Renderer {
 			$args['after_widget']  = '</div>' . $args['after_widget'];
 		}
 
-		if ( ! empty( $the_widget ) && is_a( $the_widget, 'WP_Widget' ) ) {
+		// This gives other plugins the chance to take over rendering of widgets
+		$widget_html = apply_filters( 'siteorigin_panels_the_widget_html', '', $the_widget, $args, $instance );
+
+		if( ! empty( $widget_html ) ) {
+			echo $widget_html;
+		} else if ( ! empty( $the_widget ) && is_a( $the_widget, 'WP_Widget' ) ) {
 			$the_widget->widget( $args, $instance );
 		} else {
 			// This gives themes a chance to display some sort of placeholder for missing widgets

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -228,10 +228,10 @@ class SiteOrigin_Panels_Renderer {
 		ob_start();
 
 		// Add the panel layout wrapper
-		$layout_classes    = apply_filters( 'siteorigin_panels_layout_classes', array(), $post_id, $panels_data );
+		$layout_classes    = apply_filters( 'siteorigin_panels_layout_classes', array( 'panel-layout' ), $post_id, $panels_data );
 		$layout_attributes = apply_filters( 'siteorigin_panels_layout_attributes', array(
+			'id'    => 'pl-' . $post_id,
 			'class' => implode( ' ', $layout_classes ),
-			'id'    => 'pl-' . $post_id
 		), $post_id, $panels_data );
 
 		$this->render_element( 'div', $layout_attributes );
@@ -390,10 +390,10 @@ class SiteOrigin_Panels_Renderer {
 
 		// Attributes of the widget wrapper
 		$attributes = apply_filters( 'siteorigin_panels_widget_attributes', array(
-			'class' => implode( ' ', $classes ),
 			'id' => $id,
+			'class' => implode( ' ', $classes ),
 			'data-index' => $widget_info['widget_index'],
-		) );
+		), $widget_info );
 
 		$before_widget = '<div ';
 		foreach( $attributes as $k => $v ) {
@@ -587,11 +587,10 @@ class SiteOrigin_Panels_Renderer {
 		$row_classes   = array( 'panel-grid' );
 		$row_classes[] = ! empty( $row_style_wrapper ) ? 'panel-has-style' : 'panel-no-style';
 		$row_classes   = apply_filters( 'siteorigin_panels_row_classes', $row_classes, $row );
-		$row_classes   = implode( ' ', $row_classes );
 
 		$row_attributes = apply_filters( 'siteorigin_panels_row_attributes', array(
-			'class' => $row_classes,
 			'id'    => 'pg-' . $post_id . '-' . $ri,
+			'class' => implode( ' ', $row_classes ),
 		), $row );
 
 		// This allows other themes and plugins to add html before the row
@@ -650,10 +649,10 @@ class SiteOrigin_Panels_Renderer {
 		}
 
 		// Themes can add their own styles to cells
-		$cell_classes    = apply_filters( 'siteorigin_panels_row_cell_classes', $cell_classes, $cell );
-		$cell_attributes = apply_filters( 'siteorigin_panels_row_cell_attributes', array(
+		$cell_classes    = apply_filters( 'siteorigin_panels_cell_classes', $cell_classes, $cell );
+		$cell_attributes = apply_filters( 'siteorigin_panels_cell_attributes', array(
+			'id'    => 'pgc-' . $post_id . '-' . $ri . '-' . $ci,
 			'class' => implode( ' ', $cell_classes ),
-			'id'    => 'pgc-' . $post_id . '-' . $ri . '-' . $ci
 		), $cell );
 
 		echo apply_filters( 'siteorigin_panels_before_cell', '', $cell, $cell_attributes );

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -41,10 +41,10 @@ class SiteOrigin_Panels_Renderer {
 	 */
 	public function generate_css( $post_id, $panels_data, $layout_data) {
 		// Exit if we don't have panels data
-		if ( empty( $layout_data ) && empty( $panels_data ) ) {
-			return;
-		}
-		if( empty( $layout_data ) ) {
+		if ( empty( $layout_data ) ) {
+			if ( empty( $panels_data ) ) {
+				return '';
+			}
 			$layout_data = $this->get_panels_layout_data( $panels_data );
 		}
 

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -572,8 +572,8 @@ class SiteOrigin_Panels_Styles {
 				continue;
 			}
 
-			$standard_css = apply_filters( 'siteorigin_panels_widget_style_css', array(), $widget['panels_info']['style'] );
-			$mobile_css = apply_filters( 'siteorigin_panels_widget_style_mobile_css', array(), $widget['panels_info']['style'] );
+			$standard_css = apply_filters( 'siteorigin_panels_widget_style_css', array(), ! empty( $widget['panels_info']['style'] ) ? $widget['panels_info']['style'] : array() );
+			$mobile_css = apply_filters( 'siteorigin_panels_widget_style_mobile_css', array(), ! empty( $widget['panels_info']['style'] ) ? $widget['panels_info']['style'] : array() );
 
 			if( ! empty( $standard_css ) ) {
 				$css->add_widget_css(

--- a/js/siteorigin-panels/model/builder.js
+++ b/js/siteorigin-panels/model/builder.js
@@ -310,7 +310,6 @@ module.exports = Backbone.Model.extend({
 			};
 
 			// The Regex object that'll match SiteOrigin widgets
-			// console.log( panelsOptions.siteoriginWidgetRegex );
 			var re = new RegExp( panelsOptions.siteoriginWidgetRegex , "i" );
 
 			$html.find('> .panel-layout > .panel-grid').each( function( ri, el ){

--- a/js/siteorigin-panels/model/builder.js
+++ b/js/siteorigin-panels/model/builder.js
@@ -415,7 +415,7 @@ module.exports = Backbone.Model.extend({
 			$html.find('style[data-panels-style-for-post]').remove();
 
 			// If there's anything left, add it to an editor widget at the end of panels_data
-			if( $html.html().trim().length ) {
+			if( $html.html().replace(/^\s+|\s+$/gm,'').length ) {
 				panels_data.grids.push( {
 					cells: 1,
 					style: {},
@@ -426,7 +426,7 @@ module.exports = Backbone.Model.extend({
 				} );
 				panels_data.widgets.push( {
 					filter: "1",
-					text: $html.html().trim(),
+					text: $html.html().replace(/^\s+|\s+$/gm,''),
 					title: "",
 					type: "visual",
 					panels_info: {

--- a/js/siteorigin-panels/model/builder.js
+++ b/js/siteorigin-panels/model/builder.js
@@ -387,6 +387,34 @@ module.exports = Backbone.Model.extend({
 				} );
 			} );
 
+			// Remove all the Page Builder content
+			$html.find('.panel-layout').remove();
+			$html.find('style[data-panels-style-for-post]').remove();
+
+			// If there's anything left, add it to an editor widget at the end of panels_data
+			if( $html.html().trim().length ) {
+				panels_data.grids.push( {
+					cells: 1,
+					style: {},
+				} );
+				panels_data.grid_cells.push( {
+					grid: panels_data.grids.length - 1,
+					weight: 1,
+				} );
+				panels_data.widgets.push( {
+					filter: "1",
+					text: $html.html().trim(),
+					title: "",
+					type: "visual",
+					panels_info: {
+						class: editorClass,
+						raw: false,
+						grid: panels_data.grids.length - 1,
+						cell: 0
+					}
+				} );
+			}
+
 			return panels_data;
 		}
 		else {

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -729,9 +729,9 @@ module.exports = Backbone.View.extend( {
 			) &&
 			editorContent !== ''
 		) {
-			var widgetClass = panelsOptions.text_widget;
+			var editorClass = panelsOptions.text_widget;
 			// There is a small chance a theme will have removed this, so check
-			if ( _.isEmpty( widgetClass ) ) {
+			if ( _.isEmpty( editorClass ) ) {
 				return;
 			}
 
@@ -741,24 +741,7 @@ module.exports = Backbone.View.extend( {
 			}
 
 			// Create the existing page content in a single widget
-			this.model.loadPanelsData( {
-				grid_cells: [{grid: 0, weight: 1}],
-				grids: [{cells: 1}],
-				widgets: [
-					{
-						filter: "1",
-						text: editorContent,
-						title: "",
-						type: "visual",
-						panels_info: {
-							class: widgetClass,
-							raw: false,
-							grid: 0,
-							cell: 0
-						}
-					}
-				]
-			} );
+			this.model.loadPanelsData( this.model.getPanelsDataFromHtml( editorContent, editorClass ) );
 			this.model.trigger( 'change' );
 			this.model.trigger( 'change:data' );
 		}

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -358,6 +358,10 @@ class SiteOrigin_Panels {
 
 		return $panels_data;
 	}
+
+	public static function front_css_url(){
+		return plugin_dir_url( __FILE__ ) . 'css/front.css';
+	}
 }
 
 SiteOrigin_Panels::single();

--- a/widgets/basic.php
+++ b/widgets/basic.php
@@ -38,6 +38,15 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 
 		echo $args['before_widget'];
 		echo SiteOrigin_Panels_Renderer::single()->render( 'w'.$instance['builder_id'], true, $instance['panels_data'] );
+		if( ! empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) {
+			$widget_css = file_get_contents( plugin_dir_path( __FILE__ ) . '../css/front.css' );
+			$widget_css .= SiteOrigin_Panels_Renderer::single()->generate_css( 'w'.$instance['builder_id'], false, $instance['panels_data'] );
+			$widget_css = preg_replace( '/\s+/', ' ', $widget_css );
+			echo "\n\n" .
+			     '<style type="text/css" class="panels-style" data-panels-style-for-post="' . esc_attr( 'w'.$instance['builder_id'] ) . '">' .
+			     $widget_css .
+			     '</style>';
+		}
 		echo $args['after_widget'];
 	}
 

--- a/widgets/basic.php
+++ b/widgets/basic.php
@@ -37,10 +37,10 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 		if( empty( $instance['builder_id'] ) ) $instance['builder_id'] = uniqid();
 
 		echo $args['before_widget'];
-		echo SiteOrigin_Panels_Renderer::single()->render( 'w'.$instance['builder_id'], true, $instance['panels_data'] );
+		echo SiteOrigin_Panels_Renderer::single()->render( 'w'.$instance['builder_id'], true, $instance['panels_data'], $layout_data );
 		if( ! empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) {
 			$widget_css = file_get_contents( plugin_dir_path( __FILE__ ) . '../css/front.css' );
-			$widget_css .= SiteOrigin_Panels_Renderer::single()->generate_css( 'w'.$instance['builder_id'], false, $instance['panels_data'] );
+			$widget_css .= SiteOrigin_Panels_Renderer::single()->generate_css( 'w'.$instance['builder_id'], $instance['panels_data'], $layout_data );
 			$widget_css = preg_replace( '/\s+/', ' ', $widget_css );
 			echo "\n\n" .
 			     '<style type="text/css" class="panels-style" data-panels-style-for-post="' . esc_attr( 'w'.$instance['builder_id'] ) . '">' .

--- a/widgets/basic.php
+++ b/widgets/basic.php
@@ -39,7 +39,7 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 		echo $args['before_widget'];
 		echo SiteOrigin_Panels_Renderer::single()->render( 'w'.$instance['builder_id'], true, $instance['panels_data'], $layout_data );
 		if( ! empty( $GLOBALS[ 'SITEORIGIN_PANELS_DATABASE_RENDER' ] ) ) {
-			$widget_css = file_get_contents( plugin_dir_path( __FILE__ ) . '../css/front.css' );
+			$widget_css = '@import url(' . SiteOrigin_Panels::front_css_url() . '); ';
 			$widget_css .= SiteOrigin_Panels_Renderer::single()->generate_css( 'w'.$instance['builder_id'], $instance['panels_data'], $layout_data );
 			$widget_css = preg_replace( '/\s+/', ' ', $widget_css );
 			echo "\n\n" .


### PR DESCRIPTION
This PR improves how Page Builder interacts with post_content. It's now possible to view a Page Builder page, even when the plugin is deactivated. This mainly works with Widgets Bundle widgets.

We can also parse post_content to extract the original Page Builder data.