### PR TITLE
Android Chrome: Improve edit widget touch detection

### DIFF
--- a/js/siteorigin-panels/view/widget.js
+++ b/js/siteorigin-panels/view/widget.js
@@ -11,7 +11,9 @@ module.exports = Backbone.View.extend( {
 
 	events: {
 		'click .widget-edit': 'editHandler',
+		'touchend .widget-edit': 'editHandler',
 		'click .title h4': 'editHandler',
+		'touchend .title h4': 'editHandler',
 		'click .actions .widget-duplicate': 'duplicateHandler',
 		'click .actions .widget-delete': 'deleteHandler'
 	},


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/703

This PR resolves an issue affecting certain Android devices where the edit widget prompt wouldn't be opened when they touched the widget. Instead, the widget would go into the draggable mode. This PR allows for both the edit widget prompt to open and the widgets to still be draggable.