### PR TITLE
Pass SiteOrigin Image Grid, Masonry, and Button widget data to Yoast

### DIFF
--- a/js/yoast-compat.js
+++ b/js/yoast-compat.js
@@ -117,6 +117,12 @@ jQuery(function($){
 								}
 								newHTML = newHTML.prop( 'outerHTML' );
 								break;
+							case 'SiteOrigin_Widget_Button_Widget':
+								var hrefSeparator = widgetInstance.url.includes( '://' ) === true ? '' : '#';
+								newHTML = $( '<a>' + widgetInstance.text + '</a>' ).attr({
+									'href': hrefSeparator + widgetInstance.url,
+								}).prop('outerHTML');
+								break;
 						}
 					}
 

--- a/js/yoast-compat.js
+++ b/js/yoast-compat.js
@@ -84,6 +84,24 @@ jQuery(function($){
 								}).prop('outerHTML');
 								break;
 
+							case 'SiteOrigin_Widgets_ImageGrid_Widget':
+							case 'SiteOrigin_Widget_Simple_Masonry_Widget':
+								newHTML = $( '<div/>' );
+								var contentItems = widgetClass === 'SiteOrigin_Widgets_ImageGrid_Widget' ? widgetInstance.images : widgetInstance.items;
+								for( var i = 0; i < contentItems.length; i++ ) {
+									var item = contentItems[ i ];
+									var itemHTML = $('<img/>').attr({
+									'src': '#' + item.image,
+									'srcset': '',
+									'alt': item.title,
+									'title': item.title,
+									});
+
+									newHTML.append( itemHTML )
+								}
+								newHTML = newHTML.prop( 'outerHTML' );
+								break;
+
 							case 'SiteOrigin_Widget_Accordion_Widget':
 							case 'SiteOrigin_Widget_Tabs_Widget':
 								var contentItems = widgetClass === 'SiteOrigin_Widget_Accordion_Widget' ? widgetInstance.panels : widgetInstance.tabs;

--- a/js/yoast-compat.js
+++ b/js/yoast-compat.js
@@ -88,13 +88,13 @@ jQuery(function($){
 							case 'SiteOrigin_Widget_Simple_Masonry_Widget':
 								newHTML = $( '<div/>' );
 								var contentItems = widgetClass === 'SiteOrigin_Widgets_ImageGrid_Widget' ? widgetInstance.images : widgetInstance.items;
-								for( var i = 0; i < contentItems.length; i++ ) {
+								for ( var i = 0; i < contentItems.length; i++ ) {
 									var item = contentItems[ i ];
 									var itemHTML = $('<img/>').attr({
-									'src': '#' + item.image,
-									'srcset': '',
-									'alt': item.title,
-									'title': item.title,
+										'src': '#' + item.image,
+										'srcset': '',
+										'alt': item.title,
+										'title': item.title,
 									});
 
 									newHTML.append( itemHTML )
@@ -106,7 +106,7 @@ jQuery(function($){
 							case 'SiteOrigin_Widget_Tabs_Widget':
 								var contentItems = widgetClass === 'SiteOrigin_Widget_Accordion_Widget' ? widgetInstance.panels : widgetInstance.tabs;
 								newHTML = $( '<div/>' );
-								for( var i = 0; i < contentItems.length; i++ ) {
+								for ( var i = 0; i < contentItems.length; i++ ) {
 									var item = contentItems[ i ];
 									if ( item.content_type !== 'text' ) {
 										continue;

--- a/js/yoast-compat.js
+++ b/js/yoast-compat.js
@@ -118,7 +118,7 @@ jQuery(function($){
 								newHTML = newHTML.prop( 'outerHTML' );
 								break;
 							case 'SiteOrigin_Widget_Button_Widget':
-								var hrefSeparator = widgetInstance.url.includes( '://' ) === true ? '' : '#';
+								var hrefSeparator = widgetInstance.url.includes( '://' ) ? '' : '#'
 								newHTML = $( '<a>' + widgetInstance.text + '</a>' ).attr({
 									'href': hrefSeparator + widgetInstance.url,
 								}).prop('outerHTML');

--- a/js/yoast-compat.js
+++ b/js/yoast-compat.js
@@ -52,9 +52,9 @@ jQuery(function($){
 
 			try{
 				if( ! _.isNull( match ) && $widget.html().replace( re, '' ).trim() === '' ) {
-					var classMatch = /class="(.*?)"/.exec( match[3] ),
-						dataInput = jQuery( match[5] ),
-						data = JSON.parse( decodeEntities( dataInput.val( ) ) ),
+					var classMatch = /class="(.*?)"/.exec(match[3]),
+						dataInput = jQuery(match[5]),
+						data = JSON.parse(decodeEntities(dataInput.val())),
 						widgetInstance = data.instance,
 						newHTML = '';
 
@@ -87,14 +87,14 @@ jQuery(function($){
 							case 'SiteOrigin_Widgets_ImageGrid_Widget':
 							case 'SiteOrigin_Widget_Simple_Masonry_Widget':
 								newHTML = $( '<div/>' );
-								var contentItems = widgetClass === 'SiteOrigin_Widgets_ImageGrid_Widget' ? widgetInstance.images : widgetInstance.items;
-								for ( var i = 0; i < contentItems.length; i++ ) {
-									var item = contentItems[ i ];
+								var imgItems = widgetClass === 'SiteOrigin_Widgets_ImageGrid_Widget' ? widgetInstance.images : widgetInstance.items;
+								for ( var i = 0; i < imgItems.length; i++ ) {
+									var imgItem = imgItems[ i ];
 									var itemHTML = $('<img/>').attr({
-										'src': '#' + item.image,
+										'src': '#' + imgItem.image,
 										'srcset': '',
-										'alt': item.title,
-										'title': item.title,
+										'alt': ( imgItem.hasOwnProperty( 'alt' ) ? imgItem.alt : imgItem.title ),
+										'title': imgItem.title,
 									});
 
 									newHTML.append( itemHTML )
@@ -118,7 +118,7 @@ jQuery(function($){
 								newHTML = newHTML.prop( 'outerHTML' );
 								break;
 							case 'SiteOrigin_Widget_Button_Widget':
-								var hrefSeparator = widgetInstance.url.includes( '://' ) ? '' : '#'
+								var hrefSeparator = widgetInstance.url.includes('://') ? '' : '#';
 								newHTML = $( '<a>' + widgetInstance.text + '</a>' ).attr({
 									'href': hrefSeparator + widgetInstance.url,
 								}).prop('outerHTML');


### PR DESCRIPTION
This PR will provide Yoast with all of the images used in the Image Grid and Masonry widgets.

This PR will also provide Yoast with the URL used with Yoast. As with the images, however, it doesn't resolve the link so it won't be enough to resolve the Yoast internal flag unless the user doesn't set the link using the Select Content option.