### PR TITLE
Layout Export: Correctly detect Block Editor

### DIFF
--- a/js/siteorigin-panels/dialog/prebuilt.js
+++ b/js/siteorigin-panels/dialog/prebuilt.js
@@ -172,7 +172,7 @@ module.exports = panels.view.dialog.extend( {
 			var postName = $( 'input[name="post_title"], .editor-post-title__input' ).val();
 			if ( ! postName ) {
 				postName = $('input[name="post_ID"]').val();
-			} else if ( typeof wp.data != 'undefined' ) {
+			} else if ( $( '.block-editor-page' ).length ) {
 				var currentBlockPosition = thisView.getCurrentBlockPosition();
 				if ( currentBlockPosition >= 0 ) {
 					postName += '-' + currentBlockPosition; 


### PR DESCRIPTION
This PR is a follow up to https://github.com/siteorigin/siteorigin-panels/pull/800

wp.data can be loaded in the Classic Editor by other plugins so it can't be relied on. This PR checks the body class for a Block Editor specific class as that will only ever be added if it's the block editor.