### PR TITLE
Add siteorigin_panels_layout_builder_supports

### DIFF
--- a/inc/widgets/layout.php
+++ b/inc/widgets/layout.php
@@ -102,9 +102,14 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 		if( ! is_string( $instance['panels_data'] ) ) {
 			$instance['panels_data'] = json_encode( $instance['panels_data'] );
 		}
-		
+
+		$builder_supports = apply_filters( 'siteorigin_panels_layout_builder_supports', array(), $instance['panels_data'] );
 		?>
-		<div class="siteorigin-page-builder-widget" id="siteorigin-page-builder-widget-<?php echo esc_attr( $form_id ) ?>" data-builder-id="<?php echo esc_attr( $form_id ) ?>" data-type="layout_widget">
+		<div class="" id="siteorigin-page-builder-widget-<?php echo esc_attr( $form_id ) ?>"
+			data-builder-id="<?php echo esc_attr( $form_id ) ?>"
+			data-type="layout_widget"
+			data-builder-supports="<?php echo esc_attr( json_encode( $builder_supports ) ) ?>"
+			>
 			<p>
 				<button class="button-secondary siteorigin-panels-display-builder" ><?php _e('Open Builder', 'siteorigin-panels') ?></button>
 			</p>

--- a/inc/widgets/layout.php
+++ b/inc/widgets/layout.php
@@ -105,7 +105,7 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 
 		$builder_supports = apply_filters( 'siteorigin_panels_layout_builder_supports', array(), $instance['panels_data'] );
 		?>
-		<div class="" id="siteorigin-page-builder-widget-<?php echo esc_attr( $form_id ) ?>"
+		<div class="siteorigin-page-builder-widget" id="siteorigin-page-builder-widget-<?php echo esc_attr( $form_id ) ?>"
 			data-builder-id="<?php echo esc_attr( $form_id ) ?>"
 			data-type="layout_widget"
 			data-builder-supports="<?php echo esc_attr( json_encode( $builder_supports ) ) ?>"

--- a/js/siteorigin-panels/jquery/setup-builder-widget.js
+++ b/js/siteorigin-panels/jquery/setup-builder-widget.js
@@ -13,7 +13,13 @@ module.exports = function ( config, force ) {
 		var widgetId = $$.closest( 'form' ).find( '.widget-id' ).val();
 
 		// Create a config for this specific widget
-		var thisConfig = $.extend(true, {}, config);
+		var thisConfig = $.extend(
+			true, 
+			{
+				builderSupports: $$.data( 'builder-supports' ),
+			},
+			config
+		);
 
 		// Exit if this isn't a real widget
 		if ( ! _.isUndefined( widgetId ) && widgetId.indexOf( '__i__' ) > - 1 ) {


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/433

Test code:

```
function so_disallow_new_widgets_layout_builder( $supports ) {
	$supports['addWidget'] = false;

	return $supports;
}
add_filter( 'siteorigin_panels_layout_builder_supports', 'so_disallow_new_widgets_layout_builder' );
```

[Possible options](https://github.com/siteorigin/siteorigin-panels/blob/develop/js/siteorigin-panels/view/builder.js#L45-L58).