### PR TITLE
Update front-flex.less

### DIFF
--- a/css/front-flex.less
+++ b/css/front-flex.less
@@ -9,7 +9,7 @@
 
 		-ms-flex-wrap: wrap;
 		-webkit-flex-wrap: wrap;
-		flex-wrap: nowrap;
+		flex-wrap: wrap;
 
 		-ms-justify-content: space-between;
 		-webkit-justify-content: space-between;


### PR DESCRIPTION
if i want to have the _.panel-grid-cell_ items horizontal under 780px width too and make 
```
.panel-has-style > .panel-row-style {
     -webkit-flex-direction: row !important; 
    -ms-flex-direction: row !important;
     flex-direction: row !important; 
}
```
then 
_flex-wrap: nowrap;_ blows the width of the page and leads to horizontal scrollbars unless i set **flex-wrap: wrap;**
maybe it helps someone 