### PR TITLE
Post Loop: Add filter to allow for custom template directories

### DIFF
--- a/inc/widgets/post-loop.php
+++ b/inc/widgets/post-loop.php
@@ -362,6 +362,7 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 		);
 		
 		$template_dirs = array( get_template_directory(), get_stylesheet_directory() );
+		$template_dirs = apply_filters( 'siteorigin_panels_postloop_template_directory', $template_dirs );
 		$template_dirs = array_unique( $template_dirs );
 		foreach( $template_dirs  as $dir ){
 			foreach( $template_files as $template_file ) {


### PR DESCRIPTION
This PR adds a new filter called `siteorigin_panels_postloop_template_directory`. This filter will allow plugins (and themes with more than two levels deep post template structure) to include their custom post templates.