### PR TITLE
Rename styles to declarations

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -94,18 +94,18 @@ class SiteOrigin_Panels_Styles {
 		);
 
 		$fields[ $id . '_css' ] = array(
-			'name'        => __( 'CSS Styles', 'siteorigin-panels' ),
+			'name'        => __( 'CSS Declarations', 'siteorigin-panels' ),
 			'type'        => 'code',
 			'group'       => 'attributes',
-			'description' => __( 'One style attribute per line.', 'siteorigin-panels' ),
+			'description' => __( 'One declaration per line.', 'siteorigin-panels' ),
 			'priority'    => 10,
 		);
 
 		$fields[ 'mobile_css' ] = array(
-			'name'        => __( 'Mobile CSS Styles', 'siteorigin-panels' ),
+			'name'        => __( 'Mobile CSS Declarations', 'siteorigin-panels' ),
 			'type'        => 'code',
 			'group'       => 'attributes',
-			'description' => __( 'CSS applied when in mobile view.', 'siteorigin-panels' ),
+			'description' => __( 'CSS declarations applied when in mobile view.', 'siteorigin-panels' ),
 			'priority'    => 11,
 		);
 


### PR DESCRIPTION
The CSS Styles field has always caused confusion. Typically, users try to insert CSS rules into the field:

`.red { color: red; }`

CSS Styles doesn't correctly define what should be inserted into the field. The correct term is a declaration.

Ref: https://www.w3schools.com/css/css_syntax.ASP
> Each declaration includes a CSS property name and a value, separated by a colon.

Users might not know what a declaration is but at least if they look it up they'll find a specific definition, namely a CSS property and value separated by a colon.


