### PR TITLE
Set admin widget title font size

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -432,6 +432,7 @@
 								display: block;
 								cursor: pointer;
 								margin: 0 15px 3px 0;
+								font-size: 1em;
 								font-weight: 600;
 								line-height: 1.25em;
 								color: #474747;


### PR DESCRIPTION
Resolves #700 and #709.

@AlexGStapleton Please, can you check admin widget title sizing in both the Block and Classic Editor. Do so with one of our themes and Sydney to resolve #700. Thanks.