### PR TITLE
Improve Page Builder Interface accessibility

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/css/admin.less
+++ b/css/admin.less
@@ -877,6 +877,7 @@
 			border-left: 1px solid #d8d8d8;
 			border-bottom: 1px solid #d8d8d8;
 
+			&:focus,
 			&:hover {
 				background: #e9e9e9;
 				.so-dialog-icon {
@@ -1849,6 +1850,10 @@
 
 			.user-select(none);
 
+			&:focus {
+				background: #eee;
+			}
+
 			h4 {
 				margin: 0;
 			}
@@ -1962,6 +1967,11 @@
 				cursor: pointer;
 
 				.box-shadow(~"inset 0 1px #FFFFFF");
+
+				&:focus {
+					border: 1px solid #007cba;
+					box-shadow: 0 0 0 1px #007cba;
+				}
 
 				.current-image {
 					height: @image_field_height;

--- a/css/admin.less
+++ b/css/admin.less
@@ -2223,6 +2223,7 @@
 				cursor: pointer;
 				color: #999;
 
+				&:focus,
 				&:hover {
 					color: #666;
 				}

--- a/css/admin.less
+++ b/css/admin.less
@@ -1359,7 +1359,8 @@
 				background: #F8F8F8;
 				.box-shadow(~"0 1px 2px rgba(0,0,0,0.075)");
 
-				&:hover {
+				&:hover,
+				&:focus {
 					border: 1px solid #BBBBBB;
 					background: #FFFFFF;
 					.box-shadow(~"0 2px 2px rgba(0,0,0,0.075)");
@@ -1521,7 +1522,8 @@
 
 				border-bottom: 1px solid #ccc;
 
-				&:hover {
+				&:hover,
+				&:focus {
 					background: #F0F0F0;
 				}
 
@@ -1657,6 +1659,13 @@
 						background: #F7F7F7;
 						border: 1px solid #d0d0d0;
 						.box-shadow(~"0 1px 1px rgba(0,0,0,0.1)");
+
+						&:hover,
+						&:focus {
+							border: 1px solid #BBBBBB;
+							background: #FFFFFF;
+							box-shadow: 0 2px 2px rgba(0,0,0,0.075);
+						}
 					}
 
 					.so-title {
@@ -1739,9 +1748,14 @@
 						border-top: 1px solid #d0d0d0;
 					}
 
-					&:hover .so-buttons {
-						visibility: visible;
+					&:hover, 
+					&:focus	{
+						.so-buttons {
+							visibility: visible;
+						}
 					}
+
+
 
 					&.selected {
 
@@ -2645,7 +2659,8 @@
 					outline: 0 !important;
 					.box-shadow(none);
 
-					&:hover {
+					&:hover,
+					&:focus {
 						background: #F0F0F0;
 						color: #444;
 					}

--- a/css/admin.less
+++ b/css/admin.less
@@ -71,6 +71,7 @@
 			text-align: center;
 		}
 
+		&:focus,
 		&:hover {
 			background: #FFFFFF;
 
@@ -416,10 +417,16 @@
 							.box-shadow(~"0 1px 1px rgba(0,0,0,0.075)");
 							.box-sizing(border-box);
 
+							&:focus,
 							&:hover {
 								border: 1px solid rgba( 255, 255, 255, 0.55 );
 								background: #fff;
 								.box-shadow(~"0 0 2px rgba(0,0,0,0.1)");
+							}
+
+							&:focus .title .actions a,
+							&:focus-within .title .actions a, {
+								display: inline-block;
 							}
 
 							.so-widget-wrapper {
@@ -1000,12 +1007,14 @@
 				.so-delete {
 					color: #a00;
 
+					&:focus,
 					&:hover {
 						background: #a00;
 						color: #FFFFFF;
 					}
 				}
 
+				.so-duplicate:focus,
 				.so-duplicate:hover {
 					text-decoration: underline;
 				}
@@ -1166,6 +1175,7 @@
 					.box-shadow(~"0 1px 2px rgba(0,0,0,0.075), inset 0 1px 0 #FFFFFF");
 					margin-bottom: 15px;
 
+					&:focus,
 					&:hover {
 						border: 1px solid #BBBBBB;
 						background: #FFFFFF;
@@ -2491,6 +2501,7 @@
 				padding: 3px 10px;
 				line-height: 1.3em;
 
+				&:focus,
 				&:hover,
 				&.so-active {
 					background: #F0F0F0;

--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -135,7 +135,7 @@ class SiteOrigin_Panels_Styles_Admin {
 
 			?>
 			<div class="style-section-wrapper">
-				<div class="style-section-head">
+				<div class="style-section-head" tabindex="0">
 					<h4><?php echo esc_html( $group['name'] ) ?></h4>
 				</div>
 				<div class="style-section-fields" style="display: none">
@@ -238,7 +238,7 @@ class SiteOrigin_Panels_Styles_Admin {
 				$fallback_field_name = 'style[' . $field_id . '_fallback]';
 
 				?>
-				<div class="so-image-selector">
+				<div class="so-image-selector" tabindex="0">
 					<div class="current-image" <?php if ( ! empty( $image ) ) {
 						echo 'style="background-image: url(' . esc_url( $image[0] ) . ');"';
 					} ?>>

--- a/js/siteorigin-panels/dialog/history.js
+++ b/js/siteorigin-panels/dialog/history.js
@@ -32,7 +32,7 @@ module.exports = panels.view.dialog.extend( {
 		this.on( 'open_dialog', this.renderHistoryEntries, this );
 
 		this.on( 'open_dialog_complete', function () {
-			this.$( '.history-entry' ).focus();
+			this.$( '.history-entry' ).trigger( 'focus' );
 		} );
 	},
 

--- a/js/siteorigin-panels/dialog/history.js
+++ b/js/siteorigin-panels/dialog/history.js
@@ -16,7 +16,13 @@ module.exports = panels.view.dialog.extend( {
 
 	events: {
 		'click .so-close': 'closeDialog',
-		'click .so-restore': 'restoreSelectedEntry'
+		'keyup .so-close': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
+		'click .so-restore': 'restoreSelectedEntry',
+		'keyup .history-entry': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 	},
 
 	initializeDialog: function () {
@@ -24,6 +30,10 @@ module.exports = panels.view.dialog.extend( {
 
 		this.on( 'open_dialog', this.setCurrentEntry, this );
 		this.on( 'open_dialog', this.renderHistoryEntries, this );
+
+		this.on( 'open_dialog_complete', function () {
+			this.$( '.history-entry' ).focus();
+		} );
 	},
 
 	render: function () {
@@ -101,7 +111,11 @@ module.exports = panels.view.dialog.extend( {
 			.prependTo( c );
 
 		// Handle loading and selecting
-		c.find( '.history-entry' ).click( function () {
+		c.find( '.history-entry' ).on( 'click', function (e) {
+			if ( e.type == 'keyup' && e.which != 13 ) {
+				return;
+			}
+
 			var $$ = jQuery( this );
 			c.find( '.history-entry' ).not( $$ ).removeClass( 'so-selected' );
 			$$.addClass( 'so-selected' );

--- a/js/siteorigin-panels/dialog/prebuilt.js
+++ b/js/siteorigin-panels/dialog/prebuilt.js
@@ -42,7 +42,7 @@ module.exports = panels.view.dialog.extend( {
 
 		this.on( 'open_dialog_complete', function () {
 			// Clear the search and re-filter the widgets when we open the dialog
-			this.$( '.so-sidebar-search' ).val( '' ).focus();
+			this.$( '.so-sidebar-search' ).val( '' ).trigger( 'focus' );
 		} );
 	},
 

--- a/js/siteorigin-panels/dialog/prebuilt.js
+++ b/js/siteorigin-panels/dialog/prebuilt.js
@@ -19,7 +19,14 @@ module.exports = panels.view.dialog.extend( {
 		'keyup .so-sidebar-search': 'searchHandler',
 
 		// The directory items
-		'click .so-screenshot, .so-title': 'directoryItemClickHandler'
+		'click .so-screenshot, .so-title': 'directoryItemClickHandler',
+		'keyup .so-directory-item': 'clickTitleOnEnter',
+	},
+
+	clickTitleOnEnter: function( e ) {
+		if ( e.which == 13 ) {
+			$( e.target ).find( '.so-title' ).trigger( 'click' );
+		}
 	},
 
 	/**
@@ -33,7 +40,10 @@ module.exports = panels.view.dialog.extend( {
 			thisView.$( '.so-status' ).removeClass( 'so-panels-loading' );
 		} );
 
-		this.on( 'button_click', this.toolbarButtonClick, this );
+		this.on( 'open_dialog_complete', function () {
+			// Clear the search and re-filter the widgets when we open the dialog
+			this.$( '.so-sidebar-search' ).val( '' ).focus();
+		} );
 	},
 
 	/**
@@ -41,7 +51,7 @@ module.exports = panels.view.dialog.extend( {
 	 */
 	render: function () {
 		this.renderDialog( this.parseDialogContent( $( '#siteorigin-panels-dialog-prebuilt' ).html(), {} ) );
-
+		this.on( 'button_click', this.toolbarButtonClick, this );
 		this.initToolbar();
 	},
 

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -8,12 +8,21 @@ module.exports = panels.view.dialog.extend({
 
 	events: {
 		'click .so-close': 'closeDialog',
+		'keyup .so-close': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 
 		// Toolbar buttons
 		'click .so-toolbar .so-save': 'saveHandler',
 		'click .so-toolbar .so-insert': 'insertHandler',
 		'click .so-toolbar .so-delete': 'deleteHandler',
+		'keyup .so-toolbar .so-delete': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 		'click .so-toolbar .so-duplicate': 'duplicateHandler',
+		'keyup .so-toolbar .so-duplicate': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 
 		// Changing the row
 		'change .row-set-form > *': 'setCellsFromForm',

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -61,6 +61,10 @@ module.exports = panels.view.dialog.extend({
 			this.openSelectedCellStyles();
 		}, this);
 
+		this.on( 'open_dialog_complete', function() {
+			$( '.so-panels-dialog-wrapper .so-title' ).trigger( 'focus' );
+		} );
+
 		// This is the default row layout
 		this.row = {
 			cells: new panels.collection.cells([{weight: 0.5}, {weight: 0.5}]),

--- a/js/siteorigin-panels/dialog/widget.js
+++ b/js/siteorigin-panels/dialog/widget.js
@@ -66,6 +66,18 @@ module.exports = panels.view.dialog.extend( {
 				this.$( '.so-title' ).text( this.model.getWidgetField( 'title' ) );
 			}
 		}.bind( this ) );
+
+		this.on( 'open_dialog_complete', function() {
+			// The form isn't always ready when this event fires.
+			setTimeout( function() {
+				var focusTarget = $( '.so-content .siteorigin-widget-field-repeater-item-top, .so-content input, .so-content select' ).first();
+				if ( focusTarget.length ) {
+					focusTarget.trigger( 'focus' );
+				} else {
+					$( '.so-panels-dialog-wrapper .so-title' ).trigger( 'focus' );
+				}
+			}, 1250 )
+		} );
 	},
 
 	/**

--- a/js/siteorigin-panels/dialog/widget.js
+++ b/js/siteorigin-panels/dialog/widget.js
@@ -15,12 +15,27 @@ module.exports = panels.view.dialog.extend( {
 
 	events: {
 		'click .so-close': 'saveHandler',
+		'keyup .so-close': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 		'click .so-nav.so-previous': 'navToPrevious',
+		'keyup .so-nav.so-previous': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 		'click .so-nav.so-next': 'navToNext',
+		'keyup .so-nav.so-next': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 
 		// Action handlers
 		'click .so-toolbar .so-delete': 'deleteHandler',
-		'click .so-toolbar .so-duplicate': 'duplicateHandler'
+		'keyup .so-toolbar .so-delete': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
+		'click .so-toolbar .so-duplicate': 'duplicateHandler',
+		'keyup .so-toolbar .so-duplicate': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 	},
 
 	initializeDialog: function () {

--- a/js/siteorigin-panels/dialog/widgets.js
+++ b/js/siteorigin-panels/dialog/widgets.js
@@ -12,7 +12,11 @@ module.exports = panels.view.dialog.extend( {
 	events: {
 		'click .so-close': 'closeDialog',
 		'click .widget-type': 'widgetClickHandler',
-		'keyup .so-sidebar-search': 'searchHandler'
+		'keyup .so-sidebar-search': 'searchHandler',
+		'keyup .widget-type-wrapper': 'searchHandler',
+		'keyup .widget-type-wrapper': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 	},
 
 	/**
@@ -24,6 +28,7 @@ module.exports = panels.view.dialog.extend( {
 			this.filter.search = '';
 			this.filterWidgets( this.filter );
 		}, this );
+
 
 		this.on( 'open_dialog_complete', function () {
 			// Clear the search and re-filter the widgets when we open the dialog

--- a/js/siteorigin-panels/helpers/accessibility.js
+++ b/js/siteorigin-panels/helpers/accessibility.js
@@ -6,7 +6,7 @@ module.exports = {
 	 */
 	triggerClickOnEnter: function( e ) {
 		if ( e.which == 13 ) {
-			$(e.target).trigger('click');
+			$( e.target ).trigger( 'click' );
 		}
 	},
 

--- a/js/siteorigin-panels/helpers/accessibility.js
+++ b/js/siteorigin-panels/helpers/accessibility.js
@@ -1,0 +1,13 @@
+var $ = jQuery;
+
+module.exports = {
+	/**
+	 * Trigger click on valid enter key press.
+	 */
+	triggerClickOnEnter: function( e ) {
+		if ( e.which == 13 ) {
+			$(e.target).trigger('click');
+		}
+	},
+
+};

--- a/js/siteorigin-panels/main.js
+++ b/js/siteorigin-panels/main.js
@@ -19,6 +19,7 @@ panels.helpers.clipboard = require( './helpers/clipboard' );
 panels.helpers.utils = require( './helpers/utils' );
 panels.helpers.serialize = require( './helpers/serialize' );
 panels.helpers.pageScroll = require( './helpers/page-scroll' );
+panels.helpers.accessibility = require( './helpers/accessibility' );
 
 // The models
 panels.model = {};

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -249,7 +249,7 @@ module.exports = Backbone.View.extend( {
 
 		// Switch back to the standard editor
 		if ( this.supports( 'revertToEditor' ) ) {
-			metabox.find( '.so-switch-to-standard' ).on( 'click keyup', function ( e ) {
+			metabox.find( '.so-switch-to-standard' ).on( 'click keyup', function( e ) {
 				e.preventDefault();
 
 				if ( e.type == "keyup" && e.which != 13 ) {

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -24,7 +24,10 @@ module.exports = Backbone.View.extend( {
 		'click .so-tool-button.so-row-add': 'displayAddRowDialog',
 		'click .so-tool-button.so-prebuilt-add': 'displayAddPrebuiltDialog',
 		'click .so-tool-button.so-history': 'displayHistoryDialog',
-		'click .so-tool-button.so-live-editor': 'displayLiveEditor'
+		'click .so-tool-button.so-live-editor': 'displayLiveEditor',
+		'keyup .so-tool-button': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 	},
 
 	/* A row collection */
@@ -110,7 +113,6 @@ module.exports = Backbone.View.extend( {
 				this.displayAttachedBuilder( { confirm: false } );
 			}, this );
 		}
-
 		return this;
 	},
 
@@ -247,8 +249,12 @@ module.exports = Backbone.View.extend( {
 
 		// Switch back to the standard editor
 		if ( this.supports( 'revertToEditor' ) ) {
-			metabox.find( '.so-switch-to-standard' ).click( function ( e ) {
+			metabox.find( '.so-switch-to-standard' ).on( 'click keyup', function ( e ) {
 				e.preventDefault();
+
+				if ( e.type == "keyup" && e.which != 13 ) {
+					return
+				}
 
 				if ( !confirm( panelsOptions.loc.confirm_stop_builder ) ) {
 					return;

--- a/js/siteorigin-panels/view/dialog.js
+++ b/js/siteorigin-panels/view/dialog.js
@@ -16,8 +16,17 @@ module.exports = Backbone.View.extend( {
 
 	events: {
 		'click .so-close': 'closeDialog',
+		'keyup .so-close': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 		'click .so-nav.so-previous': 'navToPrevious',
+		'keyup .so-nav.so-previous': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 		'click .so-nav.so-next': 'navToNext',
+		'keyup .so-nav.so-next': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 	},
 
 	initialize: function () {
@@ -311,16 +320,20 @@ module.exports = Backbone.View.extend( {
 
 		if ( nextDialog === null ) {
 			nextButton.hide();
-		}
-		else if ( nextDialog === false ) {
+		} else if ( nextDialog === false ) {
 			nextButton.addClass( 'so-disabled' );
+			nextButton.attr( 'tabindex', -1 );
+		} else {
+			nextButton.attr( 'tabindex', 0 );
 		}
 
 		if ( prevDialog === null ) {
 			prevButton.hide();
-		}
-		else if ( prevDialog === false ) {
+		} else if ( prevDialog === false ) {
 			prevButton.addClass( 'so-disabled' );
+			prevButton.attr( 'tabindex', -1 );
+		} else {
+			prevButton.attr( 'tabindex', 0 );
 		}
 	},
 

--- a/js/siteorigin-panels/view/dialog.js
+++ b/js/siteorigin-panels/view/dialog.js
@@ -212,8 +212,12 @@ module.exports = Backbone.View.extend( {
 	initToolbar: function () {
 		// Trigger simplified click event for elements marked as toolbar buttons.
 		var buttons = this.$( '.so-toolbar .so-buttons .so-toolbar-button' );
-		buttons.click( function ( e ) {
+		buttons.on( 'click keyup', function ( e ) {
 			e.preventDefault();
+
+			if ( e.type == 'keyup' && e.which != 13 ) {
+				return;
+			}
 
 			this.trigger( 'button_click', $( e.currentTarget ) );
 		}.bind( this ) );

--- a/js/siteorigin-panels/view/live-editor.js
+++ b/js/siteorigin-panels/view/live-editor.js
@@ -111,7 +111,7 @@ module.exports = Backbone.View.extend( {
 		this.$el.show();
 		this.refreshPreview( this.builder.model.getPanelsData() );
 
-		$( '.live-editor-close' ).focus();
+		$( '.live-editor-close' ).trigger( 'focus' );
 
 		// Move the builder view into the Live Editor
 		this.originalContainer = this.builder.$el.parent();

--- a/js/siteorigin-panels/view/live-editor.js
+++ b/js/siteorigin-panels/view/live-editor.js
@@ -14,7 +14,10 @@ module.exports = Backbone.View.extend( {
 		'click .live-editor-close': 'close',
 		'click .live-editor-save': 'closeAndSave',
 		'click .live-editor-collapse': 'collapse',
-		'click .live-editor-mode': 'mobileToggle'
+		'click .live-editor-mode': 'mobileToggle',
+		'keyup .live-editor-mode': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 	},
 
 	initialize: function ( options ) {
@@ -57,7 +60,8 @@ module.exports = Backbone.View.extend( {
 
 		// Handle highlighting the relevant widget in the live editor preview
 		var liveEditorView = this;
-		this.$el.on( 'mouseenter', '.so-widget-wrapper', function () {
+
+		this.$el.on( 'mouseenter focusin', '.so-widget', function () {
 			var $$ = $( this ),
 				previewWidget = $$.data( 'live-editor-preview-widget' );
 
@@ -67,7 +71,7 @@ module.exports = Backbone.View.extend( {
 			}
 		} );
 
-		this.$el.on( 'mouseleave', '.so-widget-wrapper', function () {
+		this.$el.on( 'mouseleave focusout', '.so-widget', function () {
 			this.resetHighlights();
 		}.bind(this) );
 
@@ -106,6 +110,8 @@ module.exports = Backbone.View.extend( {
 		// Refresh the preview display
 		this.$el.show();
 		this.refreshPreview( this.builder.model.getPanelsData() );
+
+		$( '.live-editor-close' ).focus();
 
 		// Move the builder view into the Live Editor
 		this.originalContainer = this.builder.$el.parent();
@@ -366,7 +372,7 @@ module.exports = Backbone.View.extend( {
 					} )
 					.each( function ( i, el ) {
 						var $$ = $( el );
-						var widgetEdit = thisView.$( '.so-live-editor-builder .so-widget-wrapper' ).eq( $$.data( 'index' ) );
+						var widgetEdit = thisView.$( '.so-live-editor-builder .so-widget' ).eq( $$.data( 'index' ) );
 						widgetEdit.data( 'live-editor-preview-widget', $$ );
 
 						$$

--- a/js/siteorigin-panels/view/styles.js
+++ b/js/siteorigin-panels/view/styles.js
@@ -4,6 +4,14 @@ module.exports = Backbone.View.extend( {
 
 	stylesLoaded: false,
 
+	events: {
+		'keyup .so-image-selector': function( e ) {
+			if ( e.which == 13 ) {
+				this.$el.find( '.select-image' ).trigger( 'click' );
+			}
+		},
+	},
+
 	initialize: function () {
 
 	},
@@ -99,7 +107,7 @@ module.exports = Backbone.View.extend( {
 		this.$( '.style-section-wrapper' ).each( function () {
 			var $s = $( this );
 
-			$s.find( '.style-section-head' ).click( function ( e ) {
+			$s.find( '.style-section-head' ).on( 'click keypress', function ( e ) {
 				e.preventDefault();
 				$s.find( '.style-section-fields' ).slideToggle( 'fast' );
 			} );
@@ -164,8 +172,10 @@ module.exports = Backbone.View.extend( {
 					} );
 				}
 
-				frame.open();
+				// Prevent loop that occurs if you close the frame using the close button while focused on the trigger.
+				$( this ).next().focus();
 
+				frame.open();
 			} );
 
 			// Handle clicking on remove

--- a/js/siteorigin-panels/view/widget.js
+++ b/js/siteorigin-panels/view/widget.js
@@ -13,7 +13,10 @@ module.exports = Backbone.View.extend( {
 		'click .widget-edit': 'editHandler',
 		'click .title h4': 'editHandler',
 		'click .actions .widget-duplicate': 'duplicateHandler',
-		'click .actions .widget-delete': 'deleteHandler'
+		'click .actions .widget-delete': 'deleteHandler',
+		'keyup .actions a': function( e ) {
+			panels.helpers.accessibility.triggerClickOnEnter( e );
+		},
 	},
 
 	/**

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -9,29 +9,29 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 
 		<div class="so-builder-toolbar">
 
-			<a class="so-tool-button so-widget-add" title="<?php esc_attr_e( 'Add Widget', 'siteorigin-panels' ) ?>">
+			<a class="so-tool-button so-widget-add" title="<?php esc_attr_e( 'Add Widget', 'siteorigin-panels' ) ?>" tabindex="0">
 				<span class="so-panels-icon so-panels-icon-add-widget"></span>
 				<span class="so-button-text"><?php esc_html_e('Add Widget', 'siteorigin-panels') ?></span>
 			</a>
 
-			<a class="so-tool-button so-row-add" title="<?php esc_attr_e( 'Add Row', 'siteorigin-panels' ) ?>">
+			<a class="so-tool-button so-row-add" title="<?php esc_attr_e( 'Add Row', 'siteorigin-panels' ) ?>" tabindex="0">
 				<span class="so-panels-icon so-panels-icon-add-row"></span>
 				<span class="so-button-text"><?php esc_html_e('Add Row', 'siteorigin-panels') ?></span>
 			</a>
 
-			<a class="so-tool-button so-prebuilt-add" title="<?php esc_attr_e( 'Prebuilt Layouts', 'siteorigin-panels' ) ?>">
+			<a class="so-tool-button so-prebuilt-add" title="<?php esc_attr_e( 'Prebuilt Layouts', 'siteorigin-panels' ) ?>" tabindex="0">
 				<span class="so-panels-icon so-panels-icon-layouts"></span>
 				<span class="so-button-text"><?php esc_html_e('Layouts', 'siteorigin-panels') ?></span>
 			</a>
 
 			<?php if( !empty($post) ) : ?>
 
-				<a class="so-tool-button so-history" style="display: none" title="<?php esc_attr_e( 'Edit History', 'siteorigin-panels' ) ?>">
+				<a class="so-tool-button so-history" style="display: none" title="<?php esc_attr_e( 'Edit History', 'siteorigin-panels' ) ?>" tabindex="0">
 					<span class="so-panels-icon so-panels-icon-history"></span>
 					<span class="so-button-text"><?php _e('History', 'siteorigin-panels') ?></span>
 				</a>
 
-				<a class="so-tool-button so-live-editor" style="display: none" title="<?php esc_html_e( 'Live Editor', 'siteorigin-panels' ) ?>">
+				<a class="so-tool-button so-live-editor" style="display: none" title="<?php esc_html_e( 'Live Editor', 'siteorigin-panels' ) ?>" tabindex="0">
 					<span class="so-panels-icon so-panels-icon-live-editor"></span>
 					<span class="so-button-text"><?php _e('Live Editor', 'siteorigin-panels') ?></span>
 				</a>
@@ -39,13 +39,13 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 			<?php endif; ?>
 
 			<?php if( SiteOrigin_Panels::display_premium_teaser() ) : ?>
-				<a class="so-tool-button so-learn" title="<?php esc_attr_e( 'Page Builder Addons', 'siteorigin-panels' ) ?>" href="<?php echo esc_url( SiteOrigin_Panels::premium_url() ) ?>" target="_blank" rel="noopener noreferrer" style="margin-left: 10px;">
+				<a class="so-tool-button so-learn" title="<?php esc_attr_e( 'Page Builder Addons', 'siteorigin-panels' ) ?>" href="<?php echo esc_url( SiteOrigin_Panels::premium_url() ) ?>" target="_blank" rel="noopener noreferrer" style="margin-left: 10px;" tabindex="0">
 					<span class="so-panels-icon so-panels-icon-addons"></span>
 					<span class="so-button-text"><?php esc_html_e( 'Addons', 'siteorigin-panels' ) ?></span>
 				</a>
 			<?php endif; ?>
 			
-			<a class="so-switch-to-standard"><?php _e('Revert to Editor', 'siteorigin-panels') ?></a>
+			<a class="so-switch-to-standard" tabindex="0"><?php _e('Revert to Editor', 'siteorigin-panels') ?></a>
 
 		</div>
 
@@ -88,7 +88,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 			<span class="so-row-move so-tool-button"><span class="so-panels-icon so-panels-icon-move"></span></span>
 
 			<span class="so-dropdown-wrapper">
-				<a class="so-row-settings so-tool-button"><span class="so-panels-icon so-panels-icon-settings"></span></a>
+				<a class="so-row-settings so-tool-button" tabindex="0"><span class="so-panels-icon so-panels-icon-settings"></span></a>
 
 				<div class="so-dropdown-links-wrapper">
 					<ul>
@@ -133,14 +133,14 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 </script>
 
 <script type="text/template" id="siteorigin-panels-builder-widget">
-	<div class="so-widget ui-draggable" data-widget-class="{{%- widget_class %}}">
+	<div class="so-widget ui-draggable" tabindex="0" data-widget-class="{{%- widget_class %}}">
 		<div class="so-widget-wrapper">
 			<div class="title">
 				<h4>{{%= title %}}</h4>
 				<span class="actions">
-					<a class="widget-edit"><?php _e('Edit', 'siteorigin-panels') ?></a>
-					<a class="widget-duplicate"><?php _e('Duplicate', 'siteorigin-panels') ?></a>
-					<a class="widget-delete"><?php _e('Delete', 'siteorigin-panels') ?></a>
+					<a class="widget-edit" tabindex="0"><?php _e('Edit', 'siteorigin-panels') ?></a>
+					<a class="widget-duplicate" tabindex="0"><?php _e('Duplicate', 'siteorigin-panels') ?></a>
+					<a class="widget-delete" tabindex="0"><?php _e('Delete', 'siteorigin-panels') ?></a>
 				</span>
 			</div>
 			<small class="description">{{%= description %}}</small>

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -165,7 +165,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 				<a class="so-previous so-nav"><span class="so-dialog-icon"></span></a>
 				<a class="so-next so-nav"><span class="so-dialog-icon"></span></a>
 				<a class="so-show-right-sidebar"><span class="so-dialog-icon"></span></a>
-				<a class="so-close"><span class="so-dialog-icon"></span></a>
+				<a class="so-close" tabindex="0"><span class="so-dialog-icon"></span></a>
 			</div>
 		</div>
 

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -555,13 +555,13 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 			><?php esc_html_e('Update', 'siteorigin-panels') ?></button>
 			<button class="live-editor-close button-secondary"><?php esc_html_e('Close', 'siteorigin-panels') ?></button>
 
-			<a class="live-editor-mode live-editor-desktop so-active" title="<?php esc_attr_e( 'Toggle desktop mode', 'siteorigin-panels' ) ?>" data-mode="desktop" data-width="100%" >
+			<a class="live-editor-mode live-editor-desktop so-active" title="<?php esc_attr_e( 'Toggle desktop mode', 'siteorigin-panels' ) ?>" data-mode="desktop" data-width="100%"  tabindex="0">
 				<span class="dashicons dashicons-desktop"></span>
 			</a>
-			<a class="live-editor-mode live-editor-tablet" title="<?php esc_attr_e( 'Toggle tablet mode', 'siteorigin-panels' ) ?>" data-mode="tablet" data-width="720px">
+			<a class="live-editor-mode live-editor-tablet" title="<?php esc_attr_e( 'Toggle tablet mode', 'siteorigin-panels' ) ?>" data-mode="tablet" data-width="720px" tabindex="0">
 				<span class="dashicons dashicons-tablet"></span>
 			</a>
-			<a class="live-editor-mode live-editor-mobile" title="<?php esc_attr_e( 'Toggle mobile mode', 'siteorigin-panels' ) ?>" data-mode="mobile" data-width="320px">
+			<a class="live-editor-mode live-editor-mobile" title="<?php esc_attr_e( 'Toggle mobile mode', 'siteorigin-panels' ) ?>" data-mode="mobile" data-width="320px" tabindex="0">
 				<span class="dashicons dashicons-smartphone"></span>
 			</a>
 

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -203,7 +203,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 		</div>
 
 		<div class="buttons">
-			<input type="button" class="button-primary so-close" value="<?php esc_attr_e('Done', 'siteorigin-panels') ?>" />
+			<input type="button" class="button-primary so-close" tabindex="0" value="<?php esc_attr_e('Done', 'siteorigin-panels') ?>" />
 		</div>
 
 	</div>
@@ -233,7 +233,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 		</div>
 
 		<div class="buttons">
-			<input type="button" class="button-primary so-close" value="<?php esc_attr_e('Close', 'siteorigin-panels') ?>" />
+			<input type="button" class="button-primary so-close" tabindex="0" value="<?php esc_attr_e('Close', 'siteorigin-panels') ?>" />
 		</div>
 
 	</div>
@@ -264,11 +264,11 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 
 		<div class="buttons">
 			<div class="action-buttons">
-				<a class="so-delete"><?php _e('Delete', 'siteorigin-panels') ?></a>
-				<a class="so-duplicate"><?php _e('Duplicate', 'siteorigin-panels') ?></a>
+				<a class="so-delete" tabindex="0"><?php _e('Delete', 'siteorigin-panels') ?></a>
+				<a class="so-duplicate" tabindex="0"><?php _e('Duplicate', 'siteorigin-panels') ?></a>
 			</div>
 
-			<input type="button" class="button-primary so-close" value="<?php esc_attr_e('Done', 'siteorigin-panels') ?>" />
+			<input type="button" class="button-primary so-close" tabindex="0" value="<?php esc_attr_e('Done', 'siteorigin-panels') ?>" />
 		</div>
 
 	</div>
@@ -349,15 +349,15 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 		<div class="buttons">
 			{{% if( dialogType == 'edit' ) { %}}
 				<div class="action-buttons">
-					<a class="so-delete"><?php _e('Delete', 'siteorigin-panels') ?></a>
-					<a class="so-duplicate"><?php _e('Duplicate', 'siteorigin-panels') ?></a>
+					<a class="so-delete" tabindex="0"><?php _e('Delete', 'siteorigin-panels') ?></a>
+					<a class="so-duplicate" tabindex="0"><?php _e('Duplicate', 'siteorigin-panels') ?></a>
 				</div>
 			{{% } %}}
 
 			{{% if( dialogType == 'create' ) { %}}
-				<input type="button" class="button-primary so-insert" value="<?php esc_attr_e('Insert', 'siteorigin-panels') ?>" />
+				<input type="button" class="button-primary so-insert" tabindex="0" value="<?php esc_attr_e('Insert', 'siteorigin-panels') ?>" />
 			{{% } else { %}}
-				<input type="button" class="button-primary so-save" value="<?php esc_attr_e('Done', 'siteorigin-panels') ?>" />
+				<input type="button" class="button-primary so-save" tabindex="0" value="<?php esc_attr_e('Done', 'siteorigin-panels') ?>" />
 			{{% } %}}
 		</div>
 
@@ -367,7 +367,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 <script type="text/template" id="siteorigin-panels-dialog-row-cell-preview">
 	<div class="preview-cell" style="width: {{%- weight*100 %}}%">
 		<div class="preview-cell-in">
-			<div class="preview-cell-weight">{{% print(Math.round(weight * 1000) / 10) %}}</div>
+			<div class="preview-cell-weight" tabIndex="0">{{% print(Math.round(weight * 1000) / 10) %}}</div>
 		</div>
 	</div>
 </script>

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -159,7 +159,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 				<div class="so-panels-icon so-panels-icon-{{%- dialogIcon %}}"></div>
 			{{% } %}}
 			<h3 class="so-title{{% if ( editableLabel ) print(' so-title-editable')%}}"
-			    {{% if ( editableLabel ) print('contenteditable="true" spellcheck="false" tabIndex="1"')%}}
+			    {{% if ( editableLabel ) print('contenteditable="true" spellcheck="false" tabIndex="0"')%}}
 				>{{%= title %}}</h3>
 			<div class="so-title-bar-buttons">
 				<a class="so-previous so-nav"><span class="so-dialog-icon"></span></a>

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -169,13 +169,6 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 			</div>
 		</div>
 
-		<div class="so-toolbar">
-			<div class="so-status">{{% if(typeof status != 'undefined') print(status); %}}</div>
-			<div class="so-buttons">
-				{{%= buttons %}}
-			</div>
-		</div>
-
 		<div class="so-sidebar so-left-sidebar">
 			{{% if(typeof left_sidebar  != 'undefined') print(left_sidebar ); %}}
 		</div>
@@ -186,6 +179,13 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 
 		<div class="so-content panel-dialog">
 			{{%= content %}}
+		</div>
+
+		<div class="so-toolbar">
+			<div class="so-status">{{% if(typeof status != 'undefined') print(status); %}}</div>
+			<div class="so-buttons">
+				{{%= buttons %}}
+			</div>
 		</div>
 
 	</div>
@@ -241,7 +241,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 
 <script type="text/template" id="siteorigin-panels-dialog-widgets-widget">
 	<li class="widget-type">
-		<div class="widget-type-wrapper">
+		<div class="widget-type-wrapper" tabindex="0">
 			<h3>{{%= title %}}</h3>
 			<small class="description">{{%= description %}}</small>
 		</div>
@@ -417,9 +417,9 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 
 				<div class="so-dropdown-links-wrapper hidden">
 					<ul class="so-layout-position">
-						<li><a class="so-toolbar-button" data-value="after"><?php esc_html_e('Insert after', 'siteorigin-panels') ?></a></li>
-						<li><a class="so-toolbar-button" data-value="before"><?php esc_html_e('Insert before', 'siteorigin-panels') ?></a></li>
-						<li><a class="so-toolbar-button so-needs-confirm" data-value="replace" data-confirm="<?php esc_attr_e('Are you sure?', 'siteorigin-panels') ?>"><?php esc_html_e('Replace current', 'siteorigin-panels') ?></a></li>
+						<li><a class="so-toolbar-button" data-value="after" tabindex="0"><?php esc_html_e('Insert after', 'siteorigin-panels') ?></a></li>
+						<li><a class="so-toolbar-button" data-value="before" tabindex="0"><?php esc_html_e('Insert before', 'siteorigin-panels') ?></a></li>
+						<li><a class="so-toolbar-button so-needs-confirm" data-value="replace" data-confirm="<?php esc_attr_e('Are you sure?', 'siteorigin-panels') ?>" tabindex="0"><?php esc_html_e('Replace current', 'siteorigin-panels') ?></a></li>
 					</ul>
 				</div>
 			</span>
@@ -449,7 +449,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 			{{% } else { %}}
 				{{% _.each(items, function(item) { %}}
 					<div class="so-directory-item" data-layout-id="{{%- item.id %}}" data-layout-type="{{%- item.type %}}">
-						<div class="so-directory-item-wrapper">
+						<div class="so-directory-item-wrapper" tabindex="0">
 							<div class="so-screenshot" data-src="{{%- item.screenshot %}}">
 								<div class="so-panels-loading so-screenshot-wrapper"></div>
 							</div>
@@ -534,7 +534,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 </script>
 
 <script type="text/template" id="siteorigin-panels-dialog-history-entry">
-	<div class="history-entry">
+	<div class="history-entry" tabindex="0">
 		<h3>{{%= title %}}{{% if( count > 1 ) { %}} <span class="count">({{%= count %}})</span>{{% } %}}</h3>
 		<div class="timesince"></div>
 	</div>


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/765

Status (pending approval):
- [x] Navigating page builder rows, and columns
- [x] Add Widgets view
- [x] Layouts view
- [x] History
- [x] Live Editor
- [x] Row/Widget interface navigation
- [x] Widget contents navigation https://github.com/siteorigin/so-widgets-bundle/pull/1206

Note:
- There's no way to reorder widgets or rows. This needs further investigation and will be implemented in a future PR.