### PR TITLE
Avoid relative asset URLs

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -234,16 +234,22 @@ class SiteOrigin_Panels_Admin {
 		if ( $force || self::is_admin() ) {
 			// Media is required for row styles
 			wp_enqueue_media();
-			wp_enqueue_script( 'so-panels-admin', siteorigin_panels_url( 'js/siteorigin-panels' ) . SITEORIGIN_PANELS_VERSION_SUFFIX . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array(
-				'jquery',
-				'jquery-ui-resizable',
-				'jquery-ui-sortable',
-				'jquery-ui-draggable',
-				'underscore',
-				'backbone',
-				'plupload',
-				'plupload-all'
-			), SITEORIGIN_PANELS_VERSION, true );
+			wp_enqueue_script(
+				'so-panels-admin',
+				siteorigin_panels_url( 'js/siteorigin-panels' . SITEORIGIN_PANELS_VERSION_SUFFIX . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),
+				array(
+					'jquery',
+					'jquery-ui-resizable',
+					'jquery-ui-sortable',
+					'jquery-ui-draggable',
+					'underscore',
+					'backbone',
+					'plupload',
+					'plupload-all'
+				),
+				SITEORIGIN_PANELS_VERSION,
+				true
+			);
 			add_action( 'admin_footer', array( $this, 'js_templates' ) );
 
 			$widgets = $this->get_widgets();
@@ -455,7 +461,12 @@ class SiteOrigin_Panels_Admin {
 	 */
 	function enqueue_admin_styles( $prefix = '', $force = false ) {
 		if ( $force || self::is_admin() ) {
-			wp_enqueue_style( 'so-panels-admin', siteorigin_panels_url( 'css/admin.css' ), array( 'wp-color-picker' ), SITEORIGIN_PANELS_VERSION );
+			wp_enqueue_style(
+				'so-panels-admin',
+				siteorigin_panels_url( 'css/admin.css' ),
+				array( 'wp-color-picker' ),
+				SITEORIGIN_PANELS_VERSION
+			);
 			do_action( 'siteorigin_panel_enqueue_admin_styles' );
 		}
 	}

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -234,7 +234,7 @@ class SiteOrigin_Panels_Admin {
 		if ( $force || self::is_admin() ) {
 			// Media is required for row styles
 			wp_enqueue_media();
-			wp_enqueue_script( 'so-panels-admin', plugin_dir_url( __FILE__ ) . '../js/siteorigin-panels' . SITEORIGIN_PANELS_VERSION_SUFFIX . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array(
+			wp_enqueue_script( 'so-panels-admin', siteorigin_panels_url( 'js/siteorigin-panels' ) . SITEORIGIN_PANELS_VERSION_SUFFIX . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array(
 				'jquery',
 				'jquery-ui-resizable',
 				'jquery-ui-sortable',
@@ -404,7 +404,7 @@ class SiteOrigin_Panels_Admin {
 					'error_message'       => __( 'Error uploading or importing file.', 'siteorigin-panels' ),
 				),
 				'wpColorPickerOptions'      => apply_filters( 'siteorigin_panels_wpcolorpicker_options', array() ),
-				'prebuiltDefaultScreenshot' => plugin_dir_url( __FILE__ ) . '../css/images/prebuilt-default.png',
+				'prebuiltDefaultScreenshot' => siteorigin_panels_url( 'css/images/prebuilt-default.png' ),
 				'loadOnAttach'              => siteorigin_panels_setting( 'load-on-attach' ),
 				'siteoriginWidgetRegex'     => str_replace( '*+', '*', get_shortcode_regex( array( 'siteorigin_widget' ) ) ),
 			) );
@@ -455,7 +455,7 @@ class SiteOrigin_Panels_Admin {
 	 */
 	function enqueue_admin_styles( $prefix = '', $force = false ) {
 		if ( $force || self::is_admin() ) {
-			wp_enqueue_style( 'so-panels-admin', plugin_dir_url( __FILE__ ) . '../css/admin.css', array( 'wp-color-picker' ), SITEORIGIN_PANELS_VERSION );
+			wp_enqueue_style( 'so-panels-admin', siteorigin_panels_url( 'css/admin.css' ), array( 'wp-color-picker' ), SITEORIGIN_PANELS_VERSION );
 			do_action( 'siteorigin_panel_enqueue_admin_styles' );
 		}
 	}
@@ -1047,7 +1047,7 @@ class SiteOrigin_Panels_Admin {
 		$lessons['page-builder-tips'] = array(
 			'title'            => __( '12 Page Builder Tips', 'siteorigin-panels' ),
 			'video'            => '212380146',
-			'poster'           => plugin_dir_url( __FILE__ ) . '../posters/page-builder-tips.svg',
+			'poster'           => siteorigin_panels_url( 'posters/page-builder-tips.svg' ),
 			'description'      => __( "Sign up to our newsletter and we'll send you this free Page Builder video course.", 'siteorigin-panels' ) . ' ' .
 								  __( "12 tips that'll help you get the most out of Page Builder.", 'siteorigin-panels' ) . ' ' .
 								  __( "Watch the video to find out more, then sign up below to get started.", 'siteorigin-panels' ),
@@ -1057,7 +1057,7 @@ class SiteOrigin_Panels_Admin {
 		$lessons['page-builder-animations'] = array(
 			'title'            => __( 'Free Page Builder Addons', 'siteorigin-panels' ),
 			'video'            => '212380210',
-			'poster'           => plugin_dir_url( __FILE__ ) . '../posters/addons.svg',
+			'poster'           => siteorigin_panels_url( 'posters/addons.svg' ),
 			'description'      => __( "The free animations addon allows you to add beautiful animations to Page Builder elements.", 'siteorigin-panels' ) . ' ' .
 								  __( "Sign up to our newsletter and we'll send you the addon as a free gift.", 'siteorigin-panels' ) . ' ' .
 								  __( "Plus, we'll send you even more powerful addons, for as long as you're subscribed.", 'siteorigin-panels' ),

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -92,3 +92,7 @@ function siteorigin_panels_plugin_activation_install_url( $plugin, $plugin_name,
 function siteorigin_panels_activate(){
 	return false;
 }
+
+function siteorigin_panels_url( $path = '' ) {
+	return plugins_url( 'siteorigin-panels/' . $path );
+}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -93,6 +93,14 @@ function siteorigin_panels_activate(){
 	return false;
 }
 
+
+/**
+ * Returns the base URL of our widget with `$path` appended.
+ *
+ * @param string $path Extra path to append to the end of the URL.
+ *
+ * @return string Base URL of the widget, with $path appended.
+ */
 function siteorigin_panels_url( $path = '' ) {
 	return plugins_url( 'siteorigin-panels/' . $path );
 }

--- a/inc/live-editor.php
+++ b/inc/live-editor.php
@@ -76,14 +76,14 @@ class SiteOrigin_Panels_Live_Editor {
 	function frontend_scripts() {
 		wp_enqueue_script(
 			'live-editor-front',
-			siteorigin_panels_url( 'js/live-editor/live-editor-front' ) . SITEORIGIN_PANELS_JS_SUFFIX . '.js',
+			siteorigin_panels_url( 'js/live-editor/live-editor-front' . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),
 			array( 'jquery' ),
 			SITEORIGIN_PANELS_VERSION
 		);
 
 		wp_enqueue_script(
 			'live-editor-scrollto',
-			siteorigin_panels_url( 'js/live-editor/jquery.scrollTo' ) . SITEORIGIN_PANELS_JS_SUFFIX . '.js',
+			siteorigin_panels_url( 'js/live-editor/jquery.scrollTo' . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),
 			array( 'jquery' ),
 			SITEORIGIN_PANELS_VERSION
 		);

--- a/inc/live-editor.php
+++ b/inc/live-editor.php
@@ -76,21 +76,21 @@ class SiteOrigin_Panels_Live_Editor {
 	function frontend_scripts() {
 		wp_enqueue_script(
 			'live-editor-front',
-			plugin_dir_url( __FILE__ ) . '../js/live-editor/live-editor-front' . SITEORIGIN_PANELS_JS_SUFFIX . '.js',
+			siteorigin_panels_url( 'js/live-editor/live-editor-front' ) . SITEORIGIN_PANELS_JS_SUFFIX . '.js',
 			array( 'jquery' ),
 			SITEORIGIN_PANELS_VERSION
 		);
 
 		wp_enqueue_script(
 			'live-editor-scrollto',
-			plugin_dir_url( __FILE__ ) . '../js/live-editor/jquery.scrollTo' . SITEORIGIN_PANELS_JS_SUFFIX . '.js',
+			siteorigin_panels_url( 'js/live-editor/jquery.scrollTo' ) . SITEORIGIN_PANELS_JS_SUFFIX . '.js',
 			array( 'jquery' ),
 			SITEORIGIN_PANELS_VERSION
 		);
 
 		wp_enqueue_style(
 			'live-editor-front',
-			plugin_dir_url( __FILE__ ) . '../css/live-editor-front.css',
+			siteorigin_panels_url( 'css/live-editor-front.css' ),
 			array(),
 			SITEORIGIN_PANELS_VERSION
 		);

--- a/inc/renderer-legacy.php
+++ b/inc/renderer-legacy.php
@@ -144,6 +144,6 @@ class SiteOrigin_Panels_Renderer_Legacy extends SiteOrigin_Panels_Renderer {
 	}
 	
 	public function front_css_url(){
-		return plugin_dir_url( __FILE__ ) . '../css/front' . ( siteorigin_panels_setting( 'legacy-layout' ) ? '-legacy' : '' ) . '.css';
+		return siteorigin_panels_url( 'css/front' ) . ( siteorigin_panels_setting( 'legacy-layout' ) ? '-legacy' : '' ) . '.css';
 	}
 }

--- a/inc/renderer-legacy.php
+++ b/inc/renderer-legacy.php
@@ -144,6 +144,6 @@ class SiteOrigin_Panels_Renderer_Legacy extends SiteOrigin_Panels_Renderer {
 	}
 	
 	public function front_css_url(){
-		return siteorigin_panels_url( 'css/front' ) . ( siteorigin_panels_setting( 'legacy-layout' ) ? '-legacy' : '' ) . '.css';
+		return siteorigin_panels_url( 'css/front' . ( siteorigin_panels_setting( 'legacy-layout' ) ? '-legacy' : '' ) . '.css' );
 	}
 }

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -766,6 +766,6 @@ class SiteOrigin_Panels_Renderer {
 	}
 	
 	public function front_css_url(){
-		return plugin_dir_url( __FILE__ ) . '../css/front-flex.css';
+		return siteorigin_panels_url( 'css/front-flex.css' );
 	}
 }

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -175,8 +175,8 @@ class SiteOrigin_Panels_Settings {
 		if ( $prefix != 'settings_page_siteorigin_panels' ) {
 			return;
 		}
-		wp_enqueue_style( 'siteorigin-panels-settings', plugin_dir_url( __FILE__ ) . '../settings/admin-settings.css', array(), SITEORIGIN_PANELS_VERSION );
-		wp_enqueue_script( 'siteorigin-panels-settings', plugin_dir_url( __FILE__ ) . '../settings/admin-settings' . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array(), SITEORIGIN_PANELS_VERSION );
+		wp_enqueue_style( 'siteorigin-panels-settings', siteorigin_panels_url( 'settings/admin-settings.css' ), array(), SITEORIGIN_PANELS_VERSION );
+		wp_enqueue_script( 'siteorigin-panels-settings', siteorigin_panels_url( 'settings/admin-settings' ) . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array(), SITEORIGIN_PANELS_VERSION );
 	}
 
 	/**

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -175,8 +175,18 @@ class SiteOrigin_Panels_Settings {
 		if ( $prefix != 'settings_page_siteorigin_panels' ) {
 			return;
 		}
-		wp_enqueue_style( 'siteorigin-panels-settings', siteorigin_panels_url( 'settings/admin-settings.css' ), array(), SITEORIGIN_PANELS_VERSION );
-		wp_enqueue_script( 'siteorigin-panels-settings', siteorigin_panels_url( 'settings/admin-settings' ) . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array(), SITEORIGIN_PANELS_VERSION );
+		wp_enqueue_style(
+			'siteorigin-panels-settings',
+			siteorigin_panels_url( 'settings/admin-settings.css' ),
+			array(),
+			SITEORIGIN_PANELS_VERSION
+		);
+		wp_enqueue_script(
+			'siteorigin-panels-settings',
+			siteorigin_panels_url( 'settings/admin-settings' . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),
+			array(),
+			SITEORIGIN_PANELS_VERSION
+		);
 	}
 
 	/**

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -45,8 +45,8 @@ class SiteOrigin_Panels_Styles {
 	}
 
 	static function register_scripts() {
-		wp_register_script( 'siteorigin-panels-front-styles', plugin_dir_url( __FILE__ ) . '../js/styling' . SITEORIGIN_PANELS_VERSION_SUFFIX . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array( 'jquery' ), SITEORIGIN_PANELS_VERSION );
-		wp_register_script( 'siteorigin-parallax', plugin_dir_url( __FILE__ ) . '../js/siteorigin-parallax' . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array( 'jquery' ), SITEORIGIN_PANELS_VERSION );
+		wp_register_script( 'siteorigin-panels-front-styles', siteorigin_panels_url( 'js/styling' ) . SITEORIGIN_PANELS_VERSION_SUFFIX . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array( 'jquery' ), SITEORIGIN_PANELS_VERSION );
+		wp_register_script( 'siteorigin-parallax', siteorigin_panels_url( 'js/siteorigin-parallax' ) . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array( 'jquery' ), SITEORIGIN_PANELS_VERSION );
 		wp_localize_script( 'siteorigin-panels-front-styles', 'panelsStyles', array(
 			'fullContainer' => apply_filters( 'siteorigin_panels_full_width_container', siteorigin_panels_setting( 'full-width-container' ) )
 		) );

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -45,8 +45,18 @@ class SiteOrigin_Panels_Styles {
 	}
 
 	static function register_scripts() {
-		wp_register_script( 'siteorigin-panels-front-styles', siteorigin_panels_url( 'js/styling' ) . SITEORIGIN_PANELS_VERSION_SUFFIX . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array( 'jquery' ), SITEORIGIN_PANELS_VERSION );
-		wp_register_script( 'siteorigin-parallax', siteorigin_panels_url( 'js/siteorigin-parallax' ) . SITEORIGIN_PANELS_JS_SUFFIX . '.js', array( 'jquery' ), SITEORIGIN_PANELS_VERSION );
+		wp_register_script(
+			'siteorigin-panels-front-styles',
+			siteorigin_panels_url( 'js/styling' . SITEORIGIN_PANELS_VERSION_SUFFIX . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),
+			array( 'jquery' ),
+			SITEORIGIN_PANELS_VERSION
+		);
+		wp_register_script(
+			'siteorigin-parallax',
+			siteorigin_panels_url( 'js/siteorigin-parallax' . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),
+			array( 'jquery' ),
+			SITEORIGIN_PANELS_VERSION
+		);
 		wp_localize_script( 'siteorigin-panels-front-styles', 'panelsStyles', array(
 			'fullContainer' => apply_filters( 'siteorigin_panels_full_width_container', siteorigin_panels_setting( 'full-width-container' ) )
 		) );

--- a/settings/tpl/settings.php
+++ b/settings/tpl/settings.php
@@ -2,9 +2,9 @@
 	<div class="settings-banner">
 
 		<span class="icon">
-			<img src="<?php echo plugin_dir_url(__FILE__) ?>../images/icon-layer.png" class="layer-3" />
-			<img src="<?php echo plugin_dir_url(__FILE__) ?>../images/icon-layer.png" class="layer-2" />
-			<img src="<?php echo plugin_dir_url(__FILE__) ?>../images/icon-layer.png" class="layer-1" />
+			<img src="<?php echo siteorigin_panels_url( 'settings/images/icon-layer.png' ) ?>" class="layer-3" />
+			<img src="<?php echo siteorigin_panels_url( 'settings/images/icon-layer.png' ) ?>" class="layer-2" />
+			<img src="<?php echo siteorigin_panels_url( 'settings/images/icon-layer.png' ) ?>" class="layer-1" />
 		</span>
 		<h1><?php _e('SiteOrigin Page Builder', 'siteorigin-panels') ?></h1>
 

--- a/tpl/live-editor-preview.php
+++ b/tpl/live-editor-preview.php
@@ -2,7 +2,7 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
-wp_enqueue_style( 'siteorigin-preview-style', plugin_dir_url( __FILE__ ) . '../css/live-editor-preview.css', array(), SITEORIGIN_PANELS_VERSION );
+wp_enqueue_style( 'siteorigin-preview-style', siteorigin_panels_url( 'css/live-editor-preview.css' ), array(), SITEORIGIN_PANELS_VERSION );
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>


### PR DESCRIPTION
To fix #447. Avoid using relative asset URLs which may break caching plugins.