### PR TITLE
Yoast : Resolve 14.6 Integration Issue

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -528,11 +528,17 @@ class SiteOrigin_Panels_Admin {
 
 	public function enqueue_seo_compat(){
 		if ( self::is_admin() ) {
-			if ( defined( 'WPSEO_FILE' ) && wp_script_is( 'yoast-seo-metabox' ) ) {
+			if (
+				defined( 'WPSEO_FILE' ) &&
+				(
+					wp_script_is( 'yoast-seo-admin-global-script' ) || // => 14.6
+					wp_script_is( 'yoast-seo-metabox' ) // <= 14.5
+				)
+			) {
 				wp_enqueue_script(
 					'so-panels-seo-compat',
 					siteorigin_panels_url( 'js/seo-compat' . SITEORIGIN_PANELS_JS_SUFFIX . '.js' ),
-					array('jquery', 'yoast-seo-metabox' ),
+					array( 'jquery' ),
 					SITEORIGIN_PANELS_VERSION,
 					true
 				);


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/790

Yoast merged all of their editor specific JS files into one general file so our previous script detection failed. This PR accounts for backward compatibility by retaining the previous script check.