### PR TITLE
Layout Block: Hide preview button when no preview is available

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -244,14 +244,14 @@ function (_wp$element$Component) {
       };
 
       if (this.state.editing) {
-        return React.createElement(wp.element.Fragment, null, React.createElement(wp.blockEditor.BlockControls, null, React.createElement(wp.components.Toolbar, {
+        return React.createElement(wp.element.Fragment, null, panelsData ? React.createElement(wp.blockEditor.BlockControls, null, React.createElement(wp.components.Toolbar, {
           label: wp.i18n.__('Page Builder Mode.', 'siteorigin-panels')
         }, React.createElement(wp.components.ToolbarButton, {
           icon: "visibility",
           className: "components-icon-button components-toolbar__control",
           label: wp.i18n.__('Preview layout.', 'siteorigin-panels'),
           onClick: switchToPreview
-        }))), React.createElement("div", {
+        }))) : null, React.createElement("div", {
           key: "layout-block",
           className: "siteorigin-panels-layout-block-container",
           ref: this.panelsContainer

--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -332,6 +332,11 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
           setAttributes(panelsAttributes);
           wp.data.dispatch('core/editor').unlockPostSaving();
         });
+      } else {
+        setAttributes({
+          panelsData: null,
+          contentPreview: null
+        });
       }
     };
 

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -279,6 +279,11 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 						wp.data.dispatch( 'core/editor' ).unlockPostSaving(); 
 					}
 				);
+			} else {
+				setAttributes( {
+					panelsData: null,
+					contentPreview: null,
+				} );
 			}
 		};
 		

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -170,16 +170,20 @@ class SiteOriginPanelsLayoutBlock extends wp.element.Component {
 		if ( this.state.editing ) {
 			return (
 				<wp.element.Fragment>
-					<wp.blockEditor.BlockControls>
-						<wp.components.Toolbar label={ wp.i18n.__( 'Page Builder Mode.', 'siteorigin-panels' ) }>
-							<wp.components.ToolbarButton
-								icon="visibility"
-								className="components-icon-button components-toolbar__control"
-								label={ wp.i18n.__( 'Preview layout.', 'siteorigin-panels' ) }
-								onClick={ switchToPreview }
-							/>
-						</wp.components.Toolbar>
-					</wp.blockEditor.BlockControls>
+					{ panelsData ? (
+						<wp.blockEditor.BlockControls>
+							<wp.components.Toolbar label={ wp.i18n.__( 'Page Builder Mode.', 'siteorigin-panels' ) }>
+								<wp.components.ToolbarButton
+									icon="visibility"
+									className="components-icon-button components-toolbar__control"
+									label={ wp.i18n.__( 'Preview layout.', 'siteorigin-panels' ) }
+									onClick={ switchToPreview }
+								/>
+							</wp.components.Toolbar>
+						</wp.blockEditor.BlockControls>
+					) : (
+						null
+					) }
 					<div
 						key="layout-block"
 						className="siteorigin-panels-layout-block-container"


### PR DESCRIPTION
This PR will prevent the SiteOrigin Layout Preview button from appearing when in edit mode if there's no panelsData. It'll also reset the panelsData if the user removes all rows from the SiteOrigin Layout to prevent the preview (no longer valid) preview from showing.

This change also prevents a previewing error that commonly occurs while using PHP 8. When using PHP 8, when the SiteOrigin Layout triggers an update to the server and you're in editing mode, clicking the block preview won't do anything - a second click after the preview has loaded is required to view it. Normally it switches to preview mode and adds a loading indicator.

This PR can be triggered by adding a SiteOrigin Layout Block. The preview won't appear. Add a widget and it'll appear. Remove it, and it'll disappear.