### PR TITLE
Generate preview_url before preview_content

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -198,6 +198,8 @@ class SiteOrigin_Panels_Admin {
 	 */
 	function render_meta_boxes( $post ) {
 		$panels_data = $this->get_current_admin_panels_data();
+		$preview_url = SiteOrigin_Panels::preview_url();
+		$preview_content = $this->generate_panels_preview( $post->ID, $panels_data );
 		include plugin_dir_path( __FILE__ ) . '../tpl/metabox-panels.php';
 	}
 

--- a/tpl/metabox-panels.php
+++ b/tpl/metabox-panels.php
@@ -3,13 +3,12 @@ global $post;
 $builder_id = uniqid();
 $builder_type = apply_filters( 'siteorigin_panels_post_builder_type', 'editor_attached', $post, $panels_data );
 $builder_supports = apply_filters( 'siteorigin_panels_builder_supports', array(), $post, $panels_data );
-$preview = SiteOrigin_Panels_Admin::single()->generate_panels_preview( $post->ID, $panels_data );
 ?>
 
 <div id="siteorigin-panels-metabox"
 	data-builder-type="<?php echo esc_attr( $builder_type ) ?>"
-	data-preview-url="<?php echo SiteOrigin_Panels::preview_url() ?>"
-	data-preview-markup="<?php echo esc_attr( json_encode( $preview ) ); ?>"
+	data-preview-url="<?php echo $preview_url; ?>"
+	data-preview-markup="<?php echo esc_attr( json_encode( $preview_content ) ); ?>"
 	data-builder-supports="<?php echo esc_attr( json_encode( $builder_supports ) ) ?>"
 	<?php if( !empty( $_GET['so_live_editor'] ) ) echo 'data-live-editor="1"' ?>
 	>


### PR DESCRIPTION
This resolves a Live Editor preview issue when there's a loop present on the page.

This should also resolve the following error message (although I haven't been able to replicate this error):

`An error of type E_ERROR was caused in line 6 of the file /srv/htdocs/wp-content/plugins/siteorigin-panels/tpl/metabox-panels.php. Error message: Uncaught Error: Call to undefined method SiteOrigin_Panels_Admin::generate_panels_preview() in /srv/htdocs/wp-content/plugins/siteorigin-panels/tpl/metabox-panels.php:6`