### PR TITLE
Layout Block: Prevent Block Editor Saving until Json loaded

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -278,6 +278,7 @@ registerBlockType('siteorigin-panels/layout-block', {
     var onLayoutBlockContentChange = function onLayoutBlockContentChange(newPanelsData) {
       if (!_.isEmpty(newPanelsData.widgets)) {
         // Send panelsData to server for sanitization.
+        wp.data.dispatch('core/editor').lockPostSaving();
         jQuery.post(panelsOptions.ajaxurl, {
           action: 'so_panels_builder_content_json',
           panels_data: JSON.stringify(newPanelsData),
@@ -294,6 +295,7 @@ registerBlockType('siteorigin-panels/layout-block', {
           }
 
           setAttributes(panelsAttributes);
+          wp.data.dispatch('core/editor').unlockPostSaving();
         });
       }
     };

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -241,6 +241,7 @@ registerBlockType( 'siteorigin-panels/layout-block', {
 			
 			if ( !_.isEmpty( newPanelsData.widgets ) ) {
 				// Send panelsData to server for sanitization.
+				wp.data.dispatch( 'core/editor' ).lockPostSaving();
 				jQuery.post(
 					panelsOptions.ajaxurl,
 					{
@@ -258,6 +259,7 @@ registerBlockType( 'siteorigin-panels/layout-block', {
 						}
 						
 						setAttributes( panelsAttributes );
+						wp.data.dispatch( 'core/editor' ).unlockPostSaving(); 
 					}
 				);
 			}


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/715

This PR will prevent the user from being able to save the page until Page Builder has loaded the new layouts json and stored it.