### PR TITLE
fixes js error for deprecated .load event and replace with .on

### DIFF
--- a/js/styling.js
+++ b/js/styling.js
@@ -50,7 +50,7 @@ jQuery( function ( $ ) {
 			$( window ).trigger( 'panelsStretchRows' );
 		}
 	}
-	$( window ).resize( stretchFullWidthRows ).on("load",function(){
+	$( window ).resize( stretchFullWidthRows ).on('load',function(){
 		stretchFullWidthRows();
 	});
 	stretchFullWidthRows();

--- a/js/styling.js
+++ b/js/styling.js
@@ -51,7 +51,7 @@ jQuery( function ( $ ) {
 		}
 	}
 	$( window ).resize( stretchFullWidthRows ).on("load",function(){
-		stretchFullWidthRows
+		stretchFullWidthRows;
 	});
 	stretchFullWidthRows();
 

--- a/js/styling.js
+++ b/js/styling.js
@@ -50,7 +50,9 @@ jQuery( function ( $ ) {
 			$( window ).trigger( 'panelsStretchRows' );
 		}
 	}
-	$( window ).resize( stretchFullWidthRows ).load( stretchFullWidthRows );
+	$( window ).resize( stretchFullWidthRows ).on("load",function(){
+		stretchFullWidthRows
+	});
 	stretchFullWidthRows();
 
 	// This should have been done in the footer, but run it here just incase.

--- a/js/styling.js
+++ b/js/styling.js
@@ -50,9 +50,7 @@ jQuery( function ( $ ) {
 			$( window ).trigger( 'panelsStretchRows' );
 		}
 	}
-	$( window ).resize( stretchFullWidthRows ).on('load',function(){
-		stretchFullWidthRows();
-	});
+	$( window ).on( 'resize load', stretchFullWidthRows );
 	stretchFullWidthRows();
 
 	// This should have been done in the footer, but run it here just incase.

--- a/js/styling.js
+++ b/js/styling.js
@@ -51,7 +51,7 @@ jQuery( function ( $ ) {
 		}
 	}
 	$( window ).resize( stretchFullWidthRows ).on("load",function(){
-		stretchFullWidthRows;
+		stretchFullWidthRows();
 	});
 	stretchFullWidthRows();
 


### PR DESCRIPTION
on some themes(depending on jquery version) .load event causes a javascript error, here is the javascript error: 
`Uncaught TypeError: a.indexOf is not a function`
and this doesn't let the page builder to render the page.
.load event has been replaced by .on(...

additional info:
See bug [#11733](http://bugs.jquery.com/ticket/11733), which documents this deprecation:

> The .load() method is an ambiguous signature, it can either be an ajax load or attach/fire a "load" event. CCAO cannot tell them apart since it's a dynamic decision based on arguments.