### PR TITLE
Yoast Sitemap: List images added using Page Builder

### DIFF
--- a/compat/yoast-sitemap.php
+++ b/compat/yoast-sitemap.php
@@ -23,13 +23,11 @@ function siteorigin_yoast_sitemap_images_compat( $images, $post_id ) {
 		foreach ( $dom->getElementsByTagName( 'img' ) as $img ) {
 			$src = $img->getAttribute( 'src' );
 
-			if ( empty( $src ) || $src !== esc_url( $src ) ) {
-				continue;
+			if ( ! empty( $src ) && $src == esc_url( $src ) ) {
+				$images[] = array(
+					'src'   => $src,
+				);
 			}
-
-			$images[] = array(
-				'src'   => $src,
-			);
 		}
 	}
 

--- a/compat/yoast-sitemap.php
+++ b/compat/yoast-sitemap.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Returns a list of all images added using Page Builder.
+ *
+ * @param $images an array of all detected images used in the current post.
+ * @param $post_id the current post id.
+ *
+ * @return array
+ */
+function siteorigin_yoast_sitemap_images_compat( $images, $post_id ) {
+	if ( get_post_meta( $post_id, 'panels_data', true ) && class_exists( 'DOMDocument' ) ) {
+		$content = SiteOrigin_Panels::renderer()->render(
+			$post_id,
+			false
+		);
+
+		libxml_use_internal_errors( true );
+		$dom = new DOMDocument();
+		$dom->loadHTML( '<?xml encoding="UTF-8">' . $content );
+		libxml_clear_errors();
+
+		foreach ( $dom->getElementsByTagName( 'img' ) as $img ) {
+			$src = $img->getAttribute( 'src' );
+
+			if ( empty( $src ) || $src !== esc_url( $src ) ) {
+				continue;
+			}
+
+			$images[] = array(
+				'src'   => $src,
+			);
+		}
+	}
+
+	return $images;
+}
+add_filter( 'wpseo_sitemap_urlimages', 'siteorigin_yoast_sitemap_images_compat', 10, 2 );

--- a/compat/yoast-sitemap.php
+++ b/compat/yoast-sitemap.php
@@ -9,7 +9,11 @@
  * @return array
  */
 function siteorigin_yoast_sitemap_images_compat( $images, $post_id ) {
-	if ( get_post_meta( $post_id, 'panels_data', true ) && class_exists( 'DOMDocument' ) ) {
+	if (
+		get_post_meta( $post_id, 'panels_data', true ) &&
+		extension_loaded( 'xml' ) &&
+		class_exists( 'DOMDocument' )
+	) {
 		$content = SiteOrigin_Panels::renderer()->render(
 			$post_id,
 			false

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -196,6 +196,11 @@ class SiteOrigin_Panels {
 		if( class_exists('WP_Widget_Options') ) {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/widget-options.php';
 		}
+
+		// Compatibility with Yoast Sitemap.
+		if ( defined( 'WPSEO_FILE' ) ) {
+			require_once plugin_dir_path( __FILE__ ) . 'compat/yoast-sitemap.php';
+		}
 	}
 
 	/**


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/723

I used DOMDocument rather than regex as Yoast changed from regex to DOMDocument. It appears to be due to reliability issues but I wasn't able to find concrete information on this.