### PR TITLE
Release 2.9.6

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -9,7 +9,7 @@
 	var __ = i18n.__;
 	
 	blocks.registerBlockType( 'siteorigin-panels/layout-block', {
-		title: __( 'SiteOrigin Layout (in beta)', 'siteorigin-panels' ),
+		title: __( 'SiteOrigin Layout', 'siteorigin-panels' ),
 		
 		description: __( "Build a layout using SiteOrigin's Page Builder.", 'siteorigin-panels' ),
 		

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1291,7 +1291,9 @@ class SiteOrigin_Panels_Admin {
 			<?php
 		}
 		
-		if ( ! in_array( $typenow, siteorigin_panels_setting( 'post-types' ) ) ) {
+		if ( ! in_array( $typenow, siteorigin_panels_setting( 'post-types' ) ) ||
+			 // WooCommerce product type doesn't support block editor...
+			 ( class_exists( 'WooCommerce' ) && $typenow == 'product' ) ) {
 			return;
 		}
 		

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1249,20 +1249,21 @@ class SiteOrigin_Panels_Admin {
 			return false;
 		}
 		
+		// If the `$post_type` is set to be used by Page Builder.
+		$post_types = siteorigin_panels_setting( 'post-types' );
+		$is_panels_type = in_array( $post_type, $post_types );
+		
 		// For existing posts.
 		global $post;
 		if ( ! empty( $post ) ) {
 			// If the post has blocks just allow `$use_block_editor` to decide.
 			if ( ! has_blocks( $post ) ) {
 				$panels_data = get_post_meta( $post->ID, 'panels_data', true );
-				if ( ! empty( $panels_data ) ) {
+				if ( ! empty( $panels_data ) || $is_panels_type ) {
 					$use_block_editor = false;
 				}
 			}
 		} else {
-			// If the `$post_type` is set to be used by Page Builder.
-			$post_types = siteorigin_panels_setting( 'post-types' );
-			$is_panels_type = in_array( $post_type, $post_types );
 			if ( $is_panels_type ){
 				$use_block_editor = false;
 			}


### PR DESCRIPTION
* Default to Page Builder interface for post types set to use Page Builder in Settings.
* Add check for WooCommerce 'product' type to prevent output of 'Add New' dropdown.