### PR TITLE
Prevent Potential Confirm Notice

### DIFF
--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -744,11 +744,13 @@ module.exports = Backbone.View.extend( {
 						post_id: this.config.postId
 					},
 					function ( content ) {
+						// Post content doesn't need to be generated on load while contentPreview does.
+						if ( this.contentPreview && content.post_content !== '' ) {
+							this.updateEditorContent( content.post_content );
+						}
+
 						if ( content.preview !== '' ) {
 							this.contentPreview = content.preview;
-						}
-						if ( content.post_content !== '' ) {
-							this.updateEditorContent( content.post_content );
 						}
 					}.bind( this )
 				);


### PR DESCRIPTION
This PR prevents a situation where the user views the editor, makes no changes, and then attempts to navigate away. They then get hit with a "are you sure you want to navigate away? There is unsaved data" confirm message. This PR will prevent the post content from being updated on load while still allowing `contentPreview` to be set - which is required for SEO plugins. The post content is set on save so it doesn't need to be set on load but `contentPreview` isn't and needs to be. When the post content is updated on load it triggers a keyup on TinyMCE which will make WordPress (rightfully) think there has been a content change.

I've had a hard time replicating this issue but two users have reported this fix helped.