### PR TITLE
Cache the result of url_to_postid()

### DIFF
--- a/inc/sidebars-emulator.php
+++ b/inc/sidebars-emulator.php
@@ -65,17 +65,26 @@ class SiteOrigin_Panels_Sidebars_Emulator {
 	 * Register all the current widgets so we can filter the get_option('widget_...') values to add instances
 	 */
 	function register_widgets() {
+		$current_url = add_query_arg( false, false );
+		$cache_key   = md5( $current_url );
+
 		// Get the ID of the current post
-		$post_id = url_to_postid( add_query_arg( false, false ) );
+		$post_id = wp_cache_get( $cache_key, 'siteorigin_url_to_postid' );
+		if ( false === $post_id ) {
+			$post_id = url_to_postid( $current_url );
+			wp_cache_set( $cache_key, $post_id, 'siteorigin_url_to_postid', 3 * HOUR_IN_SECONDS );
+		}
+
 		if ( empty( $post_id ) ) {
 			// Maybe this is the home page
-			$current_url_path = parse_url( add_query_arg( false, false ), PHP_URL_PATH );
+			$current_url_path = parse_url( $current_url, PHP_URL_PATH );
 			$home_url_path    = parse_url( trailingslashit( home_url() ), PHP_URL_PATH );
 
 			if ( $current_url_path === $home_url_path && get_option( 'page_on_front' ) != 0 ) {
 				$post_id = absint( get_option( 'page_on_front' ) );
 			}
 		}
+
 		if ( empty( $post_id ) ) {
 			return;
 		}


### PR DESCRIPTION
The `url_to_postid()` function includes a fairly expensive, uncached, WP query. This can happen on most to all pages with this plugin, which hurts performance significantly.

I spent a little bit of time to see if we could avoid this entirely with a better solution for getting the `$post_id` in this function, one that doesn't involve a query based on the current request URL. I didn't come across any simple changes, but open to ideas on that front.

As a fix for the performance problems here, I've implemented some caching so `url_to_postid()` isn't repeatedly called. This is similar to the helper function we use at WordPress.com VIP: https://github.com/Automattic/vip-go-mu-plugins/blob/da7fcd24b773e1957687c6eb56f0b56ddd402d9e/vip-helpers/vip-caching.php#L252-L276

