### PR TITLE
Release 2.6.1

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1501,6 +1501,8 @@
 					padding: 6px;
 
 					.so-directory-item-wrapper {
+						display: flex;
+						flex-flow: column nowrap;
 						height: 100%;
 						box-sizing: border-box;
 						padding: 15px 10px;
@@ -1515,11 +1517,8 @@
 					}
 
 					.so-screenshot {
-						// This is an escaped string to prevent LESS compilation from messing with the calc.
-						height: ~"calc(100% - 50px)";
-						background: #ffffff;
+						flex: 3 auto;
 						margin-bottom: 10px;
-						border: 1px solid #d0d0d0;
 						cursor: pointer;
 
 						&.so-loading {
@@ -1544,22 +1543,31 @@
 						.so-screenshot-wrapper {
 							display: block;
 							min-height: 40px;
+							background: #808080;
+							border: 1px solid #d0d0d0;
 						}
 					}
 
 					.so-description {
+						flex: 1 auto;
 						font-size: 0.9em;
 						color: #666;
 						margin-bottom: 10px;
+						max-height: 60px;
+						overflow: hidden;
 					}
 
 					.so-bottom {
+						flex: 1 auto;
 						position: relative;
+						max-height: 50px;
 
 						.so-title {
 							margin: 0;
 							padding: 16px 10px;
 							cursor: pointer;
+							overflow: hidden;
+							white-space: nowrap;
 						}
 
 						.so-buttons {

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1105,4 +1105,31 @@ class SiteOrigin_Panels_Admin {
 		return $strings;
 	}
 
+	/**
+	 * Display links for various SiteOrigin addons
+	 */
+	public static function display_footer_premium_link(){
+		$links = array(
+			array(
+				'text' => __('Get a lightbox addon for SiteOrigin widgets', 'siteorigin-panels'),
+				'url' => SiteOrigin_Panels::premium_url('plugin/lightbox')
+			),
+			array(
+				'text' => __('Get the row, cell and widget animations addon', 'siteorigin-panels'),
+				'url' => SiteOrigin_Panels::premium_url('plugin/lightbox')
+			),
+			array(
+				'text' => __('Get premium email support for SiteOrigin Page Builder', 'siteorigin-panels'),
+				'url' => SiteOrigin_Panels::premium_url()
+			),
+		);
+		$link = $links[array_rand($links)];
+
+		?>
+        <a href="<?php echo esc_url( $link['url'] ) ?>" target="_blank" rel='noopener noreferrer'>
+			<?php echo esc_html( $link['text'] ) ?>.
+        </a>
+		<?php
+	}
+
 }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -433,7 +433,7 @@ class SiteOrigin_Panels_Admin {
 						$widget_obj->enqueue_admin_scripts();
 					}
 					do_action_ref_array( 'in_widget_form', array( &$widget_obj, &$return, array() ) );
-					ob_clean();
+					ob_end_clean();
 					
 					// Need to render templates for new WP 4.8 widgets when not on the 'widgets' screen or in the customizer.
 					if ( $this->is_js_widget( $widget_obj ) ) {

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -403,7 +403,20 @@ class SiteOrigin_Panels_Admin {
 					'row' => array(
 						'add' => __( 'New Row', 'siteorigin-panels' ),
 						'edit' => __( 'Row', 'siteorigin-panels' ),
-					)
+					),
+					'welcomeMessage' => array(
+						'addingDisabled' => __( 'Hmmm... Adding layout elements is not enabled. Please check if Page Builder has been configured to allow adding elements.', 'siteorigin-panels' ),
+                        'oneEnabled' => __( 'Add a {{%= items[0] %}} to get started.', 'siteorigin-panels' ),
+                        'twoEnabled' => __( 'Add a {{%= items[0] %}} or {{%= items[1] %}} to get started.', 'siteorigin-panels' ),
+                        'threeEnabled' => __( 'Add a {{%= items[0] %}}, {{%= items[1] %}} or {{%= items[2] %}} to get started.', 'siteorigin-panels' ),
+                        'addWidgetButton' => "<a href='#' class='so-tool-button so-widget-add'>" . __( 'Widget', 'siteorigin-panels' ) . "</a>",
+                        'addRowButton' => "<a href='#' class='so-tool-button so-row-add'>" . __( 'Row', 'siteorigin-panels' ) . "</a>",
+                        'addPrebuiltButton' => "<a href='#' class='so-tool-button so-prebuilt-add'>" . __( 'Prebuilt Layout', 'siteorigin-panels' ) . "</a>",
+                        'docsMessage' => sprintf(
+                                __( 'Read our %s if you need help.', 'siteorigin-panels' ),
+                            "<a href='https://siteorigin.com/page-builder/documentation/' target='_blank' rel='noopener noreferrer'>" . __( 'documentation', 'siteorigin-panels' ) . "</a>"
+                        ),
+					),
 				),
 				'plupload'                  => array(
 					'max_file_size'       => wp_max_upload_size() . 'b',

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -80,12 +80,16 @@ class SiteOrigin_Panels_Renderer {
 			// Add the cell sizing
 			foreach( $row['cells'] as $ci => $cell ) {
 				$weight = apply_filters( 'siteorigin_panels_css_cell_weight', $cell['weight'], $row, $ri, $cell, $ci - 1, $panels_data, $post_id );
-
+				$rounded_width = round( $weight * 100, 4 ) . '%';
+                $calc_width = 'calc(' . $rounded_width . ' - ( ' . ( 1 - $weight ) . ' * ' . $gutter . ' ) )';
 				// Add the width and ensure we have correct formatting for CSS.
 				$css->add_cell_css( $post_id, $ri, $ci, '', array(
 					'width' => array(
-						round( $weight * 100, 4 ) . '%',
-						'calc(' . round( $weight * 100, 4 ) . '% - ( ' . ( 1 - $weight ) . ' * ' . $gutter . ' ) )',
+                        // For some locales PHP uses ',' for decimal separation.
+                        // This seems to happen when a plugin calls `setlocale(LC_ALL, 'de_DE');` or `setlocale(LC_NUMERIC, 'de_DE');`
+                        // This should prevent issues with column sizes in these cases.
+						str_replace( ',', '.', $rounded_width ),
+						str_replace( ',', '.', $calc_width ),
 					)
 				) );
 			}

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -622,7 +622,7 @@ class SiteOrigin_Panels_Settings {
 			$types[ $type_id ] = $type_object->label;
 		}
 
-		return $types;
+		return apply_filters( 'siteorigin_panels_settings_enabled_post_types', $types );
 	}
 
 }

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -168,15 +168,41 @@ module.exports = Backbone.View.extend( {
 
 		// Hide toolbar buttons we don't support
 		var toolbar = this.$('.so-builder-toolbar');
+		var welcomeMessageContainer = this.$('.so-panels-welcome-message');
+        var welcomeMessage = panelsOptions.loc.welcomeMessage;
+
+        var supportedItems = [];
+
 		if( ! this.supports( 'addWidget' ) ) {
 			toolbar.find('.so-widget-add' ).hide();
-		}
+		} else {
+            supportedItems.push(welcomeMessage.addWidgetButton);
+        }
 		if( ! this.supports( 'addRow' ) ) {
 			toolbar.find('.so-row-add' ).hide();
+		} else {
+            supportedItems.push(welcomeMessage.addRowButton);
 		}
 		if( ! this.supports( 'prebuilt' ) ) {
 			toolbar.find('.so-prebuilt-add' ).hide();
+		} else {
+            supportedItems.push(welcomeMessage.addPrebuiltButton);
 		}
+
+        var msg = '';
+		if ( supportedItems.length === 3 ) {
+			msg = welcomeMessage.threeEnabled;
+        } else if ( supportedItems.length === 2 ) {
+            msg = welcomeMessage.twoEnabled;
+        } else if ( supportedItems.length === 1 ) {
+            msg = welcomeMessage.oneEnabled;
+        } else if ( supportedItems.length === 0 ) {
+            msg = welcomeMessage.addingDisabled;
+		}
+
+        var resTemplate = _.template( panels.helpers.utils.processTemplate( msg ) );
+        var msgHTML = resTemplate({items: supportedItems}) + ' ' + welcomeMessage.docsMessage;
+        welcomeMessageContainer.find('.so-message-wrapper').html( msgHTML );
 
 		return this;
 	},

--- a/js/siteorigin-panels/view/row.js
+++ b/js/siteorigin-panels/view/row.js
@@ -67,16 +67,16 @@ module.exports = Backbone.View.extend( {
 			this.$el.addClass('so-row-no-actions');
 		}
 		else {
-			if( ! this.builder.supports( 'editWidget' ) ) {
-				this.$('.so-row-toolbar .so-row-settings' ).parent().remove();
+			if( ! this.builder.supports( 'editRow' ) ) {
+				this.$('.so-row-toolbar .so-dropdown-links-wrapper .so-row-settings' ).parent().remove();
 				this.$el.addClass('so-row-no-edit');
 			}
-			if( ! this.builder.supports( 'addWidget' ) ) {
-				this.$('.so-row-toolbar .so-row-duplicate' ).parent().remove();
+			if( ! this.builder.supports( 'addRow' ) ) {
+				this.$('.so-row-toolbar .so-dropdown-links-wrapper .so-row-duplicate' ).parent().remove();
 				this.$el.addClass('so-row-no-duplicate');
 			}
-			if( ! this.builder.supports( 'deleteWidget' ) ) {
-				this.$('.so-row-toolbar .so-row-delete' ).parent().remove();
+			if( ! this.builder.supports( 'deleteRow' ) ) {
+				this.$('.so-row-toolbar .so-dropdown-links-wrapper .so-row-delete' ).parent().remove();
 				this.$el.addClass('so-row-no-delete');
 			}
 		}
@@ -235,6 +235,9 @@ module.exports = Backbone.View.extend( {
 	 * Handle displaying the settings dialog
 	 */
 	editSettingsHandler: function () {
+		if ( ! this.builder.supports( 'editRow' ) ) {
+			return;
+		}
 		// Lets open up an instance of the settings dialog
 		if ( this.dialog === null ) {
 			// Create the dialog

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -505,16 +505,19 @@ class SiteOrigin_Panels {
 			   apply_filters( 'siteorigin_premium_upgrade_teaser', true ) &&
 			   ! defined( 'SITEORIGIN_PREMIUM_VERSION' );
 	}
-	
+
 	/**
 	 * Get the premium upgrade URL
 	 *
 	 * @return string
 	 */
-	public static function premium_url() {
+	public static function premium_url( $featured_addon = false ) {
 		$ref = apply_filters( 'siteorigin_premium_affiliate_id', '' );
 		$url = 'https://siteorigin.com/downloads/premium/?featured_plugin=siteorigin-panels';
-		if( $ref ) {
+		if( ! empty( $featured_addon ) ) {
+			$url = add_query_arg( 'featured_addon', urlencode( $featured_addon ), $url );
+        }
+		if( ! empty( $ref ) ) {
 			$url = add_query_arg( 'ref', urlencode( $ref ), $url );
 		}
 		return $url;

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -74,12 +74,10 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 				?>
 			</div>
 
-			<?php if( SiteOrigin_Panels::display_learn_button() ) : ?>
+			<?php if( SiteOrigin_Panels::display_premium_teaser() ) : ?>
 				<div class="so-tip-wrapper">
 					<strong><?php _e( 'Pro Tip', 'siteorigin-panels' ) ?>: </strong>
-					<a href="#siteorigin-learn-page-builder-tips" class="so-lesson-modal">
-						<?php _e( '12 tips every Page Builder user should know.', 'siteorigin-panels' ) ?>
-					</a>
+                    <?php SiteOrigin_Panels_Admin::display_footer_premium_link() ?>
 				</div>
 			<?php endif; ?>
 		</div>


### PR DESCRIPTION
* Switch off output buffering when enqueueing admin scripts.
* Prevent custom post types from showing in the settings list.
* Make sure `SiteOrigin_Panels_Widgets_Layout` exists before setting icon for widgets lists.
* Hide individual action links when features disabled and prevent editing by clicking directly on spanner when edit row disabled.
* Adapt welcome message when some features not supported.
* Column width CSS output correctly for locales which use ',' as decimal separator.
* Fixed prebuilt layout directory items.