### PR TITLE
Prevent boolean values from being used as widget description

### DIFF
--- a/js/siteorigin-panels/model/widget.js
+++ b/js/siteorigin-panels/model/widget.js
@@ -183,6 +183,8 @@ module.exports = Backbone.Model.extend( {
 				_.isString( values[titleFields[i]] ) &&
 				values[titleFields[i]] !== '' &&
 				values[titleFields[i]] !== 'on' &&
+				values[titleFields[i]] !== 'true' &&
+				values[titleFields[i]] !== 'false' &&
 				titleFields[i][0] !== '_' && ! jQuery.isNumeric( values[titleFields[i]] )
 			) {
 				var title = values[titleFields[i]];


### PR DESCRIPTION
[Related](https://github.com/siteorigin/so-widgets-bundle/pull/1051#issuecomment-636084170)

This PR will prevent booleans from being used as widget descriptions.