### PR TITLE
Fix notice when using WP 4.9.9

### DIFF
--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -29,16 +29,7 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 	}
 	
 	public function enqueue_layout_block_editor_assets() {
-		// This is for the Gutenberg plugin.
-		$is_gutenberg_page = function_exists( 'is_gutenberg_page' ) && is_gutenberg_page();
-		// This is for WP 5 with the integrated block editor.
-		$is_block_editor = false;
-		$current_screen = get_current_screen();
-		if ( $current_screen && method_exists( $current_screen, 'is_block_editor' ) ) {
-			$is_block_editor = $current_screen->is_block_editor();
-		}
-		
-		if ( $is_gutenberg_page || $is_block_editor ) {
+		if (  SiteOrigin_Panels_Admin::is_block_editor() ) {
 			$panels_admin = SiteOrigin_Panels_Admin::single();
 			$panels_admin->enqueue_admin_scripts();
 			$panels_admin->enqueue_admin_styles();

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -115,7 +115,7 @@ class SiteOrigin_Panels_Admin {
 		$screen         = get_current_screen();
 		$is_panels_page = ( $screen->base == 'post' && in_array( $screen->id, siteorigin_panels_setting( 'post-types' ) ) ) ||
 						  in_array( $screen->base, array( 'appearance_page_so_panels_home_page', 'widgets', 'customize' ) ) ||
-						  $screen->is_block_editor;
+						  ( ! method_exists( $screen, 'is_block_editor' ) || $screen->is_block_editor );
 
 		return apply_filters( 'siteorigin_panels_is_admin_page', $is_panels_page );
 	}

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -130,9 +130,13 @@ class SiteOrigin_Panels_Admin {
 		$is_gutenberg_page = function_exists( 'is_gutenberg_page' ) && is_gutenberg_page();
 		// This is for WP 5 with the integrated block editor.
 		$is_block_editor = false;
-		$current_screen = get_current_screen();
-		if ( $current_screen && method_exists( $current_screen, 'is_block_editor' ) ) {
-			$is_block_editor = $current_screen->is_block_editor();
+
+		if ( function_exists( 'get_current_screen' ) ) {
+			$current_screen = get_current_screen();
+			if ( $current_screen && method_exists( $current_screen, 'is_block_editor' ) ) {
+				$is_block_editor = $current_screen->is_block_editor();
+			}
+		}
 		
 		return $is_gutenberg_page || $is_block_editor;
 	}

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -115,10 +115,28 @@ class SiteOrigin_Panels_Admin {
 		$screen         = get_current_screen();
 		$is_panels_page = ( $screen->base == 'post' && in_array( $screen->id, siteorigin_panels_setting( 'post-types' ) ) ) ||
 						  in_array( $screen->base, array( 'appearance_page_so_panels_home_page', 'widgets', 'customize' ) ) ||
-						  ( ! method_exists( $screen, 'is_block_editor' ) || $screen->is_block_editor );
+						  self::is_block_editor();
 
 		return apply_filters( 'siteorigin_panels_is_admin_page', $is_panels_page );
 	}
+
+	/**
+	 * Check if the current page is Gutenberg or the Block Ediotr
+	 *
+	 * @return bool
+	 */
+	static function is_block_editor() {
+		// This is for the Gutenberg plugin.
+		$is_gutenberg_page = function_exists( 'is_gutenberg_page' ) && is_gutenberg_page();
+		// This is for WP 5 with the integrated block editor.
+		$is_block_editor = false;
+		$current_screen = get_current_screen();
+		if ( $current_screen && method_exists( $current_screen, 'is_block_editor' ) ) {
+			$is_block_editor = $current_screen->is_block_editor();
+		
+		return $is_gutenberg_page || $is_block_editor;
+	}
+
 
 	/**
 	 * Add action links to the plugin list for Page Builder.


### PR DESCRIPTION
This change prevents the below notice from occurring whenever `SiteOrigin_Panels_Admin::is_admin()` is used when using 4.9.9.

`019 15:45:24 UTC] PHP Notice:  Undefined property: WP_Screen::$is_block_editor in C:\wamp64\www\siteorigin\wp-4-9-9\wp-content\plugins\siteorigin-panels\inc\admin.php on line 118
`
Based on the previous checks, there doesn't appear to be a reliable manner to check for the Gutenberg plugin pre-WordPress 5.0. There doesn't appear to be any issues by letting it pass.