### PR TITLE
Gutenberg: Set Page Builder Meta Box backwards compatibility flag

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -145,7 +145,8 @@ class SiteOrigin_Panels_Admin {
 				array( $this, 'render_meta_boxes' ),
 				( string ) $type,
 				'advanced',
-				'high'
+				'high',
+				array( '__back_compat_meta_box' => true )
 			);
 		}
 	}


### PR DESCRIPTION
[Related Make WordPress Core post](https://make.wordpress.org/core/2018/11/07/meta-box-compatibility-flags/).

This PR will disable the Page Builder meta box for Gutenberg.

Before:
![](https://vgy.me/AgO3p8.png)

After:
![](https://vgy.me/KGfXeR.png)
