### PR TITLE
Prevent running widget logic while in wp_head

### DIFF
--- a/inc/widgets/post-loop.php
+++ b/inc/widgets/post-loop.php
@@ -81,6 +81,7 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 	 */
 	function widget( $args, $instance ) {
 		if( empty( $instance['template'] ) ) return;
+		if( doing_action('wp_head') ) return;
 		if( is_admin() ) return;
 		
 		static $depth = 0;


### PR DESCRIPTION
When Yoast SEO is installed but no description is set on the page where Page Builder is configured, the widget logic runs unnecessarily, when the Yoast is processing the metadata.