### PR TITLE
Layout Block: Add Support for History and Layout Builder

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -103,7 +103,10 @@ function (_Component) {
 
       var $panelsContainer = jQuery(this.panelsContainer.current);
       var config = {
-        editorType: 'standalone'
+        editorType: 'standalone',
+        loadLiveEditor: false,
+        postId: soPanelsBlockEditorAdmin.postId,
+        liveEditorPreview: soPanelsBlockEditorAdmin.liveEditor
       };
       var builderModel = new panels.model.builder();
       this.builderView = new panels.view.builder({

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -55,7 +55,10 @@ class SiteOriginPanelsLayoutBlock extends Component {
 		var $panelsContainer = jQuery( this.panelsContainer.current );
 		
 		var config = {
-			editorType: 'standalone'
+			editorType: 'standalone',
+	        loadLiveEditor: false,
+	        postId: soPanelsBlockEditorAdmin.postId,
+	        liveEditorPreview: soPanelsBlockEditorAdmin.liveEditor,
 		};
 		
 		var builderModel = new panels.model.builder();

--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -58,6 +58,8 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 				array(
 					'sanitizeUrl' => wp_nonce_url( admin_url( 'admin-ajax.php' ), 'layout-block-sanitize', '_panelsnonce' ),
 					'previewUrl' => wp_nonce_url( admin_url( 'admin-ajax.php' ), 'layout-block-preview', '_panelsnonce' ),
+					'postId' => get_the_ID(),
+					'liveEditor' => SiteOrigin_Panels::preview_url(),
 					'defaultMode' => siteorigin_panels_setting( 'layout-block-default-mode' ),
 					'showAddButton' => apply_filters( 'siteorigin_layout_block_show_add_button', $is_panels_post_type ),
 				)


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/729 Resolve https://github.com/siteorigin/siteorigin-panels/issues/730

Currently, this PR will only show the active SiteOrigin Layout block in the preview.
This PR modifies a Builder JS file so `build:dev` must be run.