### PR TITLE
Add filters inside row.

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -644,10 +644,14 @@ class SiteOrigin_Panels_Renderer {
 		if ( ! empty( $row_style_wrapper ) ) {
 			echo $row_style_wrapper;
 		}
+		
+		echo apply_filters( 'siteorigin_panels_before_cells', '', $row, $row_attributes );
 
 		foreach ( $row['cells'] as $ci => & $cell ) {
 			$this->render_cell( $post_id, $ri, $ci, $cell, $row['cells'], $panels_data );
 		}
+		
+		echo apply_filters( 'siteorigin_panels_after_cells', '', $row, $row_attributes );
 
 		// Close the style wrapper
 		if ( ! empty( $row_style_wrapper ) ) {


### PR DESCRIPTION
Hey,

This is an updated version of PR #309 for the 3.0 update of Page Builder.

Example use case is to have the row's background across the full width of the screen, but the row's content wrapped in a div with a max-width.

Love the plugin, thanks for making it!