### PR TITLE
Prevent jQuery migrate notice on settings page

### DIFF
--- a/settings/admin-settings.js
+++ b/settings/admin-settings.js
@@ -16,8 +16,7 @@ jQuery( function($){
                         .animate({'margin-top' : 0, 'opacity': opacity}, 280 + 40*(4 - v) );
                 }, 150 + 225 * (4 - v) );
             });
-        })
-        .each(function() { if(this.complete) { $(this).load(); } });
+        });
 
     // Settings page tabbing
 


### PR DESCRIPTION
[Related](https://github.com/siteorigin/so-widgets-bundle/pull/1129)

This PR prevents the Enable jQuery Migrate Helper plugin from triggering a warning when viewing **WP Admin > Settings > Page Builder**.