### PR TITLE
Add support for widgets that don't have a dedicated class

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -751,8 +751,8 @@ class SiteOrigin_Panels_Admin {
 	function get_widgets() {
 		global $wp_widget_factory;
 		$widgets = array();
-		foreach ( $wp_widget_factory->widgets as $widget_obj ) {
-			$class = get_class( $widget_obj );
+		foreach ( $wp_widget_factory->widgets as $class => $widget_obj ) {
+			$class = preg_match( '/[0-9a-f]{32}/', $class ) ? get_class( $widget_obj ) : $class;
 			$widgets[ $class ] = array(
 				'class'       => $class,
 				'title'       => ! empty( $widget_obj->name ) ? $widget_obj->name : __( 'Untitled Widget', 'siteorigin-panels' ),


### PR DESCRIPTION
The change https://github.com/siteorigin/siteorigin-panels/commit/2a6179a04ac88ce712e49bae6bde7a854b050c54 introduced an issue where widgets that didn't have a dedicated class weren't showing up in Page Builder. This PR fixes that by only using the `$widget_obj` class, when the given `$class` from the array key is a hash.