### PR TITLE
Copy Content: Encode Multibyte Unicode Characters Literally

### DIFF
--- a/inc/widget-shortcode.php
+++ b/inc/widget-shortcode.php
@@ -106,7 +106,7 @@ class SiteOrigin_Panels_Widget_Shortcode {
 	}
 
 	static function encode_data( $data ){
-		return '<input type="hidden" value="' . htmlentities( json_encode( $data ), ENT_QUOTES ) . '" />';
+		return '<input type="hidden" value="' . esc_attr( json_encode( $data, JSON_UNESCAPED_UNICODE ) ) . '" />';
 	}
 
 	static function decode_data( $string ){


### PR DESCRIPTION
Resolve https://github.com/siteorigin/so-widgets-bundle/issues/888
[JSON_UNESCAPED_UNICODE PHP.net Reference](https://www.php.net/manual/en/json.constants.php#constant.json-unescaped-unicode)

This will prevent an issue where certain languages, such as Greek, would be encoded and be unsearchable. Here's the test string I'm using:

`Αυτό το κείμενο χρησιμοποιείται για τη δοκιμή ενός ζητήματος που σχετίζεται με το γραφικό στοιχείο της δυνατότητας SiteOrigin.`

This PR is not retroactive so after switching to this branch you'll need to make a change to the page (Copy Content won't be triggered if no change is detected) for the updated text to be stored.