### PR TITLE
Clone Layouts - fix to allow for private posts and pages

### DIFF
--- a/inc/admin-layouts.php
+++ b/inc/admin-layouts.php
@@ -270,7 +270,7 @@ class SiteOrigin_Panels_Admin_Layouts {
 			$return['title'] = sprintf( __( 'Clone %s', 'siteorigin-panels' ), esc_html( $post_type->labels->singular_name ) );
 			
 			global $wpdb;
-			$user_can_read_private = ( $post_type == 'post' && current_user_can( 'read_private_posts' ) || ( $post_type == 'page' && current_user_can( 'read_private_pages' ) ) );
+			$user_can_read_private = ( $post_type->name == 'post' && current_user_can( 'read_private_posts' ) || ( $post_type->name == 'page' && current_user_can( 'read_private_pages' ) ) );
 			$include_private       = $user_can_read_private ? "OR posts.post_status = 'private' " : "";
 			
 			// Select only the posts with the given post type that also have panels_data


### PR DESCRIPTION
This PR fixes a bug that prevents private posts and pages from appearing in the clone list.