### PR TITLE
SiteOrigin Layout Yoast Compat: Always pass builderView

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -203,10 +203,9 @@ function (_Component) {
 
       if (typeof window.soPanelsBuilderView == 'undefined') {
         window.soPanelsBuilderView = [];
-      } else {
-        window.soPanelsBuilderView.push(this.builderView);
       }
 
+      window.soPanelsBuilderView.push(this.builderView);
       this.panelsInitialized = true;
     }
   }, {

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -122,9 +122,8 @@ class SiteOriginPanelsLayoutBlock extends Component {
 
 		if ( typeof window.soPanelsBuilderView == 'undefined' ) {
 			window.soPanelsBuilderView = [];
-		} else {
-			window.soPanelsBuilderView.push( this.builderView );
 		}
+		window.soPanelsBuilderView.push( this.builderView );
 		
 		this.panelsInitialized = true;
 	}


### PR DESCRIPTION
This PR resolve the following Yoast Notice while using the Block Editor:

![](https://i.imgur.com/ou3Vf3t.png)

This change doesn't affect the Classic Editor so it's not related to https://github.com/siteorigin/siteorigin-panels/issues/811.

