### PR TITLE
Fix/delete by meta key

### DIFF
--- a/inc/cache-renderer.php
+++ b/inc/cache-renderer.php
@@ -34,8 +34,6 @@ class SiteOrigin_Panels_Cache_Renderer {
 	 * @param bool|int $post_id The ID of the post to clear or false for all
 	 */
 	public function clear_cache( $post_id = false ){
-		global $wpdb;
-		
-		$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE meta_key = 'siteorigin_panels_cache'" );
+		delete_post_meta_by_key( 'siteorigin_panels_cache' );
 	}
 }

--- a/inc/cache-renderer.php
+++ b/inc/cache-renderer.php
@@ -30,10 +30,8 @@ class SiteOrigin_Panels_Cache_Renderer {
 	 * Clear post meta cache.
 	 *
 	 * Keep this around for a bit in attempt to delete any existing caches.
-	 *
-	 * @param bool|int $post_id The ID of the post to clear or false for all
 	 */
-	public function clear_cache( $post_id = false ){
+	public function clear_cache(){
 		delete_post_meta_by_key( 'siteorigin_panels_cache' );
 	}
 }


### PR DESCRIPTION
In order to play fair WordPress meta cache. It would be better if `siteorigin_panels_cache` meta key is deleted by using `delete_post_meta_by_key` function instead of direct queries to DB.