### PR TITLE
Layout Block: Add Support for new Preview Options

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -368,3 +368,10 @@ registerBlockType('siteorigin-panels/layout-block', {
     });
   }
 })(jQuery);
+
+// Detect preview mode changes, and trigger resize.
+jQuery(document).on('click', '.block-editor-post-preview__button-resize', function (e) {
+  if (!jQuery(this).hasClass('has-icon')) {
+    jQuery(window).trigger('resize');
+  }
+});

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -334,3 +334,10 @@ registerBlockType( 'siteorigin-panels/layout-block', {
 	}
 	
 } )( jQuery );
+
+// Detect preview mode changes, and trigger resize.
+jQuery( document ).on( 'click', '.block-editor-post-preview__button-resize', function( e ) {
+	if ( ! jQuery( this ).hasClass('has-icon') ) {
+		jQuery( window ).trigger( 'resize' ); 
+	}
+} );

--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -20,6 +20,9 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 		// This action is slightly later than `enqueue_block_editor_assets`,
 		// which we need to use to ensure our templates are loaded at the right time.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_layout_block_editor_assets' ) );
+
+		// We need to override the container when using the Block Editor to allow for resizing.
+		add_filter( 'siteorigin_panels_full_width_container', array( $this, 'override_container' ) );
 	}
 	
 	public function register_layout_block() {
@@ -112,5 +115,9 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 		$panels_data['widgets'] = SiteOrigin_Panels_Admin::single()->process_raw_widgets( $panels_data['widgets'], false, true );
 		$panels_data = SiteOrigin_Panels_Styles_Admin::single()->sanitize_all( $panels_data );
 		return $panels_data;
+	}
+
+	function override_container( $container ) {
+		return SiteOrigin_Panels_Admin::is_block_editor() ? '.editor-styles-wrapper' : $container;
 	}
 }

--- a/js/styling.js
+++ b/js/styling.js
@@ -2,13 +2,13 @@
 
 jQuery( function ( $ ) {
 
-	var fullContainer = $( panelsStyles.fullContainer );
-	if ( fullContainer.length === 0 ) {
-		fullContainer = $( 'body' );
-	}
-
 	// Stretch all the full width rows
 	var stretchFullWidthRows = function () {
+		var fullContainer = $( panelsStyles.fullContainer );
+		if ( fullContainer.length === 0 ) {
+			fullContainer = $( 'body' );
+		}
+
 		var $panelsRow = $( '.siteorigin-panels-stretch.panel-row-style' );
 		$panelsRow.each( function () {
 			var $$ = $( this );


### PR DESCRIPTION
This PR resolves an issue new [Block Editor Preview Options](https://make.wordpress.org/core/2020/08/04/new-editor-preview-options/) and layouts that contain Row Layouts set to something other than Standard. To replicate this issue please import the Consultant Layout into the Block Editor and change device preview. You'll notice that the length of the rows is larger than the device preview area. This PR triggers a row resize to resolve this issue.