### PR TITLE
Fix Background fallback URL notice

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -427,7 +427,7 @@ class SiteOrigin_Panels_Styles {
 		) {
 			$url = self::get_attachment_image_src( $style['background_image_attachment'], 'full' );
 			
-			if ( empty( $url ) ) {
+			if ( empty( $url ) && ! empty( $style['background_image_attachment_fallback'] ) ) {
 				$url = $style['background_image_attachment_fallback'];
 			}
 


### PR DESCRIPTION
Alternative title: If the background is set but missing, and the post hasn't updated after 2.6.5, notice will appear

If a post previously had a valid background image but the image is no longer available and the post hasn't been updated after installing 2.6.5, there will be a notice output as we try and output the fallback URL without checking if it exists first.


```
( ! ) Notice: Undefined index: background_image_attachment_fallback in C:\wamp64\www\siteorigin\wp-content\plugins\siteorigin-panels\inc\styles.php on line 431
--


1 | 0.0005 | 412400 | {main}( ) | ...\index.php:0
2 | 0.0013 | 412688 | require( 'C:\wamp64\www\siteorigin\wp-blog-header.php' ) | ...\index.php:17
3 | 1.2419 | 17993824 | require_once( 'C:\wamp64\www\siteorigin\wp-includes\template-loader.php' ) | ...\wp-blog-header.php:19
4 | 1.2520 | 18075440 | include( 'C:\wamp64\www\siteorigin\wp-content\themes\github\siteorigin-unwind\page.php' ) | ...\template-loader.php:74
5 | 2.2691 | 19145168 | get_template_part( ) | ...\page.php:27
6 | 2.2691 | 19145736 | locate_template( ) | ...\general-template.php:155
7 | 2.2695 | 19145864 | load_template( ) | ...\template.php:647
8 | 2.3078 | 19146296 | require( 'C:\wamp64\www\siteorigin\wp-content\themes\github\siteorigin-unwind\template-parts\content-page.php' ) | ...\template.php:690
9 | 2.3113 | 19146912 | the_content( ) | ...\content-page.php:23
10 | 2.3141 | 19149448 | apply_filters( ) | ...\post-template.php:240
11 | 2.3141 | 19149848 | WP_Hook->apply_filters( ) | ...\plugin.php:203
12 | 2.3164 | 19159832 | SiteOrigin_Panels->generate_post_content( ) | ...\class-wp-hook.php:286
13 | 2.3169 | 19159832 | SiteOrigin_Panels_Renderer->render( ) | ...\siteorigin-panels.php:296
14 | 2.3215 | 19071464 | SiteOrigin_Panels_Renderer->render_row( ) | ...\renderer.php:320
15 | 2.3218 | 19073624 | SiteOrigin_Panels_Renderer->render_cell( ) | ...\renderer.php:709
16 | 2.3221 | 19074704 | SiteOrigin_Panels_Renderer->render_widget( ) | ...\renderer.php:783
17 | 2.3222 | 19075344 | SiteOrigin_Panels_Renderer->the_widget( ) | ...\renderer.php:823
18 | 2.3227 | 19078480 | SiteOrigin_Panels_Widgets_PostLoop->widget( ) | ...\renderer.php:522
19 | 2.3896 | 19622056 | locate_template( ) | ...\post-loop.php:166
20 | 2.3899 | 19622184 | load_template( ) | ...\template.php:647
21 | 2.3913 | 19622600 | require( 'C:\wamp64\www\siteorigin\wp-content\themes\github\siteorigin-unwind\loops\loop-blog-masonry.php') | ...\template.php:690
22 | 20.8843 | 39017352 | get_template_part( ) | ...\loop-blog-masonry.php:29
23 | 20.8843 | 39017848 | locate_template( ) | ...\general-template.php:155
24 | 20.8849 | 39017976 | load_template( ) | ...\template.php:647
25 | 20.8850 | 39018392 | require( 'C:\wamp64\www\siteorigin\wp-content\themes\github\siteorigin-unwind\template-parts\content-masonry.php' ) | ...\template.php:690
26 | 20.9215 | 39018392 | siteorigin_unwind_excerpt( ) | ...\content-masonry.php:60
27 | 20.9258 | 39018392 | get_the_excerpt( ) | ...\template-tags.php:310
28 | 20.9259 | 39018392 | apply_filters( ) | ...\post-template.php:397
29 | 20.9259 | 39018792 | WP_Hook->apply_filters( ) | ...\plugin.php:203
30 | 20.9259 | 39019544 | wp_trim_excerpt( ) | ...\class-wp-hook.php:288
31 | 20.9275 | 39040024 | apply_filters( ) | ...\formatting.php:3313
32 | 20.9275 | 39040424 | WP_Hook->apply_filters( ) | ...\plugin.php:203
33 | 20.9314 | 39049368 | SiteOrigin_Panels->generate_post_content( ) | ...\class-wp-hook.php:286
34 | 20.9327 | 39049368 | SiteOrigin_Panels_Renderer->render( ) | ...\siteorigin-panels.php:296
35 | 23.6016 | 39298560 | SiteOrigin_Panels_Renderer->generate_css( ) | ...\renderer.php:333
36 | 23.6119 | 39308120 | apply_filters( ) | ...\renderer.php:253
37 | 23.6120 | 39308520 | WP_Hook->apply_filters( ) | ...\plugin.php:203
38 | 23.6120 | 39309272 | SiteOrigin_Panels_Styles->filter_css_object( ) | ...\class-wp-hook.php:286
39 | 23.6130 | 39312496 | apply_filters( ) | ...\styles.php:543
40 | 23.6130 | 39312896 | WP_Hook->apply_filters( ) | ...\plugin.php:203
41 | 23.6130 | 39313648 | SiteOrigin_Panels_Styles->general_style_css( ) | ...\class-wp-hook.php:286

```
