### PR TITLE
Content Cache: Add Enqueue hook

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -390,6 +390,7 @@ class SiteOrigin_Panels {
 		wp_enqueue_style( 'siteorigin-panels-front' );
 		wp_enqueue_script( 'siteorigin-panels-front-styles' );
 		wp_enqueue_script( 'siteorigin-parallax' );
+		do_action( 'siteorigin_panels_cache_enqueue' );
 	}
 
 	/**


### PR DESCRIPTION
This will allow plugins and themes to easily enqueue cache friendly assets when they need to.