### PR TITLE
Add "Disable Background Parallax On Mobile" Global Setting

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -122,6 +122,7 @@ class SiteOrigin_Panels_Settings {
 		$defaults['admin-post-state']       = true;
 		$defaults['admin-widget-count']     = false;
 		$defaults['parallax-motion']        = '';
+		$defaults['parallax-mobile']        = false;
 		$defaults['sidebars-emulator']      = true;
 		$defaults['layout-block-default-mode'] = 'preview';
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -286,8 +286,8 @@ class SiteOrigin_Panels_Settings {
 
 		$fields['general']['fields']['parallax-mobile'] = array(
 			'type'        => 'checkbox',
-			'label'       => __( 'Disable Background Parallax On Mobile', 'siteorigin-panels' ),
-			'description' => __( 'Disable row/widget background parallax when browser is smaller than the mobile width.', 'siteorigin-panels' ),
+			'label'       => __( 'Disable Parallax On Mobile', 'siteorigin-panels' ),
+			'description' => __( 'Disable row/widget background parallax when the browser is smaller than the mobile width.', 'siteorigin-panels' ),
 		);
 
 		$fields['general']['fields']['sidebars-emulator'] = array(

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -284,6 +284,12 @@ class SiteOrigin_Panels_Settings {
 			'description' => __( 'How many pixels of scrolling result in a single pixel of parallax motion. 0 means automatic. Lower values give more noticeable effect.', 'siteorigin-panels' ),
 		);
 
+		$fields['general']['fields']['parallax-mobile'] = array(
+			'type'        => 'checkbox',
+			'label'       => __( 'Disable Background Parallax On Mobile', 'siteorigin-panels' ),
+			'description' => __( 'Disable row/widget background parallax when browser is smaller than the mobile width.', 'siteorigin-panels' ),
+		);
+
 		$fields['general']['fields']['sidebars-emulator'] = array(
 			'type'        => 'checkbox',
 			'label'       => __( 'Sidebars Emulator', 'siteorigin-panels' ),

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -64,7 +64,7 @@ class SiteOrigin_Panels_Styles {
 			SITEORIGIN_PANELS_VERSION
 		);
 		wp_localize_script( 'siteorigin-parallax', 'parallaxStyles', array(
-			'parallax-mobile' => ! empty( siteorigin_panels_setting( 'parallax-mobile' ) ) ? siteorigin_panels_setting( 'parallax-mobile' ) : false,
+			'parallax-mobile' => ! empty( siteorigin_panels_setting( 'parallax-mobile' ) ) ?: siteorigin_panels_setting( 'parallax-mobile' ),
 			'mobile-breakpoint' => siteorigin_panels_setting( 'mobile-width' ) . 'px',
 		) );
 	}

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -54,14 +54,18 @@ class SiteOrigin_Panels_Styles {
 			array( 'jquery' ),
 			SITEORIGIN_PANELS_VERSION
 		);
+		wp_localize_script( 'siteorigin-panels-front-styles', 'panelsStyles', array(
+			'fullContainer' => apply_filters( 'siteorigin_panels_full_width_container', siteorigin_panels_setting( 'full-width-container' ) ),
+		) );
 		wp_register_script(
 			'siteorigin-parallax',
 			siteorigin_panels_url( 'js/siteorigin-parallax' . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),
 			array( 'jquery' ),
 			SITEORIGIN_PANELS_VERSION
 		);
-		wp_localize_script( 'siteorigin-panels-front-styles', 'panelsStyles', array(
-			'fullContainer' => apply_filters( 'siteorigin_panels_full_width_container', siteorigin_panels_setting( 'full-width-container' ) )
+		wp_localize_script( 'siteorigin-parallax', 'parallaxStyles', array(
+			'parallax-mobile' => ! empty( siteorigin_panels_setting( 'parallax-mobile' ) ) ? siteorigin_panels_setting( 'parallax-mobile' ) : false,
+			'mobile-breakpoint' => siteorigin_panels_setting( 'mobile-width' ) . 'px',
 		) );
 	}
 

--- a/js/siteorigin-parallax.js
+++ b/js/siteorigin-parallax.js
@@ -32,6 +32,16 @@
 		}
 
 		var setupParallax = function( ){
+			// Check if we need to disable parallax on mobiles.
+			if (
+				typeof parallaxStyles != 'undefined' &&
+				parallaxStyles['parallax-mobile'] != false &&
+				window.matchMedia( '(max-width: ' + parallaxStyles['mobile-breakpoint'] + ')' ).matches
+			) {
+				$$.css( 'background-position', '50% 50%' );
+				return;
+			}
+
 			try {
 				var wrapperSize = [
 					$$.outerWidth(),

--- a/js/siteorigin-parallax.js
+++ b/js/siteorigin-parallax.js
@@ -35,7 +35,7 @@
 			// Check if we need to disable parallax on mobiles.
 			if (
 				typeof parallaxStyles != 'undefined' &&
-				parallaxStyles['parallax-mobile'] != false &&
+				parallaxStyles['parallax-mobile'] &&
 				window.matchMedia( '(max-width: ' + parallaxStyles['mobile-breakpoint'] + ')' ).matches
 			) {
 				$$.css( 'background-position', '50% 50%' );


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/158

Requires premium PR: https://github.com/siteorigin/siteorigin-premium/pull/403
The premium is required because it overrides the PB parallax with its own (modified) verison.