### PR TITLE
Rename admin usage of .description to .so-description

### DIFF
--- a/js/siteorigin-panels/view/widget.js
+++ b/js/siteorigin-panels/view/widget.js
@@ -157,7 +157,7 @@ module.exports = Backbone.View.extend( {
 
 	onModelChange: function () {
 		// Update the description when ever the model changes
-		this.$( '.description' ).html( this.model.getTitle() );
+		this.$( '.so-description' ).html( this.model.getTitle() );
 	},
 
 	onLabelChange: function( model ) {

--- a/settings/admin-settings.js
+++ b/settings/admin-settings.js
@@ -80,8 +80,8 @@ jQuery( function($){
 
             var indexes = {
                 'title' : $s.find('label').html().toLowerCase().indexOf( query ),
-                'keywords' : $s.find('.description').data('keywords').toLowerCase().indexOf( query ),
-                'description' : $s.find('.description').html().toLowerCase().indexOf( query )
+                'keywords' : $s.find('.so-description').data('keywords').toLowerCase().indexOf( query ),
+                'description' : $s.find('.so-description').html().toLowerCase().indexOf( query )
             };
 
             if( indexes.title === 0 ) isMatch += 10;

--- a/settings/admin-settings.less
+++ b/settings/admin-settings.less
@@ -152,7 +152,7 @@
 			display: none;
 			padding: 0 30px 0 20px;
 
-			.description {
+			.so-description {
 				font-style: italic;
 				color: #999;
 				margin-top: 5px;

--- a/settings/tpl/settings.php
+++ b/settings/tpl/settings.php
@@ -47,7 +47,7 @@
 										$this->display_field( $field_id, $field );
 										if( !empty($field['description']) ) {
 											?>
-											<small class="description" data-keywords="<?php if(!empty($field['keywords'])) echo esc_attr($field['keywords']) ?>">
+											<small class="so-description" data-keywords="<?php if(!empty($field['keywords'])) echo esc_attr($field['keywords']) ?>">
 												<?php
 												echo wp_kses( $field['description'], array(
 													'a' => array(

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -143,7 +143,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 					<a class="widget-delete"><?php _e('Delete', 'siteorigin-panels') ?></a>
 				</span>
 			</div>
-			<small class="description">{{%= description %}}</small>
+			<small class="so-description">{{%= description %}}</small>
 		</div>
 	</div>
 </script>
@@ -239,7 +239,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 	<li class="widget-type">
 		<div class="widget-type-wrapper">
 			<h3>{{%= title %}}</h3>
-			<small class="description">{{%= description %}}</small>
+			<small class="so-description">{{%= description %}}</small>
 		</div>
 	</li>
 </script>
@@ -273,7 +273,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 <script type="text/template" id="siteorigin-panels-dialog-widget-sidebar-widget">
 	<div class="so-widget">
 		<h3>{{%= title %}}</h3>
-		<small class="description">
+		<small class="so-description">
 			{{%= description %}}
 		</small>
 	</div>

--- a/widgets/widgets.php
+++ b/widgets/widgets.php
@@ -201,7 +201,7 @@ abstract class SiteOrigin_Panels_Widget extends WP_Widget{
 					<?php
 					break;
 			}
-			if(!empty($field_args['description'])) echo '<small class="description">'.esc_html($field_args['description']).'</small>';
+			if(!empty($field_args['description'])) echo '<small class="so-description">'.esc_html($field_args['description']).'</small>';
 
 			?></p><?php
 		}
@@ -747,7 +747,7 @@ class SiteOrigin_Panels_Widgets_Gallery extends WP_Widget {
 			<a href="#" onclick="return false;" class="so-gallery-widget-select-attachments hidden"><?php _e('edit gallery', 'siteorigin-panels') ?></a>
 			<input type="text" class="widefat" value="<?php echo esc_attr($instance['ids']) ?>" name="<?php echo $this->get_field_name('ids') ?>" />
 		</p>
-		<p class="description">
+		<p class="so-description">
 			<?php _e("Comma separated attachment IDs. Defaults to all current page's attachments.", 'siteorigin-panels') ?>
 		</p>
 
@@ -956,7 +956,7 @@ class SiteOrigin_Panels_Widgets_Video extends WP_Widget {
 		<p>
 			<label for="<?php echo $this->get_field_id('poster') ?>"><?php _e('Poster URL', 'siteorigin-panels') ?></label>
 			<input id="<?php echo $this->get_field_id('poster') ?>" name="<?php echo $this->get_field_name('poster') ?>" type="text" class="widefat" value="<?php echo esc_attr($instance['poster']) ?>" />
-			<small class="description"><?php _e('An image that displays before the video starts playing.', 'siteorigin-panels') ?></small>
+			<small class="so-description"><?php _e('An image that displays before the video starts playing.', 'siteorigin-panels') ?></small>
 		</p>
 		<p>
 			<label for="<?php echo $this->get_field_id('autoplay') ?>">


### PR DESCRIPTION
[A user recently reported an issue ](https://siteorigin.com/thread/siteorigin-description-style-clashes-with-wp-meta-seo-plugin/) caused by another plugin where they were incorrectly (read: very little specificity) targeting `.description` and applying styling. We apply the `description` class to widget descriptions so the Page Builder interface was affected by this. This isn't the first time this has happened. Andrew suggested submitting a PR to rename the class to something a little more unique so this PR will change the class to `so-description`.

This PR does change the usage of `.description` in a few legacy widgets. If that's not desired, let me know and I'll revert those changes.