### PR TITLE
Prevent WebKit font size adjustments

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -697,6 +697,8 @@
 	@pane_padding: 15px;
 	@border_color: #D8D8D8;
 
+	-webkit-text-size-adjust: none;
+
 	.so-overlay, .so-content, .so-title-bar, .so-toolbar, .so-left-sidebar, .so-right-sidebar {
 		z-index: 100001;
 		position: fixed;


### PR DESCRIPTION
Prevent WebKite font size adjustments in the widget modal.

Resolves https://github.com/siteorigin/siteorigin-panels/issues/702.