### PR TITLE
SEO: Remove elements that have no content analysis value

### DIFF
--- a/js/seo-compat.js
+++ b/js/seo-compat.js
@@ -42,8 +42,8 @@ jQuery(function($){
 					return data;
 				}
 
-				// Remove style tags created by Widgets Bundle
-				$data.find( 'style' ).remove();
+				// Remove elements that have no content analysis value.
+				$data.find( 'iframe, script, style, link' ).remove();
 
 				$data.find( "*") .not( whitelist ).each( function() {
 					var content = $( this ).contents();


### PR DESCRIPTION
This PR removes elements that have no direct content analysis value. For example, there's no reason to include a slimmed down version of any inline JavaScript as search engines ignore it.

This PR also avoids an issue with iframes that prevent the full Rank Math interface from showing. When an iframe is added, an error occurs and that prevents [this part](https://i.imgur.com/qrCvv7D.png) of the Rank Math interface from showing. The easist way to trigger this issue is to add a YouTube URL to a SiteOrigin Editor widget.