### PR TITLE
Remove all HTML from CSS Styles and strip slashes from textarea/code style fields

### DIFF
--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -28,12 +28,12 @@ class SiteOrigin_Panels_Css_Builder {
 			if( is_array( $v ) ) {
 				for( $i = 0; $i < count( $v ); $i++ ) {
 					if ( ! strlen( (string) $v[ $i ] ) ) continue;
-					$attribute_string[] = esc_html( $k ) . ':' . esc_html( $v[ $i ] );
+					$attribute_string[] = wp_strip_all_tags( $k ) . ':' . wp_strip_all_tags( $v[ $i ] );
 				}
 			}
 			else {
 				if ( ! strlen( (string) $v ) ) continue;
-				$attribute_string[] = esc_html( $k ) . ':' . esc_html( $v );
+				$attribute_string[] = wp_strip_all_tags( $k ) . ':' . wp_strip_all_tags( $v );
 			}
 		}
 		$attribute_string = implode( ';', $attribute_string );

--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -304,7 +304,7 @@ class SiteOrigin_Panels_Styles_Admin {
 				?><textarea type="text" name="<?php echo esc_attr( $field_name ) ?>"
 				            class="widefat <?php if ( $field['type'] == 'code' ) {
 					            echo 'so-field-code';
-				            } ?>" rows="4"><?php echo esc_textarea( $current ) ?></textarea><?php
+				            } ?>" rows="4"><?php echo esc_textarea( stripslashes( $current ) ) ?></textarea><?php
 				break;
 		}
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/720

Replaces [esc_html](https://developer.wordpress.org/reference/functions/esc_html/) with [wp_strip_all_tags](https://developer.wordpress.org/reference/functions/wp_strip_all_tags/). 