### PR TITLE
CSS Builder: Don't add selectors with no attributes

### DIFF
--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -38,14 +38,17 @@ class SiteOrigin_Panels_Css_Builder {
 		}
 		$attribute_string = implode( ';', $attribute_string );
 
-		// Add everything we need to the CSS selector
-		if ( empty( $this->css[ $resolution ] ) ) {
-			$this->css[ $resolution ] = array();
+		if ( ! empty( $attribute_string ) ) {
+			// Add everything we need to the CSS selector
+			if ( empty( $this->css[ $resolution ] ) ) {
+				$this->css[ $resolution ] = array();
+			}
+			if ( empty( $this->css[ $resolution ][ $attribute_string ] ) ) {
+				$this->css[ $resolution ][ $attribute_string ] = array();
+			}
+			
+			$this->css[ $resolution ][ $attribute_string ][] = $selector;
 		}
-		if ( empty( $this->css[ $resolution ][ $attribute_string ] ) ) {
-			$this->css[ $resolution ][ $attribute_string ] = array();
-		}
-		$this->css[ $resolution ][ $attribute_string ][] = $selector;
 	}
 
 	/**


### PR DESCRIPTION
Related https://github.com/siteorigin/siteorigin-premium/pull/395#issuecomment-635546170

This PR will prevent an issue where the generated CSS will have selectors with no attributes set. It'll prevent the following situation:

![](https://user-images.githubusercontent.com/17275120/83111784-73a19100-a108-11ea-9e7e-010a775c63b3.png)
