### PR TITLE
Don't remove left/right border when Full Width Stretch Padding is enabled on row

### DIFF
--- a/js/styling.js
+++ b/js/styling.js
@@ -44,8 +44,8 @@ jQuery( function ( $ ) {
 			}
 
 			$$.css( {
-				'border-left': 0,
-				'border-right': 0
+				'border-left': defaultSidePadding,
+				'border-right': defaultSidePadding
 			} );
 		} );
 


### PR DESCRIPTION
This PR will prevent the Full Width Stretched Padding row layout from removing the right/left border on rows.