### PR TITLE
Legacy Layout: Detect IE 11 as legacy browser

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -125,8 +125,8 @@ class SiteOrigin_Panels {
 		if( empty( $agent ) ) return false;
 		
 		return
-			// IE lte 10
-			( preg_match('/MSIE\s(?P<v>\d+)/i', $agent, $B) && $B['v'] <= 10 ) ||
+			// IE lte 11
+			( preg_match('/Trident\/(?P<v>\d+)/i', $agent, $B) && $B['v'] <= 7 ) ||
 			// Chrome lte 25
 			( preg_match('/Chrome\/(?P<v>\d+)/i', $agent, $B) && $B['v'] <= 25 ) ||
 			// Firefox lte 21


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/755

This PR changes the legacy device detection to include effectively [all versions of IE](https://www.whatismybrowser.com/guides/the-latest-user-agent/internet-explorer). Edge does not include Trident in its user agent so it won't be picked up by this change.