### PR TITLE
Release 2.9.3

### DIFF
--- a/compat/gutenberg-block.php
+++ b/compat/gutenberg-block.php
@@ -35,7 +35,7 @@ class SiteOrigin_Panels_Compat_Gutenberg_Block {
 		wp_enqueue_script(
 			'siteorigin-panels-layout-block',
 			plugins_url( 'js/siteorigin-panels-layout-block' . SITEORIGIN_PANELS_JS_SUFFIX . '.js', __FILE__ ),
-			array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-compose', 'so-panels-admin' ),
+			array( 'wp-editor', 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-compose', 'so-panels-admin' ),
 			SITEORIGIN_PANELS_VERSION
 		);
 		wp_localize_script(

--- a/compat/gutenberg-block.php
+++ b/compat/gutenberg-block.php
@@ -1,13 +1,13 @@
 <?php
 
-class SiteOrigin_Panels_Compat_Gutenberg_Block {
+class SiteOrigin_Panels_Layout_Block {
 	
 	const BLOCK_NAME = 'siteorigin-panels/layout-block';
 	
 	/**
 	 * Get the singleton instance
 	 *
-	 * @return SiteOrigin_Panels_Compat_Gutenberg_Block
+	 * @return SiteOrigin_Panels_Layout_Block
 	 */
 	public static function single() {
 		static $single;
@@ -60,9 +60,9 @@ class SiteOrigin_Panels_Compat_Gutenberg_Block {
 			);
 			wp_localize_script(
 				'siteorigin-panels-layout-block',
-				'soPanelsGutenbergAdmin',
+				'soPanelsBlockEditorAdmin',
 				array(
-					'previewUrl' => wp_nonce_url( admin_url( 'admin-ajax.php' ), 'gutenberg-preview', '_panelsnonce' ),
+					'previewUrl' => wp_nonce_url( admin_url( 'admin-ajax.php' ), 'block-editor-preview', '_panelsnonce' ),
 				)
 			);
 			SiteOrigin_Panels_Styles::register_scripts();

--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -17,7 +17,7 @@
 			return el(
 				'span',
 				{
-					className: 'siteorigin-panels-gutenberg-icon'
+					className: 'siteorigin-panels-block-icon'
 				}
 			)
 		},
@@ -175,7 +175,7 @@
 						'div',
 						{
 							key: 'preview',
-							className: 'so-panels-gutenberg-layout-preview-container'
+							className: 'so-panels-block-layout-preview-container'
 						},
 						( loadingPreview ?
 							el( 'div', {

--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -9,9 +9,9 @@
 	var __ = i18n.__;
 	
 	blocks.registerBlockType( 'siteorigin-panels/layout-block', {
-		title: __( 'SiteOrigin Layout (in beta)' ),
+		title: __( 'SiteOrigin Layout (in beta)', 'siteorigin-panels' ),
 		
-		description: __( "Build a layout using SiteOrigin's Page Builder." ),
+		description: __( "Build a layout using SiteOrigin's Page Builder.", 'siteorigin-panels' ),
 		
 		icon: function() {
 			return el(
@@ -138,7 +138,7 @@
 								IconButton,
 								{
 									className: 'components-icon-button components-toolbar__control',
-									label: __( 'Preview layout.' ),
+									label: __( 'Preview layout.', 'siteorigin-panels' ),
 									onClick: fetchPreview,
 									icon: 'visibility'
 								}
@@ -164,7 +164,7 @@
 								IconButton,
 								{
 									className: 'components-icon-button components-toolbar__control',
-									label: __( 'Edit layout.' ),
+									label: __( 'Edit layout.', 'siteorigin-panels' ),
 									onClick: showEdit,
 									icon: 'edit'
 								}

--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -44,8 +44,8 @@
 			var loadingPreview = props.loadingPreview;
 			function fetchPreview() {
 				if ( props.attributes.panelsData ) {
-					$.post( soPanelsGutenbergAdmin.previewUrl, {
-						action: 'so_panels_gutenberg_preview',
+					$.post( soPanelsBlockEditorAdmin.previewUrl, {
+						action: 'so_panels_block_editor_preview',
 						panelsData:  JSON.stringify( props.attributes.panelsData ),
 					} ).then( function( result ) {
 						if ( result.html ) {
@@ -87,7 +87,7 @@
 					// Make sure panelsData is defined and clone so that we don't alter the underlying attribute.
 					var panelsData = JSON.parse( JSON.stringify( $.extend( {}, props.attributes.panelsData ) ) );
 					
-					// Disable Gutenberg block selection while dragging rows or widgets.
+					// Disable block selection while dragging rows or widgets.
 					function disableSelection() {
 						props.toggleSelection( false );
 						$( document ).on( 'mouseup', function enableSelection() {

--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -35,26 +35,13 @@
 		},
 		
 		edit: withState( {
-			editing: true,
+			editing: false,
 			panelsInitialized: false,
 			loadingPreview: false,
+			previewInitialized: false,
 			previewHtml: ''
 		} )( function ( props ) {
 			var editing = props.editing;
-			var loadingPreview = props.loadingPreview;
-			function fetchPreview() {
-				if ( props.attributes.panelsData ) {
-					$.post( soPanelsBlockEditorAdmin.previewUrl, {
-						action: 'so_panels_block_editor_preview',
-						panelsData:  JSON.stringify( props.attributes.panelsData ),
-					} ).then( function( result ) {
-						if ( result.html ) {
-							props.setState( { previewHtml: result.html, loadingPreview: false } );
-						}
-					});
-					props.setState( { editing: false, loadingPreview: true } );
-				}
-			}
 			
 			function setupPreview() {
 				if ( ! editing ) {
@@ -65,8 +52,12 @@
 				}
 			}
 			
-			function showEdit() {
+			function switchToEditing() {
 				props.setState( { editing: true, panelsInitialized: false } );
+			}
+			
+			function switchToPreview() {
+				props.setState( { editing: false, previewInitialized: false } );
 			}
 			
 			function setupPanels( panelsContainer ) {
@@ -139,7 +130,7 @@
 								{
 									className: 'components-icon-button components-toolbar__control',
 									label: __( 'Preview layout.', 'siteorigin-panels' ),
-									onClick: fetchPreview,
+									onClick: switchToPreview,
 									icon: 'visibility'
 								}
 							)
@@ -152,7 +143,24 @@
 					} )
 				];
 			} else {
-				var preview = props.previewHtml;
+				
+				var loadingPreview = !props.editing && !props.previewHtml && props.attributes.panelsData;
+				if ( loadingPreview ) {
+					$.post( {
+						url: soPanelsBlockEditorAdmin.previewUrl,
+						data: {
+							action: 'so_panels_block_editor_preview',
+							panelsData: JSON.stringify( props.attributes.panelsData ),
+						}
+					} )
+					.then( function ( preview ) {
+						props.setState( {
+							previewHtml: preview,
+							loadingPreview: false,
+						} );
+					} );
+				}
+				var preview = props.previewHtml ? props.previewHtml : '';
 				return [
 					el(
 						BlockControls,
@@ -165,7 +173,7 @@
 								{
 									className: 'components-icon-button components-toolbar__control',
 									label: __( 'Edit layout.', 'siteorigin-panels' ),
-									onClick: showEdit,
+									onClick: switchToEditing,
 									icon: 'edit'
 								}
 							)

--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -41,7 +41,7 @@
 			previewInitialized: false,
 			previewHtml: ''
 		} )( function ( props ) {
-			var editing = props.editing;
+			var editing = props.editing || ! props.attributes.panelsData;
 			
 			function setupPreview() {
 				if ( ! editing ) {

--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -65,6 +65,7 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 					'previewUrl' => wp_nonce_url( admin_url( 'admin-ajax.php' ), 'block-editor-preview', '_panelsnonce' ),
 				)
 			);
+			wp_set_script_translations( 'siteorigin-panels-layout-block', 'siteorigin-panels' );
 			SiteOrigin_Panels_Styles::register_scripts();
 			wp_enqueue_script( 'siteorigin-panels-front-styles' );
 			

--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -76,7 +76,9 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 			if ( class_exists( 'SiteOrigin_Widgets_Bundle' ) ) {
 				$sowb = SiteOrigin_Widgets_Bundle::single();
 				$sowb->register_general_scripts();
-				$sowb->enqueue_registered_widgets_scripts( true, false );
+				if ( method_exists( $sowb, 'enqueue_registered_widgets_scripts' ) ) {
+					$sowb->enqueue_registered_widgets_scripts( true, false );
+				}
 			}
 		}
 	}

--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -1,6 +1,6 @@
 <?php
 
-class SiteOrigin_Panels_Layout_Block {
+class SiteOrigin_Panels_Compat_Layout_Block {
 	
 	const BLOCK_NAME = 'siteorigin-panels/layout-block';
 	

--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -65,7 +65,10 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 					'previewUrl' => wp_nonce_url( admin_url( 'admin-ajax.php' ), 'block-editor-preview', '_panelsnonce' ),
 				)
 			);
-			wp_set_script_translations( 'siteorigin-panels-layout-block', 'siteorigin-panels' );
+			// This is only available in WP5.
+			if ( function_exists( 'wp_set_script_translations' ) ) {
+				wp_set_script_translations( 'siteorigin-panels-layout-block', 'siteorigin-panels' );
+			}
 			SiteOrigin_Panels_Styles::register_scripts();
 			wp_enqueue_script( 'siteorigin-panels-front-styles' );
 			

--- a/css/admin.less
+++ b/css/admin.less
@@ -647,7 +647,7 @@
 
 }
 
-.so-panels-dialog, .gutenberg {
+.so-panels-dialog, .block-editor {
 
 	@edge_spacing: 30px;
 
@@ -1858,7 +1858,7 @@
 		}
 	}
 
-	/* Special case of the builder interface being inside a dialog, or gutenberg editor. */
+	/* Special case of the builder interface being inside a dialog, or block editor. */
 
 	.so-content, .siteorigin-panels-layout-block-container {
 		.siteorigin-panels-builder {
@@ -1879,7 +1879,7 @@
 		}
 	}
 
-	/* Styles for PB in Gutenberg editor. */
+	/* Styles for PB in block editor. */
 	.siteorigin-panels-layout-block-container {
 		
 		font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;
@@ -1891,8 +1891,8 @@
 		}
 	}
 
-	/* PB Icon in Gutenberg */
-	.siteorigin-panels-gutenberg-icon {
+	/* PB Icon in block editor */
+	.siteorigin-panels-block-icon {
 		display: inline-block;
 		background-size: cover;
 		background-image: url('../compat/pb-icon.svg');
@@ -1900,7 +1900,7 @@
 		height: 20px;
 	}
 
-	.so-panels-gutenberg-layout-preview-container {
+	.so-panels-block-layout-preview-container {
 		.so-panels-spinner-container {
 			text-align: center;
 			> span {

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1213,10 +1213,10 @@ class SiteOrigin_Panels_Admin {
 			$is_block_editor = $current_screen->is_block_editor();
 		}
 		if ( $is_block_editor && ! empty( $panels_data ) ) {
-			$install_url = self_admin_url( 'plugin-install.php?tab=plugin-information&plugin=classic-editor&section=changelog&TB_iframe=true&width=640&height=662' );
-			$notice = sprintf( __( 'This page contains SiteOrigin Page Builder layout data. Please <a href="%s" class="thickbox open-plugin-details-modal">install the Classic Editor plugin</a> to continue editing this layout.' ), $install_url );
+			$install_url = self_admin_url( 'plugin-install.php?tab=featured' );
+			$notice = sprintf( __( 'This page contains SiteOrigin Page Builder layout data. Please <a href="%s" class="components-notice__action is-link">install the Classic Editor plugin</a> to continue editing this layout.' ), $install_url );
 			?>
-			<div id="siteorigin-panels-notice" class="notice notice-warning"><p id="test-notice"><?php echo $notice ?></p></div>
+			<div id="siteorigin-panels-notice" class="notice notice-warning is-dismissible"><p id="classic-editor-notice"><?php echo $notice ?></p></div>
 			<?php
 		}
 	}

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -54,7 +54,7 @@ class SiteOrigin_Panels_Admin {
 		add_action( 'wp_ajax_so_panels_builder_content', array( $this, 'action_builder_content' ) );
 		add_action( 'wp_ajax_so_panels_widget_form', array( $this, 'action_widget_form' ) );
 		add_action( 'wp_ajax_so_panels_live_editor_preview', array( $this, 'action_live_editor_preview' ) );
-		add_action( 'wp_ajax_so_panels_gutenberg_preview', array( $this, 'gutenberg_preview' ) );
+		add_action( 'wp_ajax_so_panels_block_editor_preview', array( $this, 'block_editor_preview' ) );
 
 		// Initialize the additional admin classes.
 		SiteOrigin_Panels_Admin_Widget_Dialog::single();
@@ -72,7 +72,6 @@ class SiteOrigin_Panels_Admin {
         add_action( 'admin_print_scripts-post.php', array( $this, 'enqueue_yoast_compat' ), 100 );
 
 		add_filter( 'gutenberg_can_edit_post_type', array( $this, 'disable_gutenberg_for_panels_posts' ), 10, 2 );
-		add_filter( 'filter_gutenberg_meta_boxes', array( $this, 'disable_panels_for_gutenberg_posts' ) );
 	}
 
 	/**
@@ -1069,11 +1068,11 @@ class SiteOrigin_Panels_Admin {
 	}
 
 	/**
-	 * Preview in the gutenberg editor.
+	 * Preview in the block editor.
 	 */
-	public function gutenberg_preview() {
+	public function block_editor_preview() {
 		
-		if ( empty( $_REQUEST['_panelsnonce'] ) || ! wp_verify_nonce( $_REQUEST['_panelsnonce'], 'gutenberg-preview' ) ) {
+		if ( empty( $_REQUEST['_panelsnonce'] ) || ! wp_verify_nonce( $_REQUEST['_panelsnonce'], 'block-editor-preview' ) ) {
 			wp_die();
 		}
 		
@@ -1215,24 +1214,5 @@ class SiteOrigin_Panels_Admin {
 		$is_panels_page = in_array( $post_type, $post_types ) && ! empty( $panels_data );
 		
 		return empty( $is_panels_page ) && $can_edit;
-	}
-	
-	/**
-	 * Disable PB when we're in the Gutenberg editor.
-	 *
-	 * @param $wp_meta_boxes
-	 *
-	 * @return mixed
-	 */
-	public function disable_panels_for_gutenberg_posts( $wp_meta_boxes ) {
-		foreach ( $wp_meta_boxes as &$locations ) {
-			foreach ( $locations as &$priorities ) {
-				foreach ( $priorities as &$boxes ) {
-					unset( $boxes['so-panels-panels'] );
-
-				}
-			}
-		}
-		return $wp_meta_boxes;
 	}
 }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1105,7 +1105,8 @@ class SiteOrigin_Panels_Admin {
 			$rendered_layout .= ob_get_clean();
 		}
 		
-		wp_send_json( array( 'html' => $rendered_layout ) );
+		echo $rendered_layout;
+		wp_die();
 	}
 
 	/**

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -70,8 +70,6 @@ class SiteOrigin_Panels_Admin {
         // Enqueue Yoast compatibility
         add_action( 'admin_print_scripts-post-new.php', array( $this, 'enqueue_yoast_compat' ), 100 );
         add_action( 'admin_print_scripts-post.php', array( $this, 'enqueue_yoast_compat' ), 100 );
-
-		add_filter( 'gutenberg_can_edit_post_type', array( $this, 'disable_gutenberg_for_panels_posts' ), 10, 2 );
 	}
 
 	/**
@@ -137,6 +135,10 @@ class SiteOrigin_Panels_Admin {
 	 * Callback to register the Page Builder Metaboxes
 	 */
 	function add_meta_boxes() {
+		global $post;
+		$panels_data = empty( $post ) ? array() : get_post_meta( $post->ID, 'panels_data', true );
+		$is_panels_page = ! empty( $panels_data );
+		
 		foreach ( siteorigin_panels_setting( 'post-types' ) as $type ) {
 			add_meta_box(
 				'so-panels-panels',
@@ -145,7 +147,12 @@ class SiteOrigin_Panels_Admin {
 				( string ) $type,
 				'advanced',
 				'high',
-				array( '__back_compat_meta_box' => true )
+				array(
+					// When we have panels data for a page this will cause the editor to fall back to classic editor,
+					// else the new block editor will be displayed.
+					'__back_compat_meta_box' => empty( $is_panels_page ),
+					'__block_editor_compatible_meta_box' => false
+				)
 			);
 		}
 	}
@@ -1190,29 +1197,5 @@ class SiteOrigin_Panels_Admin {
 			<?php echo esc_html( $link['text'] ) ?>.
         </a>
 		<?php
-	}
-	
-	/**
-	 * Disable the Gutenberg editor for existing PB posts.
-	 *
-	 * @param $can_edit
-	 * @param $post_type
-	 *
-	 * @return bool
-	 */
-	public function disable_gutenberg_for_panels_posts( $can_edit, $post_type ) {
-		
-		if ( function_exists( 'get_current_screen' ) ) {
-			$screen = get_current_screen();
-			$panels_data = $screen->base == 'post' ? $this->get_current_admin_panels_data() : array();
-		} else {
-			// Fall back to just checking the global $post for 'panels_data' metadata.
-			global $post;
-			$panels_data = empty( $post ) ? array() : get_post_meta( $post->ID, 'panels_data', true );
-		}
-		$post_types = siteorigin_panels_setting( 'post-types' );
-		$is_panels_page = in_array( $post_type, $post_types ) && ! empty( $panels_data );
-		
-		return empty( $is_panels_page ) && $can_edit;
 	}
 }

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -915,33 +915,8 @@ module.exports = Backbone.View.extend( {
 	activateContextMenu: function ( e, menu ) {
 		var builder = this;
 		
-		// Of all the visible builders, find the topmost
-		var topmostBuilder = $( '.siteorigin-panels-builder:visible' )
-		.sort( function ( a, b ) {
-			return $( a ).zIndex() > $( b ).zIndex() ? 1 : -1;
-		} )
-		.last();
-		
-		var topmostDialog = $( '.so-panels-dialog-wrapper:visible' )
-		.sort( function ( a, b ) {
-			return $( a ).zIndex() > $( b ).zIndex() ? 1 : -1;
-		} )
-		.last();
-		
-		var closestDialog = builder.$el.closest( '.so-panels-dialog-wrapper' );
-		
-		// Only run this if its element is the topmost builder, in the topmost dialog
-		if (
-			(
-				builder.$el.is( topmostBuilder ) ||
-				builder.$el.parent().is( '.siteorigin-panels-layout-block-container' ) // Layout block builder
-			)
-				&&
-			(
-				topmostDialog.length === 0 ||
-				topmostDialog.is( closestDialog )
-			)
-		) {
+		// Only run this if the event target is a descendant of this builder's DOM element.
+		if ( $.contains( builder.$el.get( 0 ), e.target ) ) {
 			// Get the element we're currently hovering over
 			var over = $( [] )
 			.add( builder.$( '.so-panels-welcome-message:visible' ) )
@@ -954,7 +929,7 @@ module.exports = Backbone.View.extend( {
 			
 			var activeView = over.last().data( 'view' );
 			if ( activeView !== undefined && activeView.buildContextualMenu !== undefined ) {
-				// We'll pass this to the current active view so it can popular the contextual menu
+				// We'll pass this to the current active view so it can populate the contextual menu
 				activeView.buildContextualMenu( e, menu );
 			}
 			else if ( over.last().hasClass( 'so-panels-welcome-message' ) ) {

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -397,10 +397,10 @@ module.exports = Backbone.View.extend( {
 			appendTo: '#wpwrap',
 			items: '.so-row-container',
 			handle: '.so-row-move',
-			// For Gutenberg, where it's possible to have multiple Page Builder blocks on a page.
-			// Also specify builderID when not in gutenberg to prevent being able to drop rows from builder in a dialog
+			// For the block editor, where it's possible to have multiple Page Builder blocks on a page.
+			// Also specify builderID when not in the block editor to prevent being able to drop rows from builder in a dialog
 			// into builder on the page under the dialog.
-			connectWith: '#' + builderID + '.so-rows-container,.gutenberg .so-rows-container',
+			connectWith: '#' + builderID + '.so-rows-container,.block-editor .so-rows-container',
 			axis: 'y',
 			tolerance: 'pointer',
 			scroll: false,
@@ -934,7 +934,7 @@ module.exports = Backbone.View.extend( {
 		if (
 			(
 				builder.$el.is( topmostBuilder ) ||
-				builder.$el.parent().is( '.siteorigin-panels-layout-block-container' ) // Gutenberg builder
+				builder.$el.parent().is( '.siteorigin-panels-layout-block-container' ) // Layout block builder
 			)
 				&&
 			(

--- a/js/siteorigin-panels/view/cell.js
+++ b/js/siteorigin-panels/view/cell.js
@@ -60,7 +60,7 @@ module.exports = Backbone.View.extend( {
 		// Create a widget sortable that's connected with all other cells
 		this.widgetSortable = this.$( '.widgets-container' ).sortable( {
 			placeholder: "so-widget-sortable-highlight",
-			connectWith: '#' + builderID + ' .so-cells .cell .widgets-container,.gutenberg .so-cells .cell .widgets-container',
+			connectWith: '#' + builderID + ' .so-cells .cell .widgets-container,.block-editor .so-cells .cell .widgets-container',
 			tolerance: 'pointer',
 			scroll: false,
 			over: function ( e, ui ) {

--- a/js/yoast-compat.js
+++ b/js/yoast-compat.js
@@ -41,9 +41,14 @@ jQuery(function($){
 			return data;
 		}
 
-		$data.find('.so-panel.widget').each(function(i, el){
-			var $widget = $(el),
-				match = re.exec( $widget.html() );
+		$data.find('.so-panel.widget').each(function(i, el) {
+			
+			var $widget = $(el);
+			// Style wrappers prevent us from matching the widget shortcode correctly.
+			if ( $widget.find( '> .panel-widget-style' ).length > 0 ) {
+				$widget = $widget.find( '> .panel-widget-style' );
+			}
+			var match = re.exec( $widget.html() );
 
 			try{
 				if( ! _.isNull( match ) && $widget.html().replace( re, '' ).trim() === '' ) {

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -71,7 +71,7 @@ class SiteOrigin_Panels {
 		SiteOrigin_Panels_Cache_Renderer::single();
 		
 		if ( function_exists( 'register_block_type' ) ) {
-			SiteOrigin_Panels_Layout_Block::single();
+			SiteOrigin_Panels_Compat_Layout_Block::single();
 		}
 		
 		

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -71,7 +71,7 @@ class SiteOrigin_Panels {
 		SiteOrigin_Panels_Cache_Renderer::single();
 		
 		if ( function_exists( 'register_block_type' ) ) {
-			SiteOrigin_Panels_Compat_Gutenberg_Block::single();
+			SiteOrigin_Panels_Layout_Block::single();
 		}
 		
 		


### PR DESCRIPTION
* Use front end i18n for block editor.
* Ensure contextual menu works in dialogs.
* Yoast compat: Check for panels style wrappers before doing widget content modifications.
* Clone Layouts: Fix to allow for private posts and pages.
* Block editor: Show preview initially when page is loaded.
* Block editor: Show classic editor for existing pages containing Page Builder layout data.