### PR TITLE
Resolve AMP Editing Issue

### DIFF
--- a/compat/amp.php
+++ b/compat/amp.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Add AMP Text widget as a Core JS Widget.
+ *
+ * @param $panels_data
+ *
+ * @return mixed
+ */
+function siteorigin_panels_add_amp_text( $widgets ) {
+	$widgets[] = 'AMP_Widget_Text';
+
+	return $widgets;
+}
+add_filter( 'siteorigin_panels_core_js_widgets', 'siteorigin_panels_add_amp_text' );

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -83,11 +83,6 @@ class SiteOrigin_Panels_Admin {
 				add_filter( 'display_post_states', array( $this, 'add_panels_post_state' ), 10, 2 );
 			}
 		}
-
-		// Compatibility with AMP plugin
-		if ( function_exists( 'amp_bootstrap_plugin' ) ) {
-			require_once plugin_dir_path( __FILE__ ) . '../compat/amp.php';
-		}
 	}
 
 	/**

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1024,14 +1024,14 @@ class SiteOrigin_Panels_Admin {
 	function is_core_js_widget( $widget ) {
 		$js_widgets = apply_filters(
 			'siteorigin_panels_core_js_widgets',
-				array(
-					'WP_Widget_Custom_HTML',
-					'WP_Widget_Media_Audio',
-					'WP_Widget_Media_Gallery',
-					'WP_Widget_Media_Image',
-					'WP_Widget_Media_Video',
-					'WP_Widget_Text',
-				),
+			array(
+				'WP_Widget_Custom_HTML',
+				'WP_Widget_Media_Audio',
+				'WP_Widget_Media_Gallery',
+				'WP_Widget_Media_Image',
+				'WP_Widget_Media_Video',
+				'WP_Widget_Text',
+			)
 		);
 
 		$is_js_widget = in_array( get_class( $widget ), $js_widgets ) &&

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1022,13 +1022,16 @@ class SiteOrigin_Panels_Admin {
 	 * @return bool Whether or not the widget is considered a JS widget.
 	 */
 	function is_core_js_widget( $widget ) {
-		$js_widgets = array(
-			'WP_Widget_Custom_HTML',
-			'WP_Widget_Media_Audio',
-			'WP_Widget_Media_Gallery',
-			'WP_Widget_Media_Image',
-			'WP_Widget_Media_Video',
-			'WP_Widget_Text',
+		$js_widgets = apply_filters(
+			'siteorigin_panels_core_js_widgets',
+				array(
+					'WP_Widget_Custom_HTML',
+					'WP_Widget_Media_Audio',
+					'WP_Widget_Media_Gallery',
+					'WP_Widget_Media_Image',
+					'WP_Widget_Media_Video',
+					'WP_Widget_Text',
+				),
 		);
 
 		$is_js_widget = in_array( get_class( $widget ), $js_widgets ) &&

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -83,6 +83,11 @@ class SiteOrigin_Panels_Admin {
 				add_filter( 'display_post_states', array( $this, 'add_panels_post_state' ), 10, 2 );
 			}
 		}
+
+		// Compatibility with AMP plugin
+		if ( function_exists( 'amp_bootstrap_plugin' ) ) {
+			require_once plugin_dir_path( __FILE__ ) . '../compat/amp.php';
+		}
 	}
 
 	/**

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -30,6 +30,7 @@ class SiteOrigin_Panels {
 
 		add_action( 'plugins_loaded', array( $this, 'version_check' ) );
 		add_action( 'plugins_loaded', array( $this, 'init' ) );
+		add_action( 'plugins_loaded', array( $this, 'init_compat' ), 100 );
 		add_action( 'admin_bar_menu', array( $this, 'admin_bar_menu' ), 100 );
 		
 		add_action('widgets_init', array( $this, 'widgets_init' ) );
@@ -191,10 +192,20 @@ class SiteOrigin_Panels {
 		if ( is_admin() ) {
 			SiteOrigin_Panels_Admin::single();
 		}
-		
+	}
+
+	/**
+	 * Loads Page Builder compatibility to allow other plugins/themes
+	 */
+	public function init_compat() {
 		// Compatibility with Widget Options plugin
-		if( class_exists('WP_Widget_Options') ) {
+		if ( class_exists( 'WP_Widget_Options' ) ) {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/widget-options.php';
+		}
+
+		// Compatibility with AMP plugin
+		if ( is_admin() && function_exists( 'amp_bootstrap_plugin' ) ) {
+			require_once plugin_dir_path( __FILE__ ) . 'compat/amp.php';
 		}
 	}
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/737

The AMP plugin overrides the text widget and extends the base text widget class to do this ([reference](https://github.com/ampproject/amp-wp/blob/6935c0c015e52fc58b27c4790348bae56522c875/includes/widgets/class-amp-widget-text.php)). The text widget requires its JS to be directly output so this PR adds the AMP widget as a Core JS widget.