### PR TITLE
Live Editor: Set preview url for iframe to avoid Chrome issue

### DIFF
--- a/js/siteorigin-panels/view/live-editor.js
+++ b/js/siteorigin-panels/view/live-editor.js
@@ -282,7 +282,7 @@ module.exports = Backbone.View.extend( {
 		var iframeId = 'siteorigin-panels-live-preview-' + this.previewFrameId;
 
 		// Remove the old preview frame
-		this.previewIframe = $('<iframe src="javascript:false;" />')
+		this.previewIframe = $('<iframe src="' + url + '" />')
 			.attr( {
 				'id' : iframeId,
 				'name' : iframeId,


### PR DESCRIPTION
This PR resolves https://github.com/siteorigin/siteorigin-panels/issues/757 by setting the Live Editor Iframe src to the current page. Previously a URL [wasn't set due to previewing issues with drafts](https://github.com/siteorigin/siteorigin-panels/commit/778957ac037d1d29de9684a9181caa8055749c54). It appears we've indirectly resolved whatever issue was occurring at the time as I didn't come across any issues with drafts after making this change.