### PR TITLE
Prevent error with invalid plugin action links

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -115,6 +115,10 @@ class SiteOrigin_Panels_Admin {
 	 * @return array
 	 */
 	function plugin_action_links( $links ) {
+		if( ! is_array( $links ) ) {
+			return $links;
+		}
+		
 		unset( $links['edit'] );
 		$links[] = '<a href="http://siteorigin.com/threads/plugin-page-builder/">' . __( 'Support Forum', 'siteorigin-panels' ) . '</a>';
 		$links[] = '<a href="http://siteorigin.com/page-builder/#newsletter">' . __( 'Newsletter', 'siteorigin-panels' ) . '</a>';


### PR DESCRIPTION
[Fixes this issue](https://wordpress.org/support/topic/page-builder-by-site-origin-ver2-5-14%E3%80%80update-error/#post-9687959). I can't actually replicate this issue but this should prevent it regardless.

[Slack](https://siteorigin.slack.com/archives/C02SYBBH2/p1510842176000393)