### PR TITLE
CSS Builder Resolve PHP 8 Notice

### DIFF
--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -154,7 +154,7 @@ class SiteOrigin_Panels_Css_Builder {
 	 * @param int $resolution The pixel resolution that this applies to
 	 * @param bool $specify_layout Sometimes for CSS specificity, we need to include the layout ID.
 	 */
-	public function add_widget_css( $li, $ri = false, $ci = false, $wi = false, $sub_selector, $attributes = array(), $resolution = 1920, $specify_layout = false ) {
+	public function add_widget_css( $li, $ri = false, $ci = false, $wi = false, $sub_selector = '', $attributes = array(), $resolution = 1920, $specify_layout = false ) {
 		$selector = array();
 
 		if ( $ri === false && $ci === false && $wi === false ) {


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/838

This PR resolves a deprecated notice while using PHP 8. `$sub_selector` is meant to be optional but it previously wasn't set as one.

[25-Dec-2020 11:27:47 UTC] PHP Deprecated:  Required parameter $sub_selector follows optional parameter $ri in C:\Users\Alex S\Local Beta Sites\siteorigin\app\public\wp-content\plugins\siteorigin-panels\inc\css-builder.php on line 157