### PR TITLE
Give post loop access to widget scope

### DIFF
--- a/inc/widgets/post-loop-helper.php
+++ b/inc/widgets/post-loop-helper.php
@@ -6,24 +6,24 @@
  * Class SiteOrigin_Panels_Widgets_PostLoop_Helper
  */
 class SiteOrigin_Panels_Widgets_PostLoop_Helper extends SiteOrigin_Widget {
-	
+
 	/**
 	 * SiteOrigin_Panels_Widgets_PostLoop_Helper constructor.
 	 *
 	 * @param array $templates
 	 */
 	function __construct( $templates ) {
-		
+
 		$template_options = array();
-		if( ! empty( $templates ) ) {
-			foreach( $templates as $template ) {
-				$headers = get_file_data( locate_template( $template ), array(
+		if ( ! empty( $templates ) ) {
+			foreach ( $templates as $template ) {
+				$headers                       = get_file_data( locate_template( $template ), array(
 					'loop_name' => 'Loop Name',
 				) );
 				$template_options[ $template ] = esc_html( ! empty( $headers['loop_name'] ) ? $headers['loop_name'] : $template );
 			}
 		}
-		
+
 		parent::__construct(
 			'siteorigin-panels-postloop-helper',
 			__( 'Post Loop', 'siteorigin-panels' ),
@@ -33,31 +33,37 @@ class SiteOrigin_Panels_Widgets_PostLoop_Helper extends SiteOrigin_Widget {
 			),
 			array(),
 			array(
-				'title' => array(
-					'type' => 'text',
+				'title'    => array(
+					'type'  => 'text',
 					'label' => __( 'Title', 'siteorigin-panels' ),
 				),
 				'template' => array(
-					'type' => 'select',
-					'label' => __( 'Template', 'siteorigin-panels' ),
+					'type'    => 'select',
+					'label'   => __( 'Template', 'siteorigin-panels' ),
 					'options' => $template_options,
 					'default' => 'loop.php',
 				),
-				'more' => array(
-					'type' => 'checkbox',
-					'label' => __( 'More link', 'so-widgets-bundle' ),
-					'description' => __( 'If the template supports it, cut posts and display the more link.', 'siteorigin-panels' ),
-					'default' => false,
+				'width'    => array(
+					'type'        => 'number',
+					'label'       => __( 'Width in pixels', 'siteorigin-panels' ),
+					'description' => __( 'Width of the div this widget instance will be inserted in', 'siteorigin-panels' ),
+					'default'     => 1200,
 				),
-				'posts' => array(
-					'type' => 'posts',
+				'more'     => array(
+					'type'        => 'checkbox',
+					'label'       => __( 'More link', 'so-widgets-bundle' ),
+					'description' => __( 'If the template supports it, cut posts and display the more link.', 'siteorigin-panels' ),
+					'default'     => false,
+				),
+				'posts'    => array(
+					'type'  => 'posts',
 					'label' => __( 'Posts query', 'so-widgets-bundle' ),
-					'hide' => true
+					'hide'  => true
 				),
 			)
 		);
 	}
-	
+
 	/**
 	 * Convert this instance into one that's compatible with the posts field
 	 *
@@ -66,28 +72,40 @@ class SiteOrigin_Panels_Widgets_PostLoop_Helper extends SiteOrigin_Widget {
 	 * @return mixed
 	 */
 	function modify_instance( $instance ) {
-		if( ! empty( $instance['post_type'] ) ) {
+		if ( ! empty( $instance['post_type'] ) ) {
 			$value = array();
-			
-			if( ! empty( $instance['post_type'] ) ) $value['post_type'] = $instance['post_type'];
-			if( ! empty( $instance['posts_per_page'] ) ) $value['posts_per_page'] = $instance['posts_per_page'];
-			if( ! empty( $instance['order'] ) ) $value['order'] = $instance['order'];
-			if( ! empty( $instance['orderby'] ) ) $value['orderby'] = $instance['orderby'];
-			if( ! empty( $instance['sticky'] ) ) $value['sticky'] = $instance['sticky'];
-			if( ! empty( $instance['additional'] ) ) $value['additional'] = $instance['additional'];
-			$instance[ 'posts' ] = $value;
-			
-			unset( $instance[ 'post_type' ] );
-			unset( $instance[ 'posts_per_page' ] );
-			unset( $instance[ 'order' ] );
-			unset( $instance[ 'orderby' ] );
-			unset( $instance[ 'sticky' ] );
-			unset( $instance[ 'additional' ] );
+
+			if ( ! empty( $instance['post_type'] ) ) {
+				$value['post_type'] = $instance['post_type'];
+			}
+			if ( ! empty( $instance['posts_per_page'] ) ) {
+				$value['posts_per_page'] = $instance['posts_per_page'];
+			}
+			if ( ! empty( $instance['order'] ) ) {
+				$value['order'] = $instance['order'];
+			}
+			if ( ! empty( $instance['orderby'] ) ) {
+				$value['orderby'] = $instance['orderby'];
+			}
+			if ( ! empty( $instance['sticky'] ) ) {
+				$value['sticky'] = $instance['sticky'];
+			}
+			if ( ! empty( $instance['additional'] ) ) {
+				$value['additional'] = $instance['additional'];
+			}
+			$instance['posts'] = $value;
+
+			unset( $instance['post_type'] );
+			unset( $instance['posts_per_page'] );
+			unset( $instance['order'] );
+			unset( $instance['orderby'] );
+			unset( $instance['sticky'] );
+			unset( $instance['additional'] );
 		}
-		
+
 		return $instance;
 	}
-	
+
 	/**
 	 * @param array $args
 	 * @param array $instance

--- a/inc/widgets/post-loop-helper.php
+++ b/inc/widgets/post-loop-helper.php
@@ -15,9 +15,9 @@ class SiteOrigin_Panels_Widgets_PostLoop_Helper extends SiteOrigin_Widget {
 	function __construct( $templates ) {
 
 		$template_options = array();
-		if ( ! empty( $templates ) ) {
-			foreach ( $templates as $template ) {
-				$headers                       = get_file_data( locate_template( $template ), array(
+		if( ! empty( $templates ) ) {
+			foreach( $templates as $template ) {
+				$headers = get_file_data( locate_template( $template ), array(
 					'loop_name' => 'Loop Name',
 				) );
 				$template_options[ $template ] = esc_html( ! empty( $headers['loop_name'] ) ? $headers['loop_name'] : $template );
@@ -33,13 +33,13 @@ class SiteOrigin_Panels_Widgets_PostLoop_Helper extends SiteOrigin_Widget {
 			),
 			array(),
 			array(
-				'title'    => array(
-					'type'  => 'text',
+				'title' => array(
+					'type' => 'text',
 					'label' => __( 'Title', 'siteorigin-panels' ),
 				),
 				'template' => array(
-					'type'    => 'select',
-					'label'   => __( 'Template', 'siteorigin-panels' ),
+					'type' => 'select',
+					'label' => __( 'Template', 'siteorigin-panels' ),
 					'options' => $template_options,
 					'default' => 'loop.php',
 				),
@@ -49,16 +49,16 @@ class SiteOrigin_Panels_Widgets_PostLoop_Helper extends SiteOrigin_Widget {
 					'description' => __( 'Width of the div this widget instance will be inserted in', 'siteorigin-panels' ),
 					'default'     => 1200,
 				),
-				'more'     => array(
-					'type'        => 'checkbox',
-					'label'       => __( 'More link', 'so-widgets-bundle' ),
+				'more' => array(
+					'type' => 'checkbox',
+					'label' => __( 'More link', 'so-widgets-bundle' ),
 					'description' => __( 'If the template supports it, cut posts and display the more link.', 'siteorigin-panels' ),
-					'default'     => false,
+					'default' => false,
 				),
-				'posts'    => array(
-					'type'  => 'posts',
+				'posts' => array(
+					'type' => 'posts',
 					'label' => __( 'Posts query', 'so-widgets-bundle' ),
-					'hide'  => true
+					'hide' => true
 				),
 			)
 		);
@@ -72,35 +72,23 @@ class SiteOrigin_Panels_Widgets_PostLoop_Helper extends SiteOrigin_Widget {
 	 * @return mixed
 	 */
 	function modify_instance( $instance ) {
-		if ( ! empty( $instance['post_type'] ) ) {
+		if( ! empty( $instance['post_type'] ) ) {
 			$value = array();
 
-			if ( ! empty( $instance['post_type'] ) ) {
-				$value['post_type'] = $instance['post_type'];
-			}
-			if ( ! empty( $instance['posts_per_page'] ) ) {
-				$value['posts_per_page'] = $instance['posts_per_page'];
-			}
-			if ( ! empty( $instance['order'] ) ) {
-				$value['order'] = $instance['order'];
-			}
-			if ( ! empty( $instance['orderby'] ) ) {
-				$value['orderby'] = $instance['orderby'];
-			}
-			if ( ! empty( $instance['sticky'] ) ) {
-				$value['sticky'] = $instance['sticky'];
-			}
-			if ( ! empty( $instance['additional'] ) ) {
-				$value['additional'] = $instance['additional'];
-			}
-			$instance['posts'] = $value;
+			if( ! empty( $instance['post_type'] ) ) $value['post_type'] = $instance['post_type'];
+			if( ! empty( $instance['posts_per_page'] ) ) $value['posts_per_page'] = $instance['posts_per_page'];
+			if( ! empty( $instance['order'] ) ) $value['order'] = $instance['order'];
+			if( ! empty( $instance['orderby'] ) ) $value['orderby'] = $instance['orderby'];
+			if( ! empty( $instance['sticky'] ) ) $value['sticky'] = $instance['sticky'];
+			if( ! empty( $instance['additional'] ) ) $value['additional'] = $instance['additional'];
+			$instance[ 'posts' ] = $value;
 
-			unset( $instance['post_type'] );
-			unset( $instance['posts_per_page'] );
-			unset( $instance['order'] );
-			unset( $instance['orderby'] );
-			unset( $instance['sticky'] );
-			unset( $instance['additional'] );
+			unset( $instance[ 'post_type' ] );
+			unset( $instance[ 'posts_per_page' ] );
+			unset( $instance[ 'order' ] );
+			unset( $instance[ 'orderby' ] );
+			unset( $instance[ 'sticky' ] );
+			unset( $instance[ 'additional' ] );
 		}
 
 		return $instance;

--- a/inc/widgets/post-loop.php
+++ b/inc/widgets/post-loop.php
@@ -185,9 +185,11 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 		self::$current_loop_instance = $instance;
 		self::$current_loop_template = $instance['template'];
 		if(strpos('/'.$instance['template'], '/content') !== false) {
+		    $index = 0;
 			while( have_posts() ) {
 				the_post();
-				locate_template($instance['template'], true, false);
+				$index++;
+				include( locate_template( $instance['template'], false, false ) );
 			}
 		}
 		else {

--- a/inc/widgets/post-loop.php
+++ b/inc/widgets/post-loop.php
@@ -185,8 +185,8 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 		self::$current_loop_instance = $instance;
 		self::$current_loop_template = $instance['template'];
 		if(strpos('/'.$instance['template'], '/content') !== false) {
-		    $index = 0;
-			while( have_posts() ) {
+			$index=0;
+		    while( have_posts() ) {
 				the_post();
 				$index++;
 				include( locate_template( $instance['template'], false, false ) );


### PR DESCRIPTION
The templates used in the post loop have no idea about the width of the div they are used in or the index of post that they are displaying. We use manually include the template instead of autoloading it, thus giving it access to the widget instance. We also add width option to the widget instance, which is passed down to the template.
