### PR TITLE
Release 2.10.3

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -78,7 +78,9 @@ class SiteOrigin_Panels_Admin {
 			add_filter( 'gutenberg_can_edit_post_type', array( $this, 'show_classic_editor_for_panels' ), 10, 2 );
 			add_filter( 'use_block_editor_for_post_type', array( $this, 'show_classic_editor_for_panels' ), 10, 2 );
 			add_action( 'admin_print_scripts-edit.php', array( $this, 'add_panels_add_new_button' ) );
-			add_filter( 'display_post_states', array( $this, 'add_panels_post_state' ), 10, 2 );
+			if( siteorigin_panels_setting( 'admin-post-state' ) ) {
+				add_filter( 'display_post_states', array( $this, 'add_panels_post_state' ), 10, 2 );
+			}
 		}
 	}
 

--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -109,7 +109,7 @@ class SiteOrigin_Panels_Css_Builder {
 				$selector[] = '#pl-' . $li;
 			}
 			$selector[] = is_string( $ri ) ? ( '#' . $ri ) : '#pg-' . $li . '-' . $ri;
-			$selector[] = '.panel-grid-cell';
+			$selector[] = '> .panel-grid-cell';
 		} elseif ( $ri !== false && $ci !== false ) {
 			// This applies to a specific cell
 			if ( $specify_layout ) {

--- a/inc/live-editor.php
+++ b/inc/live-editor.php
@@ -9,7 +9,6 @@ class SiteOrigin_Panels_Live_Editor {
 
 	function __construct() {
 		add_action( 'template_redirect', array( $this, 'xss_headers' ) );
-		add_action( 'get_post_metadata', array( $this, 'post_metadata' ), 10, 3 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_scripts' ) );
 
 		// Don't display the admin bar when in live editor mode
@@ -32,40 +31,6 @@ class SiteOrigin_Panels_Live_Editor {
 			header( 'X-XSS-Protection: 0' );
 		}
 	}
-
-	/**
-	 * Edit the page builder data when we're viewing the live editor version
-	 *
-	 * @param $value
-	 * @param $post_id
-	 * @param $meta_key
-	 *
-	 * @return array
-	 */
-	function post_metadata( $value, $post_id, $meta_key ) {
-		if (
-			$meta_key == 'panels_data' &&
-			current_user_can( 'edit_post', $post_id ) &&
-			! empty( $_POST['live_editor_panels_data'] ) &&
-			$_POST['live_editor_post_ID'] == $post_id
-		) {
-			$data = json_decode( wp_unslash( $_POST['live_editor_panels_data'] ), true );
-
-			if (
-				! empty( $data['widgets'] ) && (
-					! class_exists( 'SiteOrigin_Widget_Field_Class_Loader' ) ||
-					method_exists( 'SiteOrigin_Widget_Field_Class_Loader', 'extend' )
-				)
-			) {
-				$data['widgets'] = SiteOrigin_Panels_Admin::single()->process_raw_widgets( $data['widgets'], false, false );
-			}
-
-			$value = array( $data );
-		}
-
-		return $value;
-	}
-
 
 	/**
 	 * Load the frontend scripts for the live editor

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -210,11 +210,12 @@ class SiteOrigin_Panels_Renderer {
 					$css->add_cell_css( $post_id, $ri, false, '', array(
 						'margin-right' => 0,
 					), $panels_mobile_width );
+					
+					$css->add_cell_css( $post_id, $ri, false, '', array(
+						'width' => '100%',
+					), $panels_mobile_width );
 				}
 
-				$css->add_cell_css( $post_id, $ri, false, '', array(
-					'width' => '100%',
-				), $panels_mobile_width );
 
 				foreach ( $row['cells'] as $ci => $cell ) {
 					if ( ( $collapse_order == 'left-top' && $ci != $cell_count - 1 ) || ( $collapse_order == 'right-top' && $ci !== 0 ) ) {

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -602,7 +602,19 @@ class SiteOrigin_Panels_Renderer {
 	 * @return array
 	 */
 	private function get_panels_data_for_post( $post_id ) {
-		if ( strpos( $post_id, 'prebuilt:' ) === 0 ) {
+		if ( SiteOrigin_Panels::is_live_editor() ) {
+			if (
+				current_user_can( 'edit_post', $post_id ) &&
+				! empty( $_POST['live_editor_panels_data'] ) &&
+				$_POST['live_editor_post_ID'] == $post_id
+			) {
+				$panels_data = json_decode( wp_unslash( $_POST['live_editor_panels_data'] ), true );
+				
+				if ( ! empty( $panels_data['widgets'] ) ) {
+					$panels_data['widgets'] = SiteOrigin_Panels_Admin::single()->process_raw_widgets( $panels_data['widgets'] );
+				}
+			}
+		} else if ( strpos( $post_id, 'prebuilt:' ) === 0 ) {
 			list( $null, $prebuilt_id ) = explode( ':', $post_id, 2 );
 			$layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 			$panels_data = ! empty( $layouts[ $prebuilt_id ] ) ? $layouts[ $prebuilt_id ] : array();

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -119,6 +119,7 @@ class SiteOrigin_Panels_Settings {
 		// The general fields
 		$defaults['post-types']             = array( 'page', 'post' );
 		$defaults['live-editor-quick-link'] = true;
+		$defaults['admin-post-state']       = true;
 		$defaults['admin-widget-count']     = false;
 		$defaults['parallax-motion']        = '';
 		$defaults['sidebars-emulator']      = true;
@@ -259,6 +260,16 @@ class SiteOrigin_Panels_Settings {
 			'type'        => 'checkbox',
 			'label'       => __( 'Live Editor Quick Link', 'siteorigin-panels' ),
 			'description' => __( 'Display a Live Editor button in the admin bar.', 'siteorigin-panels' ),
+		);
+
+		$fields['general']['fields']['admin-post-state'] = array(
+			'type'        => 'checkbox',
+			'label'       => __( 'Display Post State', 'siteorigin-panels' ),
+			'description' => sprintf(
+				__( "Display a %sSiteOrigin Page Builder%s post state in the admin lists of posts/pages to indicate Page Builder is active.", 'siteorigin-panels' ),
+				'<strong>',
+				'</strong>'
+			),
 		);
 
 		$fields['general']['fields']['admin-widget-count'] = array(

--- a/inc/widgets/layout.php
+++ b/inc/widgets/layout.php
@@ -58,14 +58,18 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 			$new['panels_data'] = json_decode( $new['panels_data'], true );
 		}
 		
-		if ( ! empty( $new['panels_data'] ) && ! empty( $new['panels_data']['widgets'] ) ) {
-			$new['panels_data']['widgets'] = SiteOrigin_Panels_Admin::single()->process_raw_widgets(
-				$new['panels_data']['widgets'],
-				! empty( $old['panels_data']['widgets'] ) ? $old['panels_data']['widgets'] : false
-			);
-			foreach( $new['panels_data']['widgets'] as & $widget ) {
-				$widget['panels_info']['class'] = str_replace( '\\', '&#92;', $widget['panels_info']['class'] );
+		if ( ! empty( $new['panels_data'] ) ) {
+			if ( ! empty( $new['panels_data']['widgets'] ) ) {
+				$new['panels_data']['widgets'] = SiteOrigin_Panels_Admin::single()->process_raw_widgets(
+					$new['panels_data']['widgets'],
+					! empty( $old['panels_data']['widgets'] ) ? $old['panels_data']['widgets'] : false
+				);
+				foreach( $new['panels_data']['widgets'] as & $widget ) {
+					$widget['panels_info']['class'] = str_replace( '\\', '&#92;', $widget['panels_info']['class'] );
+				}
 			}
+			
+			$new['panels_data'] = SiteOrigin_Panels_Styles_Admin::single()->sanitize_all( $new['panels_data'] );
 		}
 		
 		return $new;

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Page Builder by SiteOrigin ===
 Tags: page builder, responsive, widget, widgets, builder, page, admin, gallery, content, cms, pages, post, css, layout, grid
 Requires at least: 4.4
-Tested up to: 5.0
+Tested up to: 5.1
 Stable tag: trunk
 Build time: unbuilt
 License: GPLv3


### PR DESCRIPTION
* Layout builder widget: Call styles sanitization in update.
* Live editor: Only call `process_raw_widgets` once for preview data.
* Add a setting for whether to display SiteOrigin Page Builder post state.
* Sidebars emulator: Cache the result of url_to_postid().
* Prevent affecting child layouts with parent layouts' CSS.