### PR TITLE
Added styling for the bg color clear button

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1806,6 +1806,11 @@
 			input {
 				max-width: 100%;
 			}
+
+			.wp-picker-clear {
+				margin-left: 6px;
+				min-height: 30px;
+			}
 		}
 
 		/* All the field types */


### PR DESCRIPTION
**Problem:**

<img width="347" alt="clear-button" src="https://user-images.githubusercontent.com/789159/74761119-25b4fb80-5284-11ea-8988-c2b23a5c5d58.png">

This PR matches the clear button styling we're using in the Hero etc.

Alex, you ok with this or should I try to do this in a more global manner? I'm not really familiar with the overall admin CSS layout so yeah, this is quite a focussed fix. I couldn't immediately see any other buttons like this on the same side panel that needs to be targetted. 