### PR TITLE
Release 2.6.5

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1670,6 +1670,7 @@
 	.so-visual-styles {
 
 		margin: -15px;
+		height: 100%;
 
 		h3 {
 			line-height: 1em;

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -433,8 +433,8 @@ class SiteOrigin_Panels_Admin {
 				'prebuiltDefaultScreenshot' => siteorigin_panels_url( 'css/images/prebuilt-default.png' ),
 				'loadOnAttach'              => siteorigin_panels_setting( 'load-on-attach' ),
 				'siteoriginWidgetRegex'     => str_replace( '*+', '*', get_shortcode_regex( array( 'siteorigin_widget' ) ) ),
-				'widgetForms' 				=> array(
-					'loadingFailed' => __( 'Unknown error. Failed to load the widget form. Please check your internet connection, contact your web site administrator, or try again later.', 'so-widgets-bundle' ),
+				'forms' 				=> array(
+					'loadingFailed' => __( 'Unknown error. Failed to load the form. Please check your internet connection, contact your web site administrator, or try again later.', 'siteorigin-panels' ),
 				)
 			) );
 			
@@ -997,10 +997,18 @@ class SiteOrigin_Panels_Admin {
 	 */
 	function action_widget_form() {
 		if ( empty( $_REQUEST['_panelsnonce'] ) || ! wp_verify_nonce( $_REQUEST['_panelsnonce'], 'panels_action' ) ) {
-			wp_die( 'The supplied nonce is invalid.', 'Invalid nonce.', 403 );
+			wp_die(
+				__( 'The supplied nonce is invalid.', 'siteorigin-panels' ),
+				__( 'Invalid nonce.', 'siteorigin-panels' ),
+				403
+			);
 		}
 		if ( empty( $_REQUEST['widget'] ) ) {
-			wp_die( 'Please specify the type of widget form to be rendered.', 'Missing widget type.', 400 );
+			wp_die(
+				__( 'Please specify the type of widget form to be rendered.', 'siteorigin-panels' ),
+				__( 'Missing widget type.', 'siteorigin-panels' ),
+				400
+			);
 		}
 		
 		$request = array_map( 'stripslashes_deep', $_REQUEST );

--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -18,12 +18,22 @@ class SiteOrigin_Panels_Styles_Admin {
 	 * Admin action for handling fetching the style fields
 	 */
 	function action_style_form() {
-		$type = $_REQUEST['type'];
-		if ( ! in_array( $type, array( 'row', 'cell', 'widget' ) ) ) {
-			exit();
+		if ( empty( $_REQUEST['_panelsnonce'] ) || ! wp_verify_nonce( $_REQUEST['_panelsnonce'], 'panels_action' ) ) {
+			wp_die(
+				__( 'The supplied nonce is invalid.', 'siteorigin-panels' ),
+				__( 'Invalid nonce.', 'siteorigin-panels' ),
+				403
+			);
 		}
-		if ( empty( $_GET['_panelsnonce'] ) || ! wp_verify_nonce( $_GET['_panelsnonce'], 'panels_action' ) ) {
-			exit();
+		
+		$type = $_REQUEST['type'];
+		
+		if ( ! in_array( $type, array( 'row', 'cell', 'widget' ) ) ) {
+			wp_die(
+				__( 'Please specify the type of style form to be rendered.', 'siteorigin-panels' ),
+				__( 'Missing style form type.', 'siteorigin-panels' ),
+				400
+			);
 		}
 
 		$current = isset( $_REQUEST['style'] ) ? $_REQUEST['style'] : array();

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -125,19 +125,16 @@ module.exports = panels.view.dialog.extend({
 		}
 
 		var $rightSidebar = this.$('.so-sidebar.so-right-sidebar');
-		this.styles.attach($rightSidebar);
+		this.styles.attach( $rightSidebar );
 
 		// Handle the loading class
 		this.styles.on('styles_loaded', function (hasStyles) {
-			// If we have styles remove the loading spinner, else remove the whole empty sidebar.
-			if (hasStyles) {
-				$rightSidebar.removeClass('so-panels-loading');
-			} else {
+			// If we don't have styles remove the empty sidebar.
+			if ( ! hasStyles ) {
 				$rightSidebar.closest('.so-panels-dialog').removeClass('so-panels-dialog-has-right-sidebar');
 				$rightSidebar.remove();
 			}
 		}, this);
-		$rightSidebar.addClass('so-panels-loading');
 
 		if (!_.isUndefined(this.model)) {
 			// Set the initial value of the
@@ -499,13 +496,6 @@ module.exports = panels.view.dialog.extend({
 		if ( this.cellStyles ) {
 			var $rightSidebar = this.$( '.so-sidebar.so-right-sidebar' );
 			this.cellStyles.attach( $rightSidebar );
-
-			if ( !this.cellStyles.stylesLoaded ) {
-				this.cellStyles.on( 'styles_loaded', function () {
-					$rightSidebar.removeClass( 'so-panels-loading' );
-				}, this );
-				$rightSidebar.addClass( 'so-panels-loading' );
-			}
 		}
 	},
 

--- a/js/siteorigin-panels/dialog/widget.js
+++ b/js/siteorigin-panels/dialog/widget.js
@@ -85,15 +85,12 @@ module.exports = panels.view.dialog.extend( {
 
 		// Handle the loading class
 		this.styles.on( 'styles_loaded', function ( hasStyles ) {
-			// If we have styles remove the loading spinner, else remove the whole empty sidebar.
-			if ( hasStyles ) {
-				$rightSidebar.removeClass( 'so-panels-loading' );
-			} else {
+			// If we don't have styles remove the empty sidebar.
+			if ( ! hasStyles ) {
 				$rightSidebar.closest( '.so-panels-dialog' ).removeClass( 'so-panels-dialog-has-right-sidebar' );
 				$rightSidebar.remove();
 			}
 		}, this );
-		$rightSidebar.addClass( 'so-panels-loading' );
 	},
 
 	/**
@@ -200,7 +197,7 @@ module.exports = panels.view.dialog.extend( {
 			if ( error && error.responseText ) {
 				html = error.responseText;
 			} else {
-				html = panelsOptions.widgetForms.loadingFailed;
+				html = panelsOptions.forms.loadingFailed;
 			}
 			
 			$soContent

--- a/js/siteorigin-panels/view/styles.js
+++ b/js/siteorigin-panels/view/styles.js
@@ -25,7 +25,7 @@ module.exports = Backbone.View.extend( {
 			dialog: null
 		}, args );
 
-		this.$el.addClass( 'so-visual-styles so-' + stylesType + '-styles' );
+		this.$el.addClass( 'so-visual-styles so-' + stylesType + '-styles so-panels-loading' );
 
 		var postArgs = {
 			builderType: args.builderType
@@ -34,7 +34,7 @@ module.exports = Backbone.View.extend( {
 		if ( stylesType === 'cell') {
 			postArgs.index = args.index;
 		}
-
+		
 		// Load the form
 		$.post(
 			panelsOptions.ajaxurl,
@@ -45,16 +45,30 @@ module.exports = Backbone.View.extend( {
 				args: JSON.stringify( postArgs ),
 				postId: postId
 			},
-			function ( response ) {
-				this.$el.html( response );
-				this.setupFields();
-				this.stylesLoaded = true;
-				this.trigger( 'styles_loaded', ! _.isEmpty( response ) );
-				if ( ! _.isNull( args.dialog ) ) {
-					args.dialog.trigger( 'styles_loaded', ! _.isEmpty( response ) );
-				}
-			}.bind(this)
-		);
+			null,
+			'html'
+		).done( function ( response ) {
+			this.$el.html( response );
+			this.setupFields();
+			this.stylesLoaded = true;
+			this.trigger( 'styles_loaded', !_.isEmpty( response ) );
+			if ( !_.isNull( args.dialog ) ) {
+				args.dialog.trigger( 'styles_loaded', !_.isEmpty( response ) );
+			}
+		}.bind( this ) )
+		.fail( function ( error ) {
+			var html;
+			if ( error && error.responseText ) {
+				html = error.responseText;
+			} else {
+				html = panelsOptions.forms.loadingFailed;
+			}
+			
+			this.$el.html( html );
+		}.bind( this ) )
+		.always( function () {
+			this.$el.removeClass( 'so-panels-loading' );
+		}.bind( this ) );
 
 		return this;
 	},


### PR DESCRIPTION
* Don't use `mime_content_type` for external layouts if it's not available. Just check file extensions.
* Get correct ID for WooCommerce shop page to allow PB to render correctly.
* Added image fallback url field for background images in row, cell and widget styles.
* Temporarily remove Jetpack widgets requiring scripts for admin form, until we can reliably enqueue their scripts.
* Remove loading indicator and display message when loading widget and style forms fail.
* Allow setting margins around specific widgets.