### PR TITLE
Set widget search form line height

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1037,6 +1037,7 @@
 			width: 100%;
 			padding: 6px;
 			margin-bottom: 20px;
+			line-height: normal;
 		}
 
 		.so-sidebar-tabs {


### PR DESCRIPTION
Resolves #711.

The new core admin styles have set a `line-height` of `2` to input fields.