### PR TITLE
Release 2.9.2

### DIFF
--- a/compat/gutenberg-block.php
+++ b/compat/gutenberg-block.php
@@ -35,7 +35,7 @@ class SiteOrigin_Panels_Compat_Gutenberg_Block {
 		wp_enqueue_script(
 			'siteorigin-panels-layout-block',
 			plugins_url( 'js/siteorigin-panels-layout-block' . SITEORIGIN_PANELS_JS_SUFFIX . '.js', __FILE__ ),
-			array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-compose', 'so-panels-admin' ),
+			array( 'wp-editor', 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-compose', 'so-panels-admin' ),
 			SITEORIGIN_PANELS_VERSION
 		);
 		wp_localize_script(

--- a/compat/gutenberg-block.php
+++ b/compat/gutenberg-block.php
@@ -27,32 +27,51 @@ class SiteOrigin_Panels_Compat_Gutenberg_Block {
 	}
 	
 	public function enqueue_layout_block_editor_assets() {
-		$panels_admin = SiteOrigin_Panels_Admin::single();
-		$panels_admin->enqueue_admin_scripts();
-		$panels_admin->enqueue_admin_styles();
-		$panels_admin->js_templates();
+		// This is for the Gutenberg plugin.
+		$is_block_editor = function_exists( 'is_gutenberg_page' ) && is_gutenberg_page();
+		// This is for WP 5 with the integrated block editor. Let it override the Gutenberg plugin.
+		$current_screen = get_current_screen();
+		if ( $current_screen && method_exists( $current_screen, 'is_block_editor' ) ) {
+			$is_block_editor = $current_screen->is_block_editor();
+		}
 		
-		wp_enqueue_script(
-			'siteorigin-panels-layout-block',
-			plugins_url( 'js/siteorigin-panels-layout-block' . SITEORIGIN_PANELS_JS_SUFFIX . '.js', __FILE__ ),
-			array( 'wp-editor', 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-compose', 'so-panels-admin' ),
-			SITEORIGIN_PANELS_VERSION
-		);
-		wp_localize_script(
-			'siteorigin-panels-layout-block',
-			'soPanelsGutenbergAdmin',
-			array(
-				'previewUrl' => wp_nonce_url( admin_url( 'admin-ajax.php' ), 'gutenberg-preview', '_panelsnonce' ),
-			)
-		);
-		SiteOrigin_Panels_Styles::register_scripts();
-		wp_enqueue_script( 'siteorigin-panels-front-styles' );
-		
-		// Enqueue front end scripts for our widgets bundle.
-		if ( class_exists( 'SiteOrigin_Widgets_Bundle' ) ) {
-			$sowb = SiteOrigin_Widgets_Bundle::single();
-			$sowb->register_general_scripts();
-			$sowb->enqueue_registered_widgets_scripts( true, false );
+		if ( $is_block_editor ) {
+			
+			$panels_admin = SiteOrigin_Panels_Admin::single();
+			$panels_admin->enqueue_admin_scripts();
+			$panels_admin->enqueue_admin_styles();
+			$panels_admin->js_templates();
+			
+			wp_enqueue_script(
+				'siteorigin-panels-layout-block',
+				plugins_url( 'js/siteorigin-panels-layout-block' . SITEORIGIN_PANELS_JS_SUFFIX . '.js', __FILE__ ),
+				array(
+					'wp-editor',
+					'wp-blocks',
+					'wp-i18n',
+					'wp-element',
+					'wp-components',
+					'wp-compose',
+					'so-panels-admin'
+				),
+				SITEORIGIN_PANELS_VERSION
+			);
+			wp_localize_script(
+				'siteorigin-panels-layout-block',
+				'soPanelsGutenbergAdmin',
+				array(
+					'previewUrl' => wp_nonce_url( admin_url( 'admin-ajax.php' ), 'gutenberg-preview', '_panelsnonce' ),
+				)
+			);
+			SiteOrigin_Panels_Styles::register_scripts();
+			wp_enqueue_script( 'siteorigin-panels-front-styles' );
+			
+			// Enqueue front end scripts for our widgets bundle.
+			if ( class_exists( 'SiteOrigin_Widgets_Bundle' ) ) {
+				$sowb = SiteOrigin_Widgets_Bundle::single();
+				$sowb->register_general_scripts();
+				$sowb->enqueue_registered_widgets_scripts( true, false );
+			}
 		}
 	}
 	

--- a/compat/gutenberg-block.php
+++ b/compat/gutenberg-block.php
@@ -17,6 +17,8 @@ class SiteOrigin_Panels_Compat_Gutenberg_Block {
 	
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_layout_block' ) );
+		// This action is slightly later than `enqueue_block_editor_assets`,
+		// which we need to use to ensure our templates are loaded at the right time.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_layout_block_editor_assets' ) );
 	}
 	

--- a/compat/gutenberg-block.php
+++ b/compat/gutenberg-block.php
@@ -52,17 +52,7 @@ class SiteOrigin_Panels_Compat_Gutenberg_Block {
 		if ( class_exists( 'SiteOrigin_Widgets_Bundle' ) ) {
 			$sowb = SiteOrigin_Widgets_Bundle::single();
 			$sowb->register_general_scripts();
-			
-			global $wp_widget_factory;
-			
-			foreach ( $wp_widget_factory->widgets as $class => $widget_obj ) {
-				if ( ! empty( $widget_obj ) && is_object( $widget_obj ) && is_subclass_of( $widget_obj, 'SiteOrigin_Widget' ) ) {
-					/* @var $widget_obj SiteOrigin_Widget */
-					ob_start();
-					$widget_obj->widget( array(), array() );
-					ob_clean();
-				}
-			}
+			$sowb->enqueue_registered_widgets_scripts( true, false );
 		}
 	}
 	

--- a/compat/gutenberg-block.php
+++ b/compat/gutenberg-block.php
@@ -17,7 +17,7 @@ class SiteOrigin_Panels_Compat_Gutenberg_Block {
 	
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_layout_block' ) );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_layout_block_editor_assets' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_layout_block_editor_assets' ) );
 	}
 	
 	public function register_layout_block() {

--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -17,7 +17,7 @@
 			return el(
 				'span',
 				{
-					className: 'siteorigin-panels-gutenberg-icon'
+					className: 'siteorigin-panels-block-icon'
 				}
 			)
 		},
@@ -175,7 +175,7 @@
 						'div',
 						{
 							key: 'preview',
-							className: 'so-panels-gutenberg-layout-preview-container'
+							className: 'so-panels-block-layout-preview-container'
 						},
 						( loadingPreview ?
 							el( 'div', {

--- a/css/admin.less
+++ b/css/admin.less
@@ -1889,14 +1889,6 @@
 		ul {
 			list-style: none;
 		}
-		
-		.so-builder-container {
-			margin: 0 -28px;
-			
-			&.so-display-narrow {
-				margin: 0 -15px;
-			}
-		}
 	}
 
 	/* PB Icon in Gutenberg */

--- a/css/admin.less
+++ b/css/admin.less
@@ -647,7 +647,7 @@
 
 }
 
-.so-panels-dialog, .gutenberg {
+.so-panels-dialog, .block-editor {
 
 	@edge_spacing: 30px;
 
@@ -1858,7 +1858,7 @@
 		}
 	}
 
-	/* Special case of the builder interface being inside a dialog, or gutenberg editor. */
+	/* Special case of the builder interface being inside a dialog, or block editor. */
 
 	.so-content, .siteorigin-panels-layout-block-container {
 		.siteorigin-panels-builder {
@@ -1879,7 +1879,7 @@
 		}
 	}
 
-	/* Styles for PB in Gutenberg editor. */
+	/* Styles for PB in block editor. */
 	.siteorigin-panels-layout-block-container {
 		
 		font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;
@@ -1891,8 +1891,8 @@
 		}
 	}
 
-	/* PB Icon in Gutenberg */
-	.siteorigin-panels-gutenberg-icon {
+	/* PB Icon in block editor */
+	.siteorigin-panels-block-icon {
 		display: inline-block;
 		background-size: cover;
 		background-image: url('../compat/pb-icon.svg');
@@ -1900,7 +1900,7 @@
 		height: 20px;
 	}
 
-	.so-panels-gutenberg-layout-preview-container {
+	.so-panels-block-layout-preview-container {
 		.so-panels-spinner-container {
 			text-align: center;
 			> span {

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -474,6 +474,7 @@ module.exports = Backbone.View.extend( {
 				data = JSON.parse( data );
 			}
 			catch ( err ) {
+				console.log( "Failed to parse Page Builder layout data from supplied data field." );
 				data = {};
 			}
 			

--- a/js/siteorigin-panels/view/widgets/text-widget.js
+++ b/js/siteorigin-panels/view/widgets/text-widget.js
@@ -26,6 +26,12 @@ var textWidget = {
 		}
 
 		var widgetControl = new component.TextWidgetControl( options );
+		var wpEditor = wp.oldEditor ? wp.oldEditor : wp.editor;
+		if ( wpEditor && wpEditor.hasOwnProperty( 'autop' ) ) {
+			wp.editor.autop = wpEditor.autop;
+			wp.editor.removep = wpEditor.removep;
+			wp.editor.initialize = wpEditor.initialize
+		}
 
 		widgetControl.initializeEditor();
 

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,13 @@ We've tried to ensure that Page Builder is compatible with most plugin widgets. 
 
 == Changelog ==
 
+= 2.9.2 - 31 October 2018 =
+* Block editor: Call `enqueue_registered_widgets_scripts` which will reset global `$post`.
+* Block editor: Only enqueue layout block scripts when using the block editor.
+* WP 5: Fixed styles in the block editor.
+* WP 5: Ensure the block editor scripts are enqueued.
+* WP 5: Fix WP Text Widget for layout block.
+
 = 2.9.1 - 23 October 2018 =
 * Fix auto-excerpt output.
 * Layout builder: Fix 'undefined index' when saving before having added any widgets.


### PR DESCRIPTION
* Gutenberg: Call `enqueue_registered_widgets_scripts` which will reset global `$post`.
* WP 5: Fixed styles in the block editor.
* WP 5: Ensure the block editor scripts are enqueued.