### PR TITLE
Limit CSS Output Location Setting to Classic Editor

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -25,14 +25,23 @@ class SiteOrigin_Panels_Renderer {
 		if ( is_null( $this->inline_css ) ) {
 			// Initialize the inline CSS array and add actions to handle printing.
 			$this->inline_css = array();
-
+			$css_output_set = false;
 			$output_css = siteorigin_panels_setting( 'output-css-header');
+
 			if ( is_admin() || SiteOrigin_Panels_Admin::is_block_editor() || $output_css == 'auto' ) {
 				add_action( 'wp_head', array( $this, 'print_inline_css' ), 12 );
 				add_action( 'wp_footer', array( $this, 'print_inline_css' ) );
-			} else if ( $output_css == 'header' ) {
+				$css_output_set = true;
+			}
+
+			// The CSS can only be output in the header if the page is powered by the Classic Editor.
+			// $post_id won't be a number if the current page is powered by the Block Editor.
+			if ( ! $css_output_set && $output_css == 'header' && is_numeric( $post_id ) ) {
 				add_action( 'wp_head', array( $this, 'print_inline_css' ), 12 );
-			} else {
+				$css_output_set = true;
+			}
+
+			if ( ! $css_output_set ) {
 				add_action( 'wp_footer', array( $this, 'print_inline_css' ) );
 			}
 		}

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -455,6 +455,7 @@ class SiteOrigin_Panels_Settings {
 				'footer' => __( 'Footer', 'siteorigin-panels' ),
 			),
 			'label'       => __( 'Page Builder Layout CSS Output Location', 'siteorigin-panels' ),
+			'description' => __( 'This setting is only applicable in the Classic Editor.', 'siteorigin-panels' ),
 		);
 
 		// The content fields


### PR DESCRIPTION
Related https://siteorigin.com/thread/having-issue-with-page-builder-layout-css-output/

The CSS Output Location setting isn't compatible with the Block Editor in a reliable manner - it's rare that it does work. This PR will limit this setting to the Block Editor and add it mentions this limitation in the description in the CSS Output Location description.