### PR TITLE
Get CSS change to allow for only min-width to be set

### DIFF
--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -217,7 +217,7 @@ class SiteOrigin_Panels_Css_Builder {
 				continue;
 			}
 
-			if ( empty( $max_res ) && ! empty( $min_res ) ) {
+			if ( $max_res === '' && ! empty( $min_res ) ) {
 				$css_text .= '@media (min-width:' . intval( $min_res ) . 'px) {';
 			} elseif ( $max_res < 1920 ) {
 				$css_text .= '@media (max-width:' . intval( $max_res ) . 'px)';

--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -232,7 +232,7 @@ class SiteOrigin_Panels_Css_Builder {
 				$css_text .= implode( ' , ', $selector ) . ' { ' . $property . ' } ';
 			}
 
-			if ( ( $max_res == 0 && ! empty( $min_res ) ) ||  $max_res < 1920 ) {
+			if ( ( $max_res === 0 && ! empty( $min_res ) ) ||  $max_res < 1920 ) {
 				$css_text .= ' } ';
 			}
 		}

--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -217,7 +217,9 @@ class SiteOrigin_Panels_Css_Builder {
 				continue;
 			}
 
-			if ( $max_res < 1920 ) {
+			if ( $max_res == 0 && ! empty( $min_res ) ) {
+				$css_text .= '@media (min-width:' . intval( $min_res ) . 'px) {';
+			} elseif( $max_res < 1920 ) {
 				$css_text .= '@media (max-width:' . intval( $max_res ) . 'px)';
 				if( ! empty( $min_res ) ) {
 					$css_text .= ' and (min-width:' . intval( $min_res ) . 'px) ';
@@ -230,7 +232,7 @@ class SiteOrigin_Panels_Css_Builder {
 				$css_text .= implode( ' , ', $selector ) . ' { ' . $property . ' } ';
 			}
 
-			if ( $max_res < 1920 ) {
+			if ( ( $max_res == 0 && ! empty( $min_res ) ) ||  $max_res < 1920 ) {
 				$css_text .= ' } ';
 			}
 		}

--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -217,7 +217,7 @@ class SiteOrigin_Panels_Css_Builder {
 				continue;
 			}
 
-			if ( $max_res === '' && $min_res > 0 && ! empty( $min_res ) ) {
+			if ( $max_res === '' && $min_res > 0 ) {
 				$css_text .= '@media (min-width:' . intval( $min_res ) . 'px) {';
 			} elseif ( $max_res < 1920 ) {
 				$css_text .= '@media (max-width:' . intval( $max_res ) . 'px)';
@@ -232,7 +232,7 @@ class SiteOrigin_Panels_Css_Builder {
 				$css_text .= implode( ' , ', $selector ) . ' { ' . $property . ' } ';
 			}
 
-			if ( ( $max_res === '' && $min_res > 0 && ! empty( $min_res ) ) ||  $max_res < 1920 ) {
+			if ( ( $max_res === '' && $min_res > 0 ) ||  $max_res < 1920 ) {
 				$css_text .= ' } ';
 			}
 		}

--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -205,7 +205,7 @@ class SiteOrigin_Panels_Css_Builder {
 		$css_text = '';
 		krsort( $this->css );
 		foreach ( $this->css as $res => $def ) {
-			if( strpos( $res, ':' ) ) {
+			if( strpos( $res, ':' ) !== false ) {
 				list( $max_res, $min_res ) = explode( ':', $res, 2 );
 			}
 			else {
@@ -217,7 +217,7 @@ class SiteOrigin_Panels_Css_Builder {
 				continue;
 			}
 
-			if ( $max_res == 0 && ! empty( $min_res ) ) {
+			if ( empty( $max_res ) && ! empty( $min_res ) ) {
 				$css_text .= '@media (min-width:' . intval( $min_res ) . 'px) {';
 			} elseif ( $max_res < 1920 ) {
 				$css_text .= '@media (max-width:' . intval( $max_res ) . 'px)';

--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -221,7 +221,7 @@ class SiteOrigin_Panels_Css_Builder {
 				$css_text .= '@media (min-width:' . intval( $min_res ) . 'px) {';
 			} elseif ( $max_res < 1920 ) {
 				$css_text .= '@media (max-width:' . intval( $max_res ) . 'px)';
-				if( ! empty( $min_res ) ) {
+				if ( ! empty( $min_res ) ) {
 					$css_text .= ' and (min-width:' . intval( $min_res ) . 'px) ';
 				}
 				$css_text .= '{ ';

--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -217,7 +217,7 @@ class SiteOrigin_Panels_Css_Builder {
 				continue;
 			}
 
-			if ( $max_res === '' && ! empty( $min_res ) ) {
+			if ( $max_res === '' && $min_res > 0 && ! empty( $min_res ) ) {
 				$css_text .= '@media (min-width:' . intval( $min_res ) . 'px) {';
 			} elseif ( $max_res < 1920 ) {
 				$css_text .= '@media (max-width:' . intval( $max_res ) . 'px)';
@@ -232,7 +232,7 @@ class SiteOrigin_Panels_Css_Builder {
 				$css_text .= implode( ' , ', $selector ) . ' { ' . $property . ' } ';
 			}
 
-			if ( ( $max_res === 0 && ! empty( $min_res ) ) ||  $max_res < 1920 ) {
+			if ( ( $max_res === '' && $min_res > 0 && ! empty( $min_res ) ) ||  $max_res < 1920 ) {
 				$css_text .= ' } ';
 			}
 		}

--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -219,7 +219,7 @@ class SiteOrigin_Panels_Css_Builder {
 
 			if ( $max_res == 0 && ! empty( $min_res ) ) {
 				$css_text .= '@media (min-width:' . intval( $min_res ) . 'px) {';
-			} elseif( $max_res < 1920 ) {
+			} elseif ( $max_res < 1920 ) {
 				$css_text .= '@media (max-width:' . intval( $max_res ) . 'px)';
 				if( ! empty( $min_res ) ) {
 					$css_text .= ' and (min-width:' . intval( $min_res ) . 'px) ';


### PR DESCRIPTION
Previously it wasn't possible to only specify a `min-width` with `get_css()` (which is used with `add_row_css()`). This PR will allow you to set only a `min-width` by passing a breakpoint of `0:768` (`768 `being the `min-width`).