### PR TITLE
Row Cell options: Prevent Yoast from resizing fields

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1234,6 +1234,7 @@
 				input, select, button, strong, span {
 					display: inline;
 					margin: 1px 5px;
+					width: auto;
 
 					outline: none;
 					box-shadow: none;


### PR DESCRIPTION
This fixes an issue that Yoast introduced in the latest update where it'll resize the column size fields. This PR also prevents it from happening again because setting a width by default.


![](https://i.imgur.com/uSSHh9J.png)
![](https://i.imgur.com/MFCw0cr.png)
