### PR TITLE
Add filter to the background-image url in the CSS output

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -415,7 +415,7 @@ class SiteOrigin_Panels_Styles {
 			$url = self::get_attachment_image_src( $style['background_image_attachment'], 'full' );
 
 			if ( ! empty( $url ) ) {
-				$css[ 'background-image' ] = 'url(' . $url[0] . ')';
+				$css[ 'background-image' ] = 'url(' . apply_filters( 'siteorigin_panels_background_image_url' ,$url[0] ) . ')';
 
 				switch ( $style['background_display'] ) {
 					case 'parallax':


### PR DESCRIPTION
I personally want as much as possible to be sent via a CDN when it comes to site images & other assets. Adding the `siteorigin_panels_background_image_url` filter to the background-image URL would allow me (and others) to replace the URL with the CDN's URL. This can also be useful for those simply using Jetpack's Photon feature as the filter can allow jetpack_photon_url(); to replace the URL being used with the image on WordPress' CDN.