### PR TITLE
Sidebar Emulator: Account for widgets that don't use ids and instead rely on widget class

### DIFF
--- a/inc/sidebars-emulator.php
+++ b/inc/sidebars-emulator.php
@@ -6,7 +6,7 @@ class SiteOrigin_Panels_Sidebars_Emulator {
 
 	function __construct() {
 		$this->all_posts_widgets = array();
-		add_action( 'widgets_init', array( $this, 'register_widgets' ), 99 );
+		add_action( 'widgets_init', array( $this, 'register_widgets' ) );
 		add_filter( 'sidebars_widgets', array( $this, 'add_widgets_to_sidebars' ) );
 	}
 
@@ -146,11 +146,12 @@ class SiteOrigin_Panels_Sidebars_Emulator {
 		foreach ( array_keys( $this->all_posts_widgets ) as $post_id ) {
 			$post_widgets = $this->all_posts_widgets[ $post_id ];
 			foreach ( $post_widgets as $widget_instance ) {
-				if ( empty( $widget_instance['id'] ) ) {
+				if ( empty( $widget_instance['id'] ) && empty( $widget_instance['panels_info']['class'] ) ) {
 					continue;
 				}
+				// var_dump($widget_instance['panels_info']['class']);
 				//Sidebars widgets and the global $wp_registered widgets use full widget ids as keys
-				$siteorigin_panels_widget_ids[] = $widget_instance['id'];
+				$siteorigin_panels_widget_ids[] = ! empty( $widget_instance['id'] ) ? $widget_instance['id'] : strtolower( $widget_instance['panels_info']['class'] );
 			}
 			if ( ! empty( $siteorigin_panels_widget_ids ) ) {
 				$sidebars_widgets[ 'sidebar-siteorigin_panels-post-' . $post_id ] = $siteorigin_panels_widget_ids;

--- a/inc/sidebars-emulator.php
+++ b/inc/sidebars-emulator.php
@@ -149,7 +149,6 @@ class SiteOrigin_Panels_Sidebars_Emulator {
 				if ( empty( $widget_instance['id'] ) && empty( $widget_instance['panels_info']['class'] ) ) {
 					continue;
 				}
-				// var_dump($widget_instance['panels_info']['class']);
 				//Sidebars widgets and the global $wp_registered widgets use full widget ids as keys
 				$siteorigin_panels_widget_ids[] = ! empty( $widget_instance['id'] ) ? $widget_instance['id'] : strtolower( $widget_instance['panels_info']['class'] );
 			}


### PR DESCRIPTION
The [Jetpack Milestone](https://jetpack.com/support/extra-sidebar-widgets/milestone-widget/) widget [uses a classnames](https://github.com/Automattic/jetpack/blob/6.5/modules/widgets/milestone/milestone.php#L37) instead of an id and the sidebar emulator doesn't support classes. This PR fixes this and allows for the Jetpack Milestone widget and any other widget that relies on Class Names to work.

Note: The priority for the sidebar emulation code was changed due to Jetpack running it's is_widget_active() check before we set up the sidebar emulation. I couldn't find an explanation as to why the priority was changed so I reverted the priority to default - this may have unintended consequences but I wasn't able to find any during testing.