### PR TITLE
Layout Block: Use new Block Categories if WP 5.5

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -252,6 +252,9 @@ function (_Component) {
   return SiteOriginPanelsLayoutBlock;
 }(Component);
 
+var hasLayoutCategory = wp.blocks.getCategories().some(function (category) {
+  return category.slug === 'layout';
+});
 registerBlockType('siteorigin-panels/layout-block', {
   title: __('SiteOrigin Layout', 'siteorigin-panels'),
   description: __("Build a layout using SiteOrigin's Page Builder.", 'siteorigin-panels'),
@@ -260,7 +263,7 @@ registerBlockType('siteorigin-panels/layout-block', {
       className: "siteorigin-panels-block-icon"
     });
   },
-  category: 'layout',
+  category: hasLayoutCategory ? 'layout' : 'design',
   keywords: ['page builder', 'column,grid', 'panel'],
   supports: {
     html: false

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -212,6 +212,10 @@ class SiteOriginPanelsLayoutBlock extends Component {
 	}
 }
 
+var hasLayoutCategory = wp.blocks.getCategories().some( function( category ) {
+	return category.slug === 'layout';
+} );
+
 registerBlockType( 'siteorigin-panels/layout-block', {
 	title: __( 'SiteOrigin Layout', 'siteorigin-panels' ),
 	
@@ -221,7 +225,7 @@ registerBlockType( 'siteorigin-panels/layout-block', {
 		return <span className="siteorigin-panels-block-icon"/>;
 	},
 	
-	category: 'layout',
+	category: hasLayoutCategory ? 'layout' : 'design',
 	
 	keywords: [ 'page builder', 'column,grid', 'panel' ],
 	


### PR DESCRIPTION
Uses the suggested compatibility code. Tested using 5.5-RC1-48698 and 5.4.2. Please note that formatting is different in .js due to spaces being stripped by `build:dev`.