### PR TITLE
Live editor: Use Global Settings for device widths and prevent scaling

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -2175,7 +2175,6 @@
 		top: 0;
 		right: 0;
 		bottom: 0;
-		left: @live_editor_width;
 		background-color: #191e23;
 
 		form {
@@ -2183,11 +2182,15 @@
 		}
 
 		iframe{
-			float: left;
+			display: block;
 			width: 100%;
 			height: 100%;
 			margin: 0 auto;
 		}
+	}
+
+	.so-preview, .so-preview-overlay {
+		width: calc(100% - @live_editor_width);
 	}
 
 	.so-preview-overlay {
@@ -2196,7 +2199,6 @@
 		top: 0;
 		right: 0;
 		bottom: 0;
-		left: @live_editor_width;
 		background-color: #F4F4F4;
 		cursor: wait;
 
@@ -2238,57 +2240,11 @@
 			display: none;
 		}
 
-		.so-preview,
-		.so-preview-overlay {
-			left: 0;
+		.so-preview, .so-preview-overlay {
+			width: 100%;
 		}
 	}
 
-	&.live-editor-mobile-mode {
-		.so-preview iframe {
-			max-width: 480px;
-			max-height: 640px;
-			position: absolute;
-			top: 50%;
-			left: 50%;
-			margin-left: -240px;
-			margin-top: -320px;
-
-			@media (max-width: 840px) {
-				& {
-					position: static;
-					margin-left: 0;
-					margin-top: 0;
-				}
-			}
-
-			@media (max-height: 640px) {
-				& {
-					position: static;
-					margin-left: 0;
-					margin-top: 0;
-				}
-			}
-		}
-	}
-
-	&.live-editor-tablet-mode {
-		.so-preview iframe {
-			position: absolute;
-			max-width: 768px;
-			top: 0;
-			left: 50%;
-			margin-left: -384px;
-
-			@media (max-width: 1128px) {
-				& {
-					position: static;
-					margin-left: 0;
-					margin-top: 0;
-				}
-			}
-		}
-	}
 }
 
 .so-panels-loading {

--- a/css/admin.less
+++ b/css/admin.less
@@ -2187,6 +2187,7 @@
 			width: 100%;
 			height: 100%;
 			margin: 0 auto;
+			transition: all .2s ease;
 		}
 	}
 

--- a/css/admin.less
+++ b/css/admin.less
@@ -2176,6 +2176,7 @@
 		right: 0;
 		bottom: 0;
 		background-color: #191e23;
+		overflow: scroll;
 
 		form {
 			display: none;

--- a/js/siteorigin-panels/view/live-editor.js
+++ b/js/siteorigin-panels/view/live-editor.js
@@ -416,7 +416,7 @@ module.exports = Backbone.View.extend( {
 
 		this.$el
 			.removeClass( 'live-editor-desktop-mode live-editor-tablet-mode live-editor-mobile-mode' )
-			.addClass( 'live-editor-' + button.data( 'mode' ) + '-mode' );
-
+			.addClass( 'live-editor-' + button.data( 'mode' ) + '-mode' )
+			.find( 'iframe' ).css( 'width', button.data( 'width' ) );
 	}
 } );

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -555,13 +555,13 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 			><?php esc_html_e('Update', 'siteorigin-panels') ?></button>
 			<button class="live-editor-close button-secondary"><?php esc_html_e('Close', 'siteorigin-panels') ?></button>
 
-			<a class="live-editor-mode live-editor-desktop so-active" title="<?php esc_attr_e( 'Toggle desktop mode', 'siteorigin-panels' ) ?>" data-mode="desktop">
+			<a class="live-editor-mode live-editor-desktop so-active" title="<?php esc_attr_e( 'Toggle desktop mode', 'siteorigin-panels' ) ?>" data-mode="desktop" data-width="100%" >
 				<span class="dashicons dashicons-desktop"></span>
 			</a>
-			<a class="live-editor-mode live-editor-tablet" title="<?php esc_attr_e( 'Toggle tablet mode', 'siteorigin-panels' ) ?>" data-mode="tablet">
+			<a class="live-editor-mode live-editor-tablet" title="<?php esc_attr_e( 'Toggle tablet mode', 'siteorigin-panels' ) ?>" data-mode="tablet" data-width="<?php esc_attr_e( siteorigin_panels_setting( 'tablet-width' ) ); ?>px">
 				<span class="dashicons dashicons-tablet"></span>
 			</a>
-			<a class="live-editor-mode live-editor-mobile" title="<?php esc_attr_e( 'Toggle mobile mode', 'siteorigin-panels' ) ?>" data-mode="mobile">
+			<a class="live-editor-mode live-editor-mobile" title="<?php esc_attr_e( 'Toggle mobile mode', 'siteorigin-panels' ) ?>" data-mode="mobile" data-width="<?php esc_attr_e( siteorigin_panels_setting( 'mobile-width' ) ); ?>px">
 				<span class="dashicons dashicons-smartphone"></span>
 			</a>
 

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -558,10 +558,10 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 			<a class="live-editor-mode live-editor-desktop so-active" title="<?php esc_attr_e( 'Toggle desktop mode', 'siteorigin-panels' ) ?>" data-mode="desktop" data-width="100%" >
 				<span class="dashicons dashicons-desktop"></span>
 			</a>
-			<a class="live-editor-mode live-editor-tablet" title="<?php esc_attr_e( 'Toggle tablet mode', 'siteorigin-panels' ) ?>" data-mode="tablet" data-width="<?php esc_attr_e( siteorigin_panels_setting( 'tablet-width' ) ); ?>px">
+			<a class="live-editor-mode live-editor-tablet" title="<?php esc_attr_e( 'Toggle tablet mode', 'siteorigin-panels' ) ?>" data-mode="tablet" data-width="720px">
 				<span class="dashicons dashicons-tablet"></span>
 			</a>
-			<a class="live-editor-mode live-editor-mobile" title="<?php esc_attr_e( 'Toggle mobile mode', 'siteorigin-panels' ) ?>" data-mode="mobile" data-width="<?php esc_attr_e( siteorigin_panels_setting( 'mobile-width' ) ); ?>px">
+			<a class="live-editor-mode live-editor-mobile" title="<?php esc_attr_e( 'Toggle mobile mode', 'siteorigin-panels' ) ?>" data-mode="mobile" data-width="320px">
 				<span class="dashicons dashicons-smartphone"></span>
 			</a>
 


### PR DESCRIPTION
Resolve #284

This PR changes the device resolutions in the Live Editor to reflect the global Page Builder Settings. It also prevents the resizing of the preview to allow for accurate previews on devices that use a resolution higher than the one they're previewing.

To prevent the misalignment of the preview at different resolutions and adjusted device widths (if the user changes to a device other than the default), how the preview is displayed had to modified to be closer to rely less on negative margins to account for the Live Editor side. Instead, a calculated width was used instead.