### PR TITLE
SiteOrigin Layout: Don't Attempt to Render Empty Layout

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1199,7 +1199,7 @@ class SiteOrigin_Panels_Admin {
 	 */
 	public function layout_block_preview() {
 
-		if ( empty( $_REQUEST['_panelsnonce'] ) || ! wp_verify_nonce( $_REQUEST['_panelsnonce'], 'layout-block-preview' ) ) {
+		if ( empty( $_POST['panelsData'] ) || empty( $_REQUEST['_panelsnonce'] ) || ! wp_verify_nonce( $_REQUEST['_panelsnonce'], 'layout-block-preview' ) ) {
 			wp_die();
 		}
 


### PR DESCRIPTION
This PR will prevent a situation where the SiteOrigin Layout will attempt to render an empty block. This situation should rarely happen after https://github.com/siteorigin/siteorigin-panels/pull/837 but if the user clicks fast enough they can force it.

`[25-Dec-2020 11:40:49 UTC] PHP Warning:  Undefined array key "panelsData" in C:\Users\Alex S\Local Beta Sites\siteorigin\app\public\wp-content\plugins\siteorigin-panels\inc\admin.php on line 1206`