### PR TITLE
Fix right sidebar overlap on desktop

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1199,7 +1199,7 @@
 	&.so-panels-dialog-has-right-sidebar {
 		@media (min-width: 980px) {
 			.so-content {
-				right: @sidebar_width;
+				right: @edge_spacing + @sidebar_width;
 			}
 		}
 


### PR DESCRIPTION
Resolve the sidebar overlap issue on desktop.
![Edit_Page_‹_SiteOrigin_—_WordPress](https://user-images.githubusercontent.com/17275120/87509302-95ed6f00-c6b4-11ea-91f9-06c182936ae9.jpg)
