### PR TITLE
Release 2.5.12

### DIFF
--- a/js/siteorigin-panels/helpers/utils.js
+++ b/js/siteorigin-panels/helpers/utils.js
@@ -14,6 +14,9 @@ module.exports = {
 	},
 
 	processTemplate: function ( s ) {
+		if ( _.isUndefined( s ) || _.isNull( s ) ) {
+			return '';
+		}
 		s = s.replace( /{{%/g, '<%' );
 		s = s.replace( /%}}/g, '%>' );
 		s = s.trim();

--- a/js/siteorigin-panels/model/builder.js
+++ b/js/siteorigin-panels/model/builder.js
@@ -410,6 +410,7 @@ module.exports = Backbone.Model.extend({
 							panels_info = {
 								grid: ri,
 								cell: ci,
+								style: $widget.data( 'style' ),
 								raw: false,
 								label: $widget.data( 'label' )
 							};

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -333,6 +333,13 @@ module.exports = Backbone.View.extend( {
 		// Hide the standard content editor
 		$( '#wp-content-wrap' ).hide();
 
+
+		$( '#editor-expand-toggle' ).on( 'change.editor-expand', function () {
+			if ( ! $( this ).prop( 'checked' ) ) {
+				$( '#wp-content-wrap' ).hide();
+			}
+		} );
+
 		// Show page builder and the inside div
 		this.metabox.show().find( '> .inside' ).show();
 


### PR DESCRIPTION
* Learn: fixed broken image.
* Prevent JS error when PB active alongside Elementor.
* Disabling DFW mode no longer hides PB.
* Hide Cell Vertical Alignment options if Legacy Layout is set to always.