### PR TITLE
Improve Block Editor SEO Compatibility Support

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -167,6 +167,12 @@ function (_Component) {
         }
       });
       jQuery(document).trigger('panels_setup', this.builderView);
+
+      if ( typeof window.soPanelsBuilderView == 'undefined' ) {
+        window.soPanelsBuilderView = [];
+      }
+      window.soPanelsBuilderView.push( this.builderView );
+
       this.panelsInitialized = true;
     }
   }, {

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -118,6 +118,12 @@ class SiteOriginPanelsLayoutBlock extends Component {
 		} );
 		
 		jQuery( document ).trigger( 'panels_setup', this.builderView );
+
+		if ( typeof window.soPanelsBuilderView == 'undefined' ) {
+			window.soPanelsBuilderView = [];
+		}
+			window.soPanelsBuilderView.push( this.builderView );
+		}
 		
 		this.panelsInitialized = true;
 	}

--- a/js/seo-compat.js
+++ b/js/seo-compat.js
@@ -17,19 +17,7 @@ jQuery(function($){
 	};
 
 	SiteOriginSeoCompat.prototype.contentModification = function(data) {
-		if(
-			typeof window.soPanelsBuilderView !== 'undefined' &&
-			window.soPanelsBuilderView.contentPreview
-		) {
-			var $data = $( window.soPanelsBuilderView.contentPreview );
-
-			if( $data.find('.so-panel.widget').length === 0 ) {
-				// Skip this for empty pages
-				return data;
-			}
-
-			// Remove style tags created by Widgets Bundle
-			$data.find('style').remove();
+		if ( typeof window.soPanelsBuilderView !== 'undefined' ) {
 
 			var whitelist = [
 				'p', 'a', 'img', 'caption', 'br',
@@ -41,12 +29,34 @@ jQuery(function($){
 				'table', 'tr', 'th', 'td'
 			].join(',');
 
-			$data.find("*").not(whitelist).each(function() {
-				var content = $(this).contents();
-				$(this).replaceWith(content);
-			});
+			var extractContent = function( data ) {
+				var $data = $( data );
 
-			data = $data.html();
+				if( $data.find('.so-panel.widget').length === 0 ) {
+					// Skip this for empty pages
+					return data;
+				}
+
+				// Remove style tags created by Widgets Bundle
+				$data.find('style').remove();
+
+				$data.find("*").not(whitelist).each(function() {
+					var content = $(this).contents();
+					$(this).replaceWith(content);
+				});
+
+				return $data.html();
+			};
+
+			if ( ! Array.isArray( window.soPanelsBuilderView ) ) {
+				data = extractContent( window.soPanelsBuilderView.contentPreview );
+			} else {
+				$this = this;
+				data = null;
+				window.soPanelsBuilderView.forEach(function(panel){
+					data += extractContent( panel.contentPreview );
+				});
+			}
 		}
 
 		return data;

--- a/js/seo-compat.js
+++ b/js/seo-compat.js
@@ -16,7 +16,7 @@ jQuery(function($){
 
 	};
 
-	SiteOriginSeoCompat.prototype.contentModification = function(data) {
+	SiteOriginSeoCompat.prototype.contentModification = function( data ) {
 		if ( typeof window.soPanelsBuilderView !== 'undefined' ) {
 
 			var whitelist = [
@@ -27,23 +27,23 @@ jQuery(function($){
 				'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
 				'ul', 'ol', 'li',
 				'table', 'tr', 'th', 'td'
-			].join(',');
+			].join( ',' );
 
 			var extractContent = function( data ) {
 				var $data = $( data );
 
-				if( $data.find('.so-panel.widget').length === 0 ) {
+				if( $data.find( '.so-panel.widget' ).length === 0 ) {
 					// Skip this for empty pages
 					return data;
 				}
 
 				// Remove style tags created by Widgets Bundle
-				$data.find('style').remove();
+				$data.find( 'style' ).remove();
 
-				$data.find("*").not(whitelist).each(function() {
-					var content = $(this).contents();
-					$(this).replaceWith(content);
-				});
+				$data.find( "*") .not( whitelist ).each( function() {
+					var content = $( this ).contents();
+					$( this ).replaceWith( content );
+				} );
 
 				return $data.html();
 			};
@@ -51,11 +51,11 @@ jQuery(function($){
 			if ( ! Array.isArray( window.soPanelsBuilderView ) ) {
 				data = extractContent( window.soPanelsBuilderView.contentPreview );
 			} else {
-				$this = this;
+				var $this = this;
 				data = null;
-				window.soPanelsBuilderView.forEach(function(panel){
+				window.soPanelsBuilderView.forEach( function( panel ) {
 					data += extractContent( panel.contentPreview );
-				});
+				} );
 			}
 		}
 

--- a/js/siteorigin-panels/helpers/editor.js
+++ b/js/siteorigin-panels/helpers/editor.js
@@ -1,0 +1,9 @@
+module.exports = {
+	isBlockEditor: function() {
+		return typeof wp.blocks !== 'undefined';
+	},
+
+	isClassicEditor: function( builder ) {
+		return builder.attachedToEditor && builder.$el.is( ':visible' );
+	},
+}

--- a/js/siteorigin-panels/main.js
+++ b/js/siteorigin-panels/main.js
@@ -17,6 +17,7 @@ window.siteoriginPanels = panels;
 panels.helpers = {};
 panels.helpers.clipboard = require( './helpers/clipboard' );
 panels.helpers.utils = require( './helpers/utils' );
+panels.helpers.editor = require( './helpers/editor' );
 panels.helpers.serialize = require( './helpers/serialize' );
 panels.helpers.pageScroll = require( './helpers/page-scroll' );
 

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -731,8 +731,15 @@ module.exports = Backbone.View.extend( {
 	handleContentChange: function () {
 
 		// Make sure we actually need to copy content.
-		if ( panelsOptions.copy_content && this.attachedToEditor && this.$el.is( ':visible' ) ) {
-
+		if ( panelsOptions.copy_content	&&
+			(
+				typeof wp.blocks !== 'undefined' ||
+				(
+					this.attachedToEditor &&
+					this.$el.is( ':visible' )
+				)
+			)
+		) {
 			var panelsData = this.model.getPanelsData();
 			if ( !_.isEmpty( panelsData.widgets ) ) {
 				// We're going to create a copy of page builder content into the post content

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -731,15 +731,7 @@ module.exports = Backbone.View.extend( {
 	handleContentChange: function () {
 
 		// Make sure we actually need to copy content.
-		if ( panelsOptions.copy_content	&&
-			(
-				typeof wp.blocks !== 'undefined' ||
-				(
-					this.attachedToEditor &&
-					this.$el.is( ':visible' )
-				)
-			)
-		) {
+		if ( panelsOptions.copy_content	&& ( panels.helpers.editor.isBlockEditor() || panels.helpers.editor.isClassicEditor( this ) ) ) {
 			var panelsData = this.model.getPanelsData();
 			if ( !_.isEmpty( panelsData.widgets ) ) {
 				// We're going to create a copy of page builder content into the post content


### PR DESCRIPTION
This PR improves the SEO compatibility code for the SiteOrigin Layout Block. It allows for multiple SiteOrigin Layout Blocks to pass changes to SEO Plugins and also resolves a content extraction issue for the SiteOrigin Layout Block that prevented certain widgets from being completely compatible. An example of such a widget is the SiteOrigin Block Editor widget where the Destination Link setting wasn't being picked up correctly.

This is quite a large change with a lot of moving parts so thorough testing is required. This PR must also be tested using either `build:dev` or `build:release` as editor JS files were modified.