### PR TITLE
Add content analysis integration for Rank Math 

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -536,7 +536,7 @@ class SiteOrigin_Panels_Admin {
 					SITEORIGIN_PANELS_VERSION,
 					true
 				);
-			} else if ( defined( 'RANK_MATH_VERSION' ) && wp_script_is( 'rank-math-analyzer' ) ) {
+			} elseif ( defined( 'RANK_MATH_VERSION' ) && wp_script_is( 'rank-math-analyzer' ) ) {
 				wp_enqueue_script(
 					'so-panels-seo-compat',
 					siteorigin_panels_url( 'js/seo-compat' . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -70,8 +70,8 @@ class SiteOrigin_Panels_Admin {
 
 
 		// Enqueue Yoast compatibility
-		add_action( 'admin_print_scripts-post-new.php', array( $this, 'enqueue_yoast_compat' ), 100 );
-		add_action( 'admin_print_scripts-post.php', array( $this, 'enqueue_yoast_compat' ), 100 );
+		add_action( 'admin_print_scripts-post-new.php', array( $this, 'enqueue_seo_compat' ), 100 );
+		add_action( 'admin_print_scripts-post.php', array( $this, 'enqueue_seo_compat' ), 100 );
 
 		// Block editor specific actions
 		if ( function_exists( 'register_block_type' ) ) {
@@ -526,16 +526,26 @@ class SiteOrigin_Panels_Admin {
 		}
 	}
 
-	public function enqueue_yoast_compat(){
-        if( self::is_admin() && defined( 'WPSEO_FILE' ) && wp_script_is( 'yoast-seo-metabox' ) ) {
-            wp_enqueue_script(
-                'so-panels-yoast-compat',
-                siteorigin_panels_url( 'js/yoast-compat' . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),
-                array('jquery', 'yoast-seo-metabox' ),
-                SITEORIGIN_PANELS_VERSION,
-                true
-            );
-        }
+	public function enqueue_seo_compat(){
+		if ( self::is_admin() ) {
+			if ( defined( 'WPSEO_FILE' ) && wp_script_is( 'yoast-seo-metabox' ) ) {
+				wp_enqueue_script(
+					'so-panels-seo-compat',
+					siteorigin_panels_url( 'js/seo-compat' . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),
+					array('jquery', 'yoast-seo-metabox' ),
+					SITEORIGIN_PANELS_VERSION,
+					true
+				);
+			} else if ( defined( 'RANK_MATH_VERSION' ) && wp_script_is( 'rank-math-analyzer' ) ) {
+				wp_enqueue_script(
+					'so-panels-seo-compat',
+					siteorigin_panels_url( 'js/seo-compat' . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),
+					array('jquery', 'rank-math-analyzer' ),
+					SITEORIGIN_PANELS_VERSION,
+					true
+				);
+			}
+		}
 	}
 
 	/**

--- a/js/seo-compat.js
+++ b/js/seo-compat.js
@@ -2,17 +2,21 @@
 
 jQuery(function($){
 
-	if( typeof YoastSEO.app === 'undefined' ){
-		// Skip all this if we don't have the yoast app
-		return;
-	}
 
-	var SiteOriginYoastCompat = function() {
-		YoastSEO.app.registerPlugin( 'siteOriginYoastCompat', { status: 'ready' } );
-		YoastSEO.app.registerModification( 'content', this.contentModification, 'siteOriginYoastCompat', 5 );
+	var SiteOriginSeoCompat = function() {
+
+		if ( typeof YoastSEO !== 'undefined' ) {
+			YoastSEO.app.registerPlugin( 'SiteOriginSeoCompat', { status: 'ready' } );
+			YoastSEO.app.registerModification( 'content', this.contentModification, 'SiteOriginSeoCompat', 5 );
+		}
+
+		if ( typeof rankMathEditor !== 'undefined' ) {
+			wp.hooks.addFilter( 'rank_math_content', 'SiteOriginSeoCompat', this.contentModification );
+		}
+
 	};
 
-	SiteOriginYoastCompat.prototype.contentModification = function(data) {
+	SiteOriginSeoCompat.prototype.contentModification = function(data) {
 		if(
 			typeof window.soPanelsBuilderView !== 'undefined' &&
 			window.soPanelsBuilderView.contentPreview
@@ -48,5 +52,5 @@ jQuery(function($){
 		return data;
 	};
 
-	new SiteOriginYoastCompat();
+	new SiteOriginSeoCompat();
 });

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -779,7 +779,7 @@ module.exports = Backbone.View.extend( {
 	},
 
 	/**
-	 * Trigger a change SEO plugins
+	 * Trigger a change in SEO plugins.
 	 */
 	triggerSeoChange: function () {
 		if ( typeof YoastSEO !== 'undefined' && ! _.isNull( YoastSEO ) && ! _.isNull( YoastSEO.app.refresh ) ) {

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -775,15 +775,18 @@ module.exports = Backbone.View.extend( {
 			contentEd.fire( 'keyup' );
 		}
 
-		this.triggerYoastSeoChange();
+		this.triggerSeoChange();
 	},
 
 	/**
-	 * Trigger a change on Yoast SEO
+	 * Trigger a change SEO plugins
 	 */
-	triggerYoastSeoChange: function () {
-		if( ! _.isNull( YoastSEO ) && ! _.isNull( YoastSEO.app.refresh ) ) {
+	triggerSeoChange: function () {
+		if ( typeof YoastSEO !== 'undefined' && ! _.isNull( YoastSEO ) && ! _.isNull( YoastSEO.app.refresh ) ) {
 			YoastSEO.app.refresh();
+		}
+		if ( typeof rankMathEditor !== 'undefined' && ! _.isNull( rankMathEditor ) && ! _.isNull( rankMathEditor.refresh ) ) {
+			rankMathEditor.refresh( 'content' );
 		}
 	},
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/726

While https://github.com/siteorigin/siteorigin-panels/pull/752 indirectly helped, there were certain widget not being picked up correctly. Widgets such as the Image widget. To verify this PR helps, please add a focus keyword and then add an image with that focus keyword in the alt. In develop, the `Focus Keyword found in image alt attribute(s)` check will never pass.

I went with renaming yoast-compat.js rather than creating a new dedicated rankmath-comat.js file due to the vast amount of code that would need to be repeated.

![Screenshot_2020-06-18 Edit Page ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/84935666-62064480-b11c-11ea-9700-33f03b4735de.png)
