### PR TITLE
Fixed bug with the layout IDs for revisions

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -193,10 +193,13 @@ class SiteOrigin_Panels_Admin {
 
 			if( siteorigin_panels_setting( 'copy-content' ) ) {
 				// Store a version of the HTML in post_content
+				$post_parent_id = wp_is_post_revision( $post_id );
+				$layout_id = ( ! empty( $post_parent_id ) ) ? $post_parent_id : $post_id;
+				
 				SiteOrigin_Panels_Post_Content_Filters::add_filters();
 				$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-				$post_content = SiteOrigin_Panels::renderer()->render( $post_id, false, $panels_data );
-				$post_css = SiteOrigin_Panels::renderer()->generate_css( $post_id, $panels_data );
+				$post_content = SiteOrigin_Panels::renderer()->render( $layout_id, false, $panels_data );
+				$post_css = SiteOrigin_Panels::renderer()->generate_css( $layout_id, $panels_data );
 				SiteOrigin_Panels_Post_Content_Filters::remove_filters();
 				unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 
@@ -204,7 +207,7 @@ class SiteOrigin_Panels_Admin {
 				$post->post_content = $post_content;
 				if( siteorigin_panels_setting( 'copy-styles' ) ) {
 					$post->post_content .= "\n\n";
-					$post->post_content .= '<style type="text/css" class="panels-style" data-panels-style-for-post="' . intval( $post_id ) . '">';
+					$post->post_content .= '<style type="text/css" class="panels-style" data-panels-style-for-post="' . intval( $layout_id ) . '">';
 					$post->post_content .= '@import url(' . SiteOrigin_Panels::front_css_url() . '); ';
 					$post->post_content .= $post_css;
 					$post->post_content .= '</style>';


### PR DESCRIPTION
Layout IDs should use the post ID rather than the revision ID to prevent WordPress from highlighting the ID as a change in the revision browser.

The "Content" section in the revision browser has the wrong layout IDs.
e.g.
![wrong-id-in-revision-browser](https://user-images.githubusercontent.com/2400084/41776225-d0f5ce78-761e-11e8-9d14-b0653c37a753.png)

The "Page Builder Content" section has things right imo. This uses the current post ID rather than revision ID. The Content section IMO should also use the post ID rather than revision ID. This PR fixes this so things are like this:
![wrong-id-in-revision-browser-fix](https://user-images.githubusercontent.com/2400084/41776314-2db07942-761f-11e8-905a-9c40aef8d652.png)
