### PR TITLE
Release 2.6.2

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1147,7 +1147,15 @@ class SiteOrigin_Panels_Admin {
         </a>
 		<?php
 	}
-
+	
+	/**
+	 * Disable the Gutenberg editor for existing PB posts.
+	 *
+	 * @param $can_edit
+	 * @param $post_type
+	 *
+	 * @return bool
+	 */
 	public function disable_gutenberg_for_panels_posts( $can_edit, $post_type ) {
 		$screen = get_current_screen();
 		$post_types = siteorigin_panels_setting( 'post-types' );
@@ -1157,7 +1165,14 @@ class SiteOrigin_Panels_Admin {
 
 		return ! $is_panels_page && $can_edit;
 	}
-
+	
+	/**
+	 * Disable PB when we're in the Gutenberg editor.
+	 *
+	 * @param $wp_meta_boxes
+	 *
+	 * @return mixed
+	 */
 	public function disable_panels_for_gutenberg_posts( $wp_meta_boxes ) {
 		foreach ( $wp_meta_boxes as &$locations ) {
 			foreach ( $locations as &$priorities ) {

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -61,6 +61,8 @@ class SiteOrigin_Panels_Admin {
 		SiteOrigin_Panels_Admin_Layouts::single();
 
 		$this->in_save_post = false;
+
+		add_filter( 'gutenberg_can_edit_post_type', array( $this, 'disable_gutenberg_for_panels_posts' ), 10, 2 );
 	}
 
 	/**
@@ -1145,4 +1147,13 @@ class SiteOrigin_Panels_Admin {
 		<?php
 	}
 
+	public function disable_gutenberg_for_panels_posts( $can_edit, $post_type ) {
+		$screen = get_current_screen();
+		$post_types = siteorigin_panels_setting( 'post-types' );
+		$panels_data = $screen->base == 'post' ? $this->get_current_admin_panels_data() : array();
+
+		$is_panels_page = in_array( $post_type, $post_types ) && ! empty( $panels_data );
+
+		return ! $is_panels_page && $can_edit;
+	}
 }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -63,6 +63,7 @@ class SiteOrigin_Panels_Admin {
 		$this->in_save_post = false;
 
 		add_filter( 'gutenberg_can_edit_post_type', array( $this, 'disable_gutenberg_for_panels_posts' ), 10, 2 );
+		add_filter( 'filter_gutenberg_meta_boxes', array( $this, 'disable_panels_for_gutenberg_posts' ) );
 	}
 
 	/**
@@ -1155,5 +1156,18 @@ class SiteOrigin_Panels_Admin {
 		$is_panels_page = in_array( $post_type, $post_types ) && ! empty( $panels_data );
 
 		return ! $is_panels_page && $can_edit;
+	}
+
+	public function disable_panels_for_gutenberg_posts( $wp_meta_boxes ) {
+		foreach ( $wp_meta_boxes as &$locations ) {
+			foreach ( $locations as &$priorities ) {
+				foreach ( $priorities as &$boxes ) {
+					unset( $boxes['so-panels-panels'] );
+					unset( $boxes['siteorigin_page_settings'] );
+
+				}
+			}
+		}
+		return $wp_meta_boxes;
 	}
 }


### PR DESCRIPTION
Small release to prevent the Gutenberg plugin from messing with existing PB pages.

* Prevent Gutenberg from taking over existing PB pages.