### PR TITLE
Yoast SEO Compat: Wait until Yoast is ready

### DIFF
--- a/js/seo-compat.js
+++ b/js/seo-compat.js
@@ -62,5 +62,14 @@ jQuery(function($){
 		return data;
 	};
 
-	new SiteOriginSeoCompat();
+	if ( typeof rankMathEditor !== 'undefined' ) {
+		new SiteOriginSeoCompat();
+	} else {
+		$( window ).on(
+			'YoastSEO:ready',
+			function () {
+				new SiteOriginSeoCompat();
+			}
+		);
+	}
 });


### PR DESCRIPTION
This PR resolves the below error message. This error can prevent `contentModification` from being run. This can result in situations where blank empty widgets are included in the content analysis ([related](https://siteorigin.com/thread/yoast-compatability-issue/)).

![](https://i.imgur.com/soUgN9N.png)

I've run some tests using older versions of Yoast and this PR still applies.