### PR TITLE
WIP: Stop duplicate revisions and post meta from being created.

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -193,10 +193,13 @@ class SiteOrigin_Panels_Admin {
 
 			if( siteorigin_panels_setting( 'copy-content' ) ) {
 				// Store a version of the HTML in post_content
+				$post_parent_id = wp_is_post_revision( $post_id );
+				$layout_id = ( ! empty( $post_parent_id ) ) ? $post_parent_id : $post_id;
+
 				SiteOrigin_Panels_Post_Content_Filters::add_filters();
 				$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-				$post_content = SiteOrigin_Panels::renderer()->render( $post_id, false, $panels_data );
-				$post_css = SiteOrigin_Panels::renderer()->generate_css( $post_id, $panels_data );
+				$post_content = SiteOrigin_Panels::renderer()->render( $layout_id, false, $panels_data );
+				$post_css = SiteOrigin_Panels::renderer()->generate_css( $layout_id, $panels_data );
 				SiteOrigin_Panels_Post_Content_Filters::remove_filters();
 				unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 
@@ -204,12 +207,14 @@ class SiteOrigin_Panels_Admin {
 				$post->post_content = $post_content;
 				if( siteorigin_panels_setting( 'copy-styles' ) ) {
 					$post->post_content .= "\n\n";
-					$post->post_content .= '<style type="text/css" class="panels-style" data-panels-style-for-post="' . intval( $post_id ) . '">';
+					$post->post_content .= '<style type="text/css" class="panels-style" data-panels-style-for-post="' . intval( $layout_id ) . '">';
 					$post->post_content .= '@import url(' . SiteOrigin_Panels::front_css_url() . '); ';
 					$post->post_content .= $post_css;
 					$post->post_content .= '</style>';
 				}
+				remove_action( 'post_updated', 'wp_save_post_revision' );
 				wp_update_post( $post );
+				add_action( 'post_updated', 'wp_save_post_revision' );
 			}
 
 		} else {

--- a/inc/revisions.php
+++ b/inc/revisions.php
@@ -8,7 +8,6 @@
 class SiteOrigin_Panels_Revisions {
 
 	function __construct() {
-		add_action( 'save_post', array( $this, 'save_post' ), 11, 2 );
 		add_action( 'wp_restore_post_revision', array( $this, 'revisions_restore' ), 10, 2 );
 
 		add_filter( '_wp_post_revision_fields', array( $this, 'revisions_fields' ) );
@@ -21,25 +20,6 @@ class SiteOrigin_Panels_Revisions {
 	public static function single() {
 		static $single;
 		return empty( $single ) ? $single = new self() : $single;
-	}
-
-	/**
-	 * Store the Page Builder meta in the revision.
-	 *
-	 * @param $post_id
-	 * @param $post
-	 */
-	function save_post( $post_id, $post ) {
-		if( is_preview() ) return;
-
-		$parent_id = wp_is_post_revision( $post_id );
-		if ( $parent_id ) {
-			// If the panels data meta exists, copy it into the revision.
-			$panels_data = get_post_meta( $parent_id, 'panels_data', true );
-			if ( ! empty( $panels_data ) ) {
-				add_metadata( 'post', $post_id, 'panels_data', $panels_data );
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
I've found a few bugs with how post/page revisions are handled with SiteOrigin's Page Builder plugin.

I discover the issues on a one of our websites but have also tested on a clean WordPress install using the twentyseventeen theme.

Here are the bug I found:

1. When a post/page is created using the page builder, a duplicate post revision is being created everytime i.e. there are 2 revision per update. The call to wp_update_post() in the save_post hook is causing this. The solution is to remove the WordPress hook that creates revisions before calling wp_update_post(). The hook then needs to be added back afterwards. Also see: https://wordpress.stackexchange.com/questions/3393/enable-disable-post-revisions-programmatically/3398
2. When viewing the contents of post revisions (i.e. browsing the revisions), the pl-{ID} attributes in the HTML matches the ID of the revision rather than the post. WordPress then highlights these as changes. I think it make more sense to save the revision content using the post ID rather than the revision.
3. Duplicate 'panels_data' is getting added to the postmeta table on preview and save of revisions. We have a page that is frequently updated/previewed and it had over 700 duplicates. The code causing this is in revision.php. The save_post hook was adding the postmeta to the duplicate revision created above (1) and also the initial revision 2 times per page preview. The is_preview() check doesn't work in the context of save_post (the hook is called before the WP_Query object is setup). Anyway with the fix to remove the duplicate revision (1) this hook becomes redundant and can be remove.

Thats probably a lot to review for a single pull request but these 3 issues are all linked. I hope you consider these changes. I'm happy to explain the changes I more detail if you like.