### PR TITLE
Dashboard Assets: Check if $screen exists

### DIFF
--- a/inc/admin-dashboard.php
+++ b/inc/admin-dashboard.php
@@ -40,7 +40,7 @@ class SiteOrigin_Panels_Admin_Dashboard {
 	 */
 	public function enqueue_admin_styles( $page ){
 		$screen = get_current_screen();
-		if( $screen->id == 'dashboard' ) {
+		if( ! empty( $screen ) && $screen->id == 'dashboard' ) {
 			wp_enqueue_style(
 				'so-panels-dashboard',
 				siteorigin_panels_url( 'css/dashboard.css' ),


### PR DESCRIPTION
This PR fixes the following notice when running the WooCommerce Setup Wizard.

`Notice: Trying to get property of non-object in C:\wamp64\www\siteorigin\wp-content\plugins\siteorigin-panels\inc\admin-dashboard.php on line 43`

![](https://i.imgur.com/ZhX93Yo.png)

You can rerun the WooCommerce setup by opening a WooCommerce page, and click **Help**. Open the **Setup Wizard** tab and click **Setup Wizard**.