### PR TITLE
Stopped duplicate revisions from being created in the wp_posts table.

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -209,7 +209,9 @@ class SiteOrigin_Panels_Admin {
 					$post->post_content .= $post_css;
 					$post->post_content .= '</style>';
 				}
+				remove_action( 'post_updated', 'wp_save_post_revision' );
 				wp_update_post( $post );
+				add_action( 'post_updated', 'wp_save_post_revision' );
 			}
 
 		} else {


### PR DESCRIPTION
This PR stops duplicate revisions from being created in the wp_posts table.

If you create a new page with the page builder an extra revision is saved for every update made. 

e.g. this page has been saved then updated but has a total of 4 revisions
![duplicate-revisions](https://user-images.githubusercontent.com/2400084/41775718-fa18d4be-761c-11e8-8c7a-2fe17d766aa6.png)

This PR stops the extra revision from been created by temporarily removing the save revision hook while wp_update_post() is called. 
![duplicate-revisions-fix](https://user-images.githubusercontent.com/2400084/41775981-efadb322-761d-11e8-9b37-7e9de7c52aac.png)

See this on stackexchange for more details: https://wordpress.stackexchange.com/questions/3393/enable-disable-post-revisions-programmatically/3398