### PR TITLE
SEO: Set ContentPreview on load

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1047,6 +1047,17 @@ class SiteOrigin_Panels_Admin {
 		return $is_js_widget;
 	}
 
+	function generate_panels_preview( $post_id, $panels_data ) {
+		$GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] = true;
+		$return = SiteOrigin_Panels::renderer()->render( intval( $post_id ), false, $panels_data );
+		if ( function_exists( 'wp_targeted_link_rel' ) ) {
+			$return = wp_targeted_link_rel( $return );
+		}
+		unset( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] );
+
+		return $return;
+	}
+
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	//  ADMIN AJAX ACTIONS
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1128,12 +1139,7 @@ class SiteOrigin_Panels_Admin {
 		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 
-		$GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] = true;
-		$return['preview'] = SiteOrigin_Panels::renderer()->render( intval( $_POST['post_id'] ), false, $panels_data );
-		if ( function_exists( 'wp_targeted_link_rel' ) ) {
-			$return['preview'] = wp_targeted_link_rel( $return['preview'] );
-		}
-		unset( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] );
+		$return['preview'] = $this->generate_panels_preview( intval( $_POST['post_id'] ), $panels_data );
 
 		echo json_encode( $return );
 

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -71,6 +71,13 @@ module.exports = Backbone.View.extend( {
 			prebuilt: new panels.dialog.prebuilt()
 		};
 
+		
+		// Check if we have preview markup available.
+		$panelsMetabox = $( '#siteorigin-panels-metabox' );
+		if ( $panelsMetabox.length ) {
+			this.contentPreview = $.parseHTML( $panelsMetabox.data( 'preview-markup' ) );
+		}
+
 		// Set the builder for each dialog and render it.
 		_.each( this.dialogs, function ( p, i, d ) {
 			d[ i ].setBuilder( builder );

--- a/tpl/metabox-panels.php
+++ b/tpl/metabox-panels.php
@@ -3,11 +3,13 @@ global $post;
 $builder_id = uniqid();
 $builder_type = apply_filters( 'siteorigin_panels_post_builder_type', 'editor_attached', $post, $panels_data );
 $builder_supports = apply_filters( 'siteorigin_panels_builder_supports', array(), $post, $panels_data );
+$preview = SiteOrigin_Panels_Admin::single()->generate_panels_preview( $post->ID, $panels_data );
 ?>
 
 <div id="siteorigin-panels-metabox"
 	data-builder-type="<?php echo esc_attr( $builder_type ) ?>"
 	data-preview-url="<?php echo SiteOrigin_Panels::preview_url() ?>"
+	data-preview-markup="<?php echo esc_attr( json_encode( $preview ) ); ?>"
 	data-builder-supports="<?php echo esc_attr( json_encode( $builder_supports ) ) ?>"
 	<?php if( !empty( $_GET['so_live_editor'] ) ) echo 'data-live-editor="1"' ?>
 	>


### PR DESCRIPTION
This PR sets contentPreview on load to prevent a Rankmath sometimes not picking up on the page builder layout on load.