### PR TITLE
Reset fixed background image display setting on mobile

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -474,6 +474,10 @@ class SiteOrigin_Panels_Styles {
 		if( ! empty( $style['mobile_padding'] ) ) {
 			$css['padding'] = $style[ 'mobile_padding' ];
 		}
+		
+		if ( ! empty( $style['background_display'] ) && ! empty( $style['background_image_attachment'] ) && $style['background_display'] == 'fixed' ) {
+			$css[ 'background-attachment' ] = 'scroll';
+		}
 
 		if ( ! empty( $style[ 'mobile_css' ] ) ) {
 			preg_match_all( '/^([A-Za-z0-9\-]+?):(.+?);?$/m', $style[ 'mobile_css' ], $matches );


### PR DESCRIPTION
Mobile browsers disable fixed backgrounds. "Certain" browsers can do it in a really weird manner and result in the image being really zoomed in ([reference](https://stackoverflow.com/questions/22141681/css-background-images-resizing-incorrectly-on-ipad-and-iphone)). To resolve this issue, we need to set background-attachment: to scroll;.