### PR TITLE
Max Mega Menu: Prevent layout builder duplication

### DIFF
--- a/inc/widgets/layout.php
+++ b/inc/widgets/layout.php
@@ -116,11 +116,13 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 			<input type="hidden" value="<?php echo esc_attr( $instance['builder_id'] ) ?>" name="<?php echo $this->get_field_name('builder_id') ?>" />
 		</div>
 		<script type="text/javascript">
-			if(
+			if (
 				typeof jQuery.fn.soPanelsSetupBuilderWidget != 'undefined' &&
-				( ! jQuery('body').hasClass('wp-customizer') || jQuery( "#siteorigin-page-builder-widget-<?php echo esc_attr( $form_id ) ?>").closest( '.panel-dialog' ).length )
+				( 
+					( ! jQuery( 'body' ).hasClass( 'wp-customizer' ) && ! jQuery( 'body' ).hasClass( 'megamenu_enabled' ) )
+					|| jQuery( "#siteorigin-page-builder-widget-<?php echo esc_attr( $form_id ) ?>").closest( '.panel-dialog' ).length )
 			) {
-				jQuery( "#siteorigin-page-builder-widget-<?php echo esc_attr( $form_id ) ?>").soPanelsSetupBuilderWidget();
+				jQuery( "#siteorigin-page-builder-widget-<?php echo esc_attr( $form_id ) ?>" ).soPanelsSetupBuilderWidget();
 			}
 		</script>
 		<?php


### PR DESCRIPTION
Resolve #573 

Max Mega Menu loads the full widget form which includes the `soPanelsSetupBuilderWidget();` setup code in inc/widgets/layout.php.

Max Mega Menu always triggers `widget-added` upon succesful widget load. This is good but as we run `soPanelsSetupBuilderWidget();` when that event is triggered it results in mutiple instances of SiteOrigin Page Builder being setup

[](https://github.com/siteorigin/siteorigin-panels/blob/2.8.2/js/siteorigin-panels/main.js#L145) widget-added on load. 