### PR TITLE
Resolve WP 5.4 Add SO Layout Block button not appearing

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -316,7 +316,7 @@ registerBlockType('siteorigin-panels/layout-block', {
         var editorDispatch = wp.data.dispatch('core/editor');
         var editorSelect = wp.data.select('core/editor');
         var tmpl = jQuery('#siteorigin-panels-add-layout-block-button').html();
-        var $addButton = jQuery(tmpl).insertAfter('.editor-writing-flow > div:first');
+        var $addButton = jQuery(tmpl).insertAfter('.editor-writing-flow > div:first, .block-editor-writing-flow > div:not([tabindex])');
         $addButton.on('click', function () {
           var layoutBlock = wp.blocks.createBlock('siteorigin-panels/layout-block', {});
           var isEmpty = editorSelect.isEditedPostEmpty();

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -284,7 +284,7 @@ registerBlockType( 'siteorigin-panels/layout-block', {
 				const editorDispatch = wp.data.dispatch( 'core/editor' );
 				const editorSelect = wp.data.select( 'core/editor' );
 				var tmpl = jQuery( '#siteorigin-panels-add-layout-block-button' ).html();
-				var $addButton = jQuery(tmpl).insertAfter( '.editor-writing-flow > div:first' );
+				var $addButton = jQuery(tmpl).insertAfter( '.editor-writing-flow > div:first, .block-editor-writing-flow > div:not([tabindex])' );
 				$addButton.on( 'click', () => {
 					var layoutBlock = wp.blocks.createBlock( 'siteorigin-panels/layout-block', {} );
 					const isEmpty = editorSelect.isEditedPostEmpty();


### PR DESCRIPTION
In WP 5.4, .editor-writing-flow was renamed to `.block-editor-writing-flow` and an accessibility div with a tabindex was also added. This PR accounts for both and allows for the Add SiteOrigin Layout Block to appear again.

This PR also accounts for backward compatibility by maintaining the previous selector.

![](https://i.imgur.com/8s27xpI.png)