### PR TITLE
Add wp-color-picker as editor dependency

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -299,6 +299,7 @@ class SiteOrigin_Panels_Admin {
 					'jquery-ui-resizable',
 					'jquery-ui-sortable',
 					'jquery-ui-draggable',
+					'wp-color-picker',
 					'underscore',
 					'backbone',
 					'plupload',


### PR DESCRIPTION
[Reported here](https://siteorigin.com/thread/color-picker-not-working/)

This will prevent the colour field from appearing as a text field if no other plugin loads the WordPress Color picker. The color picker was added in WordPress 3.5 and is a dependecy of the SiteOrigin Widgets Bundle so backwards compatability isn't a major concern.