### PR TITLE
PB 2.5: Add ability to filter widget title

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -393,8 +393,17 @@ class SiteOrigin_Panels_Renderer {
 			'widget_id'     => 'widget-' . $grid_index . '-' . $cell_index . '-' . $widget_index
 		);
 
+		// Allow plugins/themes to filter widget title
+		if ( !empty( $instance['title'] ) && !empty( $the_widget ) && !empty( $the_widget->id_base ) ) {
+			$args['title'] = apply_filters( 'widget_title', $instance['title'], $instance, $the_widget->id_base );
+		}
+
 		// Let other themes and plugins change the arguments that go to the widget class.
 		$args = apply_filters( 'siteorigin_panels_widget_args', $args );
+
+		if( isset( $args['title'] ) ) {
+			$instance['title'] = $args['title'];
+		}
 
 		// If there is a style wrapper, add it.
 		if ( ! empty( $style_wrapper ) ) {


### PR DESCRIPTION
#320 for 2.5.

Awkwardly, the initial PR applied the title to $args['title'] but it was never actually applied as the title was always taken from $instance['title'] (at least in 99% of cases). As a result, I applied set $instance['title'] to $args['title'] after the `siteorigin_panels_widget_args` hook to allow for plugins/themes and developers to more easily filter it (if desired).

`siteorigin_panels_widget_args` still includes less context, however. In an Ideal world, it would pass $instance.