### PR TITLE
Update Depreciated jQuery Bind Usage

### DIFF
--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -842,7 +842,7 @@ module.exports = Backbone.View.extend( {
 
 					// Wrap the call
 					$( window ).off( 'scroll', event.handler );
-					$( window ).bind( 'scroll', function( e ) {
+					$( window ).on( 'scroll', function( e ) {
 						if ( !this.attachedVisible ) {
 							event.handler( e );
 						}


### PR DESCRIPTION
This PR updates the depreciated jQuery Bind instance. Please note that the other usage of bind, such as `.bind( this )`, is using native JS ([reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind)).