### PR TITLE
Raise minimum WordPress version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Page Builder by SiteOrigin ===
 Tags: page builder, responsive, widget, widgets, builder, page, admin, gallery, content, cms, pages, post, css, layout, grid
-Requires at least: 4.4
+Requires at least: 4.7
 Tested up to: 5.2.2
 Stable tag: trunk
 Build time: unbuilt


### PR DESCRIPTION
Hi,

just had an issue with this plugin and the WordPress Updater, because this plugin says it requires at least WordPress 4.4, but it uses the [wp_doing_ajax](https://github.com/siteorigin/siteorigin-panels/blob/15cbc79ae97aedcf0d33e6b23544bb624a765140/siteorigin-panels.php#L46) function, which was [introduced in WordPress 4.7](https://developer.wordpress.org/reference/functions/wp_doing_ajax/#changelog)

This broke my site and should be preventable by raising the minimum WordPress Version or removing the function. This PR does the easy thing of just raising the minimum WordPress Version.