### PR TITLE
Fix "undefined" Page Builder tab issue in WP 5.5

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -18,7 +18,9 @@
 
 		margin-top: 20px;
 
-		.hndle, .handlediv {
+		.postbox-header,
+		.hndle,
+		.handlediv {
 			display: none !important;
 		}
 

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -237,7 +237,7 @@ module.exports = Backbone.View.extend( {
 			thisView.trigger( 'hide_builder' );
 		} ).end()
 		.append(
-			$( '<button type="button" id="content-panels" class="hide-if-no-js wp-switch-editor switch-panels">' + metabox.find( '.hndle span' ).html() + '</button>' )
+			$( '<button type="button" id="content-panels" class="hide-if-no-js wp-switch-editor switch-panels">' + metabox.find( 'h2.hndle' ).html() + '</button>' )
 			.click( function ( e ) {
 				if ( thisView.displayAttachedBuilder( { confirm: true } ) ) {
 					e.preventDefault();


### PR DESCRIPTION
This PR resolves a few issues with the page builder interface in WP 5.5. 

Fix "undefined" Page Builder tab issue in WP 5.5
![Add_New_Page_‹_SiteOrigin_—_WordPress](https://user-images.githubusercontent.com/17275120/87054969-16d8e080-c247-11ea-9f52-eeaf50bc6b4c.jpg)

Fix "undefined" Page Builder tab issue in WP 5.5. For whatever reason, the span inside of the h2 was removed in WordPress 5.5. Removing the span from the selector resolves this issue and results in no adverse effects in either version of WP.