### PR TITLE
Run wp_targeted_link_rel on the generated preview content

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1129,7 +1129,7 @@ class SiteOrigin_Panels_Admin {
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 
 		$GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] = true;
-		$return['preview'] = SiteOrigin_Panels::renderer()->render( intval( $_POST['post_id'] ), false, $panels_data );
+		$return['preview'] = wp_targeted_link_rel( SiteOrigin_Panels::renderer()->render( intval( $_POST['post_id'] ), false, $panels_data ) );
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] );
 
 		echo json_encode( $return );

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1129,7 +1129,10 @@ class SiteOrigin_Panels_Admin {
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 
 		$GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] = true;
-		$return['preview'] = wp_targeted_link_rel( SiteOrigin_Panels::renderer()->render( intval( $_POST['post_id'] ), false, $panels_data ) );
+		$return['preview'] = SiteOrigin_Panels::renderer()->render( intval( $_POST['post_id'] ), false, $panels_data );
+		if ( function_exists( 'wp_targeted_link_rel' ) ) {
+			$return['preview'] = wp_targeted_link_rel( $return['preview'] );
+		}
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] );
 
 		echo json_encode( $return );


### PR DESCRIPTION
Resolves https://github.com/siteorigin/siteorigin-panels/issues/795

This commit prevents an issue where the SO Layout Block may break due to saved data being different.

To test this issue you'll need to have a widget that adds a link with `target="_blank"` set and doesn't set both `noopener` and `noreferrer` (related https://github.com/siteorigin/so-widgets-bundle/pull/1080). Add the widget, set the widget up to add the link and then save. Reload the page and the editor will SiteOrigin Layout Block will Break:

![](https://i.imgur.com/qUn0OOT.png)

Load this PR and recover the block by clicking the three dots and then selecting `Attempt Block Recovery`. Duplicate a widget/row (this will trigger the block content to update itself) and then remove the duplicate. Save. Reload the editor and the Block will work as expected.