### PR TITLE
Update admin.less

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1663,7 +1663,7 @@
 	.so-visual-styles {
 
 		margin: -15px;
-		height: 100%;
+		height: auto;
 
 		h3 {
 			line-height: 1em;


### PR DESCRIPTION
in the row editor dialog, right panel and multiple cols in the row:
height: 100% for .so-panels-dialog .so-visual-styles results in big gap between head section and cell section on selecting a cell and overlapping if you open e.g head layout panel

![2018-06-05_13h03_50](https://user-images.githubusercontent.com/4427908/40972822-443273ce-68c2-11e8-91b1-f9dd78b070e9.png)

![2018-06-05_13h05_48](https://user-images.githubusercontent.com/4427908/40972826-47f111c8-68c2-11e8-83df-5a33a572aac1.png)
