### PR TITLE
SEO Compat: Ensure PB is enabled before running compatibility code

### DIFF
--- a/js/seo-compat.js
+++ b/js/seo-compat.js
@@ -17,7 +17,12 @@ jQuery(function($){
 	};
 
 	SiteOriginSeoCompat.prototype.contentModification = function( data ) {
-		if ( typeof window.soPanelsBuilderView !== 'undefined' ) {
+
+		var isBlockEditorPanelsEnabled =  $( '.block-editor-page' ).length && typeof window.soPanelsBuilderView !== 'undefined';
+		var isClassicEditorPanelsEnabled = $( '#so-panels-panels.attached-to-editor' ).is( ':visible' );
+
+		// Check if the editor has Page Builder Enabled before proceeding.
+		if ( isClassicEditorPanelsEnabled || isBlockEditorPanelsEnabled ) {
 
 			var whitelist = [
 				'p', 'a', 'img', 'caption', 'br',


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/811

window.soPanelsBuilderView will always be set when using the Classic Editor so the compatibility code will always run. This is fine in the Block Editor, but it runs into issues with the Classic Editor. This PR is set up to only run the Compatability code when PB is enabled or the SiteOrigin Layout is present.