### PR TITLE
Avoid potential JS i18n variable conflict

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -8,15 +8,45 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _createSuper(Derived) {
+  function isNativeReflectConstruct() {
+    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+    if (Reflect.construct.sham) return false;
+    if (typeof Proxy === "function") return true;
+
+    try {
+      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  return function () {
+    var Super = _getPrototypeOf(Derived),
+        result;
+
+    if (isNativeReflectConstruct()) {
+      var NewTarget = _getPrototypeOf(this).constructor;
+
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+
+    return _possibleConstructorReturn(this, result);
+  };
+}
+
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 var _lodash = lodash,
     isEqual = _lodash.isEqual,
@@ -34,7 +64,6 @@ var _wp$components = wp.components,
     Toolbar = _wp$components.Toolbar,
     IconButton = _wp$components.IconButton,
     Spinner = _wp$components.Spinner;
-var __ = wp.i18n.__;
 var _window = window,
     soPanelsBlockEditorAdmin = _window.soPanelsBlockEditorAdmin;
 
@@ -43,12 +72,14 @@ var SiteOriginPanelsLayoutBlock =
 function (_Component) {
   _inherits(SiteOriginPanelsLayoutBlock, _Component);
 
+  var _super = _createSuper(SiteOriginPanelsLayoutBlock);
+
   function SiteOriginPanelsLayoutBlock(props) {
     var _this;
 
     _classCallCheck(this, SiteOriginPanelsLayoutBlock);
 
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(SiteOriginPanelsLayoutBlock).call(this, props));
+    _this = _super.call(this, props);
     var editMode = soPanelsBlockEditorAdmin.defaultMode === 'edit' || isEmpty(props.panelsData);
     _this.state = {
       editing: editMode,
@@ -222,7 +253,7 @@ function (_Component) {
         return React.createElement(Fragment, null, React.createElement(BlockControls, null, React.createElement(Toolbar, null, React.createElement(IconButton, {
           icon: "visibility",
           className: "components-icon-button components-toolbar__control",
-          label: __('Preview layout.', 'siteorigin-panels'),
+          label: wp.i18n.__('Preview layout.', 'siteorigin-panels'),
           onClick: switchToPreview
         }))), React.createElement("div", {
           key: "layout-block",
@@ -234,7 +265,7 @@ function (_Component) {
         return React.createElement(Fragment, null, React.createElement(BlockControls, null, React.createElement(Toolbar, null, React.createElement(IconButton, {
           icon: "edit",
           className: "components-icon-button components-toolbar__control",
-          label: __('Edit layout.', 'siteorigin-panels'),
+          label: wp.i18n.__('Edit layout.', 'siteorigin-panels'),
           onClick: switchToEditing
         }))), React.createElement("div", {
           key: "preview",
@@ -256,8 +287,8 @@ var hasLayoutCategory = wp.blocks.getCategories().some(function (category) {
   return category.slug === 'layout';
 });
 registerBlockType('siteorigin-panels/layout-block', {
-  title: __('SiteOrigin Layout', 'siteorigin-panels'),
-  description: __("Build a layout using SiteOrigin's Page Builder.", 'siteorigin-panels'),
+  title: wp.i18n.__('SiteOrigin Layout', 'siteorigin-panels'),
+  description: wp.i18n.__("Build a layout using SiteOrigin's Page Builder.", 'siteorigin-panels'),
   icon: function icon() {
     return React.createElement("span", {
       className: "siteorigin-panels-block-icon"

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -3,7 +3,6 @@ const { registerBlockType } = wp.blocks;
 const { Component, Fragment, RawHTML, createRef } = wp.element;
 const { BlockControls } = wp.editor;
 const { Toolbar, IconButton, Spinner } = wp.components;
-const { __ } = wp.i18n;
 const { soPanelsBlockEditorAdmin } = window;
 
 class SiteOriginPanelsLayoutBlock extends Component {
@@ -169,7 +168,7 @@ class SiteOriginPanelsLayoutBlock extends Component {
 							<IconButton
 								icon="visibility"
 								className="components-icon-button components-toolbar__control"
-								label={ __( 'Preview layout.', 'siteorigin-panels' ) }
+								label={ wp.i18n.__( 'Preview layout.', 'siteorigin-panels' ) }
 								onClick={ switchToPreview }
 							/>
 						</Toolbar>
@@ -190,7 +189,7 @@ class SiteOriginPanelsLayoutBlock extends Component {
 							<IconButton
 								icon="edit"
 								className="components-icon-button components-toolbar__control"
-								label={ __( 'Edit layout.', 'siteorigin-panels' ) }
+								label={ wp.i18n.__( 'Edit layout.', 'siteorigin-panels' ) }
 								onClick={ switchToEditing }
 							/>
 						</Toolbar>
@@ -217,9 +216,9 @@ var hasLayoutCategory = wp.blocks.getCategories().some( function( category ) {
 } );
 
 registerBlockType( 'siteorigin-panels/layout-block', {
-	title: __( 'SiteOrigin Layout', 'siteorigin-panels' ),
+	title: wp.i18n.__( 'SiteOrigin Layout', 'siteorigin-panels' ),
 	
-	description: __( "Build a layout using SiteOrigin's Page Builder.", 'siteorigin-panels' ),
+	description: wp.i18n.__( "Build a layout using SiteOrigin's Page Builder.", 'siteorigin-panels' ),
 	
 	icon () {
 		return <span className="siteorigin-panels-block-icon"/>;


### PR DESCRIPTION
`__` is far too common to rely so this PR uses `wp.i18n.__` directly. 