### PR TITLE
Replace older-style PHP type conversion functions with type casts.

### DIFF
--- a/inc/admin-layouts.php
+++ b/inc/admin-layouts.php
@@ -189,7 +189,7 @@ class SiteOrigin_Panels_Admin_Layouts {
 		
 		$type   = ! empty( $_REQUEST['type'] ) ? $_REQUEST['type'] : 'directory-siteorigin';
 		$search = ! empty( $_REQUEST['search'] ) ? trim( strtolower( $_REQUEST['search'] ) ) : '';
-		$page_num = ! empty( $_REQUEST['page'] ) ? intval( $_REQUEST['page'] ) : 1;
+		$page_num = ! empty( $_REQUEST['page'] ) ? (int) $_REQUEST['page'] : 1;
 		
 		$return = array(
 			'title' => '',
@@ -284,7 +284,7 @@ class SiteOrigin_Panels_Admin_Layouts {
 					" . ( ! empty( $search ) ? 'AND posts.post_title LIKE "%' . esc_sql( $search ) . '%"' : '' ) . "
 					AND ( posts.post_status = 'publish' OR posts.post_status = 'draft' " . $include_private . ")
 				ORDER BY post_date DESC
-				LIMIT 16 OFFSET " . intval( ( $page_num - 1 ) * 16 ) );
+				LIMIT 16 OFFSET " . (int) ( $page_num - 1 ) * 16 );
 			$total_posts = $wpdb->get_var( "SELECT FOUND_ROWS();" );
 			
 			foreach ( $results as $result ) {

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -262,7 +262,7 @@ class SiteOrigin_Panels_Admin {
 				$post->post_content = $post_content;
 				if( siteorigin_panels_setting( 'copy-styles' ) ) {
 					$post->post_content .= "\n\n";
-					$post->post_content .= '<style type="text/css" class="panels-style" data-panels-style-for-post="' . intval( $layout_id ) . '">';
+					$post->post_content .= '<style type="text/css" class="panels-style" data-panels-style-for-post="' . (int) $layout_id . '">';
 					$post->post_content .= '@import url(' . SiteOrigin_Panels::front_css_url() . '); ';
 					$post->post_content .= $post_css;
 					$post->post_content .= '</style>';
@@ -1052,7 +1052,7 @@ class SiteOrigin_Panels_Admin {
 
 	function generate_panels_preview( $post_id, $panels_data ) {
 		$GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] = true;
-		$return = SiteOrigin_Panels::renderer()->render( intval( $post_id ), false, $panels_data );
+		$return = SiteOrigin_Panels::renderer()->render( (int) $post_id, false, $panels_data );
 		if ( function_exists( 'wp_targeted_link_rel' ) ) {
 			$return = wp_targeted_link_rel( $return );
 		}
@@ -1097,7 +1097,7 @@ class SiteOrigin_Panels_Admin {
 		// Create a version of the builder data for post content
 		SiteOrigin_Panels_Post_Content_Filters::add_filters();
 		$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-		echo SiteOrigin_Panels::renderer()->render( intval( $_POST['post_id'] ), false, $panels_data );
+		echo SiteOrigin_Panels::renderer()->render( (int) $_POST['post_id'], false, $panels_data );
 		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 
@@ -1138,11 +1138,11 @@ class SiteOrigin_Panels_Admin {
 		// Create a version of the builder data for post content
 		SiteOrigin_Panels_Post_Content_Filters::add_filters();
 		$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-		$return['post_content'] = SiteOrigin_Panels::renderer()->render( intval( $_POST['post_id'] ), false, $panels_data );
+		$return['post_content'] = SiteOrigin_Panels::renderer()->render( (int) $_POST['post_id'], false, $panels_data );
 		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 
-		$return['preview'] = $this->generate_panels_preview( intval( $_POST['post_id'] ), $panels_data );
+		$return['preview'] = $this->generate_panels_preview( (int) $_POST['post_id'], $panels_data );
 
 		echo json_encode( $return );
 

--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -235,11 +235,11 @@ class SiteOrigin_Panels_Css_Builder {
 			}
 
 			if ( $max_res === '' && $min_res > 0 ) {
-				$css_text .= '@media (min-width:' . intval( $min_res ) . 'px) {';
+				$css_text .= '@media (min-width:' . (int) $min_res . 'px) {';
 			} elseif ( $max_res < 1920 ) {
-				$css_text .= '@media (max-width:' . intval( $max_res ) . 'px)';
+				$css_text .= '@media (max-width:' . (int) $max_res . 'px)';
 				if ( ! empty( $min_res ) ) {
-					$css_text .= ' and (min-width:' . intval( $min_res ) . 'px) ';
+					$css_text .= ' and (min-width:' . (int) $min_res . 'px) ';
 				}
 				$css_text .= '{ ';
 			}

--- a/inc/post-content-filters.php
+++ b/inc/post-content-filters.php
@@ -38,13 +38,13 @@ class SiteOrigin_Panels_Post_Content_Filters {
 			$attributes[ 'data-style' ] = json_encode( $row['style'] );
 		}
 		if( ! empty( $row['ratio'] ) ) {
-			$attributes[ 'data-ratio' ] = floatval( $row['ratio'] );
+			$attributes[ 'data-ratio' ] = (float) $row['ratio'];
 		}
 		if( ! empty( $row['ratio_direction'] ) ) {
 			$attributes[ 'data-ratio-direction' ] = $row['ratio_direction'];
 		}
 		if( ! empty( $row['color_label'] ) ) {
-			$attributes[ 'data-color-label' ] = intval( $row['color_label'] );
+			$attributes[ 'data-color-label' ] = (int) $row['color_label'];
 		}
 		if( ! empty( $row['label'] ) ) {
 			$attributes[ 'data-label' ] = $row['label'];

--- a/inc/renderer-legacy.php
+++ b/inc/renderer-legacy.php
@@ -75,7 +75,7 @@ class SiteOrigin_Panels_Renderer_Legacy extends SiteOrigin_Panels_Renderer {
 				) );
 			}
 
-			$margin_half = ( floatval( $gutter_parts[1] ) / 2 ) . $gutter_parts[2];
+			$margin_half = ( (float) $gutter_parts[1] / 2 ) . $gutter_parts[2];
 			$css->add_row_css($post_id, $ri, '', array(
 				'margin-left' => '-' . $margin_half,
 				'margin-right' => '-' . $margin_half,

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -106,7 +106,7 @@ class SiteOrigin_Panels_Renderer {
 						// This seems to happen when a plugin calls `setlocale(LC_ALL, 'de_DE');` or `setlocale(LC_NUMERIC, 'de_DE');`
 						// This should prevent issues with column sizes in these cases.
 						str_replace( ',', '.', $rounded_width ),
-						str_replace( ',', '.', intval($gutter) ? $calc_width : '' ), // Exclude if there's a zero gutter
+						str_replace( ',', '.', (int) $gutter ? $calc_width : '' ), // Exclude if there's a zero gutter
 					)
 				) );
 				
@@ -190,11 +190,11 @@ class SiteOrigin_Panels_Renderer {
 						// Tablet responsive css for cells
 
 						$css->add_cell_css( $post_id, $ri, false, ':nth-child(even)', array(
-							'padding-left' => ( floatval( $gutter_parts[1] / 2 ) . $gutter_parts[2] ),
+							'padding-left' => ( (float) $gutter_parts[1] / 2 . $gutter_parts[2] ),
 						), $panels_tablet_width . ':' . ( $panels_mobile_width + 1 ) );
 
 						$css->add_cell_css( $post_id, $ri, false, ':nth-child(odd)', array(
-							'padding-right' => ( floatval( $gutter_parts[1] / 2 ) . $gutter_parts[2] ),
+							'padding-right' => ( (float) $gutter_parts[1] / 2 . $gutter_parts[2] ),
 						), $panels_tablet_width . ':' . ( $panels_mobile_width + 1 ) );
 					}
 
@@ -688,14 +688,14 @@ class SiteOrigin_Panels_Renderer {
 			$layout_data[ $cell['grid'] ]['cells'][] = array(
 				'widgets' => array(),
 				'style'   => ! empty( $cell['style'] ) ? $cell['style'] : array(),
-				'weight'  => floatval( $cell['weight'] ),
+				'weight'  => (float) $cell['weight'],
 			);
 		}
 
 		foreach ( $panels_data['widgets'] as $i => $widget ) {
 			$widget['panels_info']['widget_index'] = $i;
-			$row_index = intval( $widget['panels_info']['grid'] );
-			$cell_index = intval( $widget['panels_info']['cell'] );
+			$row_index = (int) $widget['panels_info']['grid'];
+			$cell_index = (int) $widget['panels_info']['cell'];
 			$layout_data[ $row_index ]['cells'][ $cell_index ]['widgets'][] = $widget;
 		}
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -518,7 +518,7 @@ class SiteOrigin_Panels_Settings {
 			case 'html':
 				?><textarea name="<?php echo esc_attr( $field_name ) ?>"
 				            class="panels-setting-<?php echo esc_attr( $field['type'] ) ?> widefat"
-				            rows="<?php echo ! empty( $field['rows'] ) ? intval( $field['rows'] ) : 2 ?>"><?php echo esc_textarea( $value ) ?></textarea> <?php
+				            rows="<?php echo ! empty( $field['rows'] ) ? (int) $field['rows'] : 2 ?>"><?php echo esc_textarea( $value ) ?></textarea> <?php
 				break;
 
 			case 'checkbox':
@@ -598,7 +598,7 @@ class SiteOrigin_Panels_Settings {
 
 					case 'number':
 						if ( $post[ $field_id ] != '' ) {
-							$values[ $field_id ] = ! empty( $post[ $field_id ] ) ? intval( $post[ $field_id ] ) : 0;
+							$values[ $field_id ] = ! empty( $post[ $field_id ] ) ? (int) $post[ $field_id ] : 0;
 						} else {
 							$values[ $field_id ] = '';
 						}
@@ -606,7 +606,7 @@ class SiteOrigin_Panels_Settings {
 
 					case 'float':
 						if ( $post[ $field_id ] != '' ) {
-							$values[ $field_id ] = ! empty( $post[ $field_id ] ) ? floatval( $post[ $field_id ] ) : 0;
+							$values[ $field_id ] = ! empty( $post[ $field_id ] ) ? (float) $post[ $field_id ] : 0;
 						} else {
 							$values[ $field_id ] = '';
 						}

--- a/inc/sidebars-emulator.php
+++ b/inc/sidebars-emulator.php
@@ -149,10 +149,9 @@ class SiteOrigin_Panels_Sidebars_Emulator {
 	 */
 	public function generate_sidebar_widget_ids( $widgets, $post_id, $start = 1 ) {
 		foreach ( $widgets as $i => &$widget_instance ) {
-			$id_val = $post_id . strval( ( 10000 * $start ) + intval( $i ) );
+			$id_val = $post_id . ( (string) ( 10000 * $start ) + (int) $i );
 			$widget_class = $widget_instance['panels_info']['class'];
-			
-			
+
 			if( $widget_instance['panels_info']['class'] === 'SiteOrigin_Panels_Widgets_Layout' ) {
 				if ( ! empty( $widget_instance['panels_data']['widgets'] ) ) {
 					// Recursively set widget ids in layout widgets.

--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -47,7 +47,7 @@ class SiteOrigin_Panels_Styles_Admin {
 				break;
 
 			case 'cell':
-				$cell_number = isset( $args['index'] ) ? ' ' . ( intval( $args['index'] ) + 1 ) : '';
+				$cell_number = isset( $args['index'] ) ? ' ' . ( (int) $args['index'] + 1 ) : '';
 				$this->render_styles_fields( 'cell', '<h3>' . sprintf( __( 'Cell%s Styles', 'siteorigin-panels' ), $cell_number ) . '</h3>', '', $current, $post_id, $args );
 				break;
 
@@ -248,7 +248,7 @@ class SiteOrigin_Panels_Styles_Admin {
 						<?php _e( 'Select Image', 'siteorigin-panels' ) ?>
 					</div>
 					<input type="hidden" name="<?php echo esc_attr( $field_name ) ?>"
-					       value="<?php echo intval( $current ) ?>"/>
+					       value="<?php echo (int) $current; ?>"/>
 				</div>
 				<a href="#" class="remove-image <?php if ( empty( $current ) ) echo ' hidden' ?>"><?php _e( 'Remove', 'siteorigin-panels' ) ?></a>
 				

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -405,7 +405,7 @@ class SiteOrigin_Panels_Styles {
 					'backgroundUrl'    => $url[0],
 					'backgroundSize'   => array( $url[1], $url[2] ),
 					'backgroundSizing' => $style['background_display'] == 'parallax-original' ? 'original' : 'scaled',
-					'limitMotion'      => siteorigin_panels_setting( 'parallax-motion' ) ? floatval( siteorigin_panels_setting( 'parallax-motion' ) ) : 'auto',
+					'limitMotion'      => siteorigin_panels_setting( 'parallax-motion' ) ? (float) siteorigin_panels_setting( 'parallax-motion' ) : 'auto',
 				);
 				$attributes['data-siteorigin-parallax'] = json_encode( $parallax_args );
 			}

--- a/inc/widgets/post-loop.php
+++ b/inc/widgets/post-loop.php
@@ -162,8 +162,11 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 				} else if ( strpos( $_SERVER['REQUEST_URI'], '/page/' ) !== false ) {
 					// When the widget appears on the home page.
 					preg_match('/\/page\/([0-9]+)\//', $_SERVER['REQUEST_URI'], $matches);
-					if(!empty($matches[1])) $query_args['paged'] = intval($matches[1]);
-					else $query_args['paged'] = 1;
+					if ( ! empty( $matches[1] ) ) {
+						$query_args['paged'] = (int) $matches[1];
+					} else {
+						$query_args['paged'] = 1;
+					}
 				}
 			}
 
@@ -172,7 +175,7 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 			}
 		} else {
 			// Get current page number when we're not using permalinks
-			$query_args['paged'] = isset($_GET['paged']) ? intval($_GET['paged']) : 1;
+			$query_args['paged'] = isset( $_GET['paged'] ) ? (int) $_GET['paged'] : 1;
 		}
 		
 		// Exclude the current post to prevent possible infinite loop

--- a/widgets/widgets.php
+++ b/widgets/widgets.php
@@ -183,10 +183,10 @@ abstract class SiteOrigin_Panels_Widget extends WP_Widget{
 					break;
 				case 'textarea' :
 					if(empty($field_args['height'])) $field_args['height'] = 6;
-					?><textarea class="widefat" id="<?php echo $this->get_field_id( $field_id ); ?>" name="<?php echo $this->get_field_name( $field_id ); ?>" rows="<?php echo intval($field_args['height']) ?>"><?php echo esc_textarea($instance[$field_id]) ?></textarea><?php
+					?><textarea class="widefat" id="<?php echo $this->get_field_id( $field_id ); ?>" name="<?php echo $this->get_field_name( $field_id ); ?>" rows="<?php echo (int) $field_args['height']; ?>"><?php echo esc_textarea($instance[$field_id]) ?></textarea><?php
 					break;
 				case 'number' :
-					?><input type="number" class="small-text" id="<?php echo $this->get_field_id( $field_id ); ?>" name="<?php echo $this->get_field_name( $field_id ); ?>" value="<?php echo floatval($instance[$field_id]) ?>" /><?php
+					?><input type="number" class="small-text" id="<?php echo $this->get_field_id( $field_id ); ?>" name="<?php echo $this->get_field_name( $field_id ); ?>" value="<?php echo (float) $instance[$field_id]; ?>" /><?php
 					break;
 				case 'checkbox' :
 					?><input type="checkbox" class="small-text" id="<?php echo $this->get_field_id( $field_id ); ?>" name="<?php echo $this->get_field_name( $field_id ); ?>" <?php checked(!empty($instance[$field_id])) ?>/><?php


### PR DESCRIPTION
This PR replace PHP 4 type conversion functions with type casts. [This is in line with WordPress 5.6](https://core.trac.wordpress.org/ticket/42918) and there's a slight performance improvement.

`intval()` replaced with `(int)`
`strval()` replaced with `(string)`
`floatval()` replaced with `(float)`

lessc uses `floatval()` but it was not modified.