### PR TITLE
Resolve Read More Custom Text issue

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -328,7 +328,7 @@ class SiteOrigin_Panels {
 						$content = explode( $matches[0], $content, 2 );
 						$content = $content[0];
 						$content = force_balance_tags( $content );
-						if ( ! empty( $matches[1] ) && ! empty( $more_link_text ) ) {
+						if ( ! empty( $matches[1] ) ) {
 							$more_link_text = strip_tags( wp_kses_no_null( trim( $matches[1] ) ) );
 						} else {
 							$more_link_text = __( 'Read More', 'siteorigin-panels' );


### PR DESCRIPTION
This PR fixes an issue that prevents custom Read More text from being used.

`$more_link_text` is only set if `$matches[1]` is empty so checking if `$more_link_text` exists will always fail. Checking the contents of `$matches[1]` is enough to determine if a custom read more text is present.