### PR TITLE
WP 5.7: Prevent duplicate Add SO Layout button

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -368,7 +368,16 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
         var editorDispatch = wp.data.dispatch('core/editor');
         var editorSelect = wp.data.select('core/editor');
         var tmpl = jQuery('#siteorigin-panels-add-layout-block-button').html();
-        var $addButton = jQuery(tmpl).insertAfter('.editor-writing-flow > div:first, .block-editor-writing-flow > div:not([tabindex])');
+
+        if (jQuery('.block-editor-writing-flow > .block-editor-block-list__layout').length) {
+          // > WP 5.7
+          var buttonSelector = '.block-editor-writing-flow > .block-editor-block-list__layout';
+        } else {
+          // < WP 5.7
+          var buttonSelector = '.editor-writing-flow > div:first, .block-editor-writing-flow > div:not([tabindex])';
+        }
+
+        var $addButton = jQuery(tmpl).appendTo(buttonSelector);
         $addButton.on('click', function () {
           var layoutBlock = wp.blocks.createBlock('siteorigin-panels/layout-block', {});
           var isEmpty = editorSelect.isEditedPostEmpty();

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -319,7 +319,14 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 				const editorDispatch = wp.data.dispatch( 'core/editor' );
 				const editorSelect = wp.data.select( 'core/editor' );
 				var tmpl = jQuery( '#siteorigin-panels-add-layout-block-button' ).html();
-				var $addButton = jQuery(tmpl).insertAfter( '.editor-writing-flow > div:first, .block-editor-writing-flow > div:not([tabindex])' );
+				if ( jQuery( '.block-editor-writing-flow > .block-editor-block-list__layout' ).length ) {
+					// > WP 5.7
+					var buttonSelector = '.block-editor-writing-flow > .block-editor-block-list__layout';
+				} else {
+					// < WP 5.7
+					var buttonSelector = '.editor-writing-flow > div:first, .block-editor-writing-flow > div:not([tabindex])';
+				}
+				var $addButton = jQuery( tmpl ).appendTo( buttonSelector );
 				$addButton.on( 'click', () => {
 					var layoutBlock = wp.blocks.createBlock( 'siteorigin-panels/layout-block', {} );
 					const isEmpty = editorSelect.isEditedPostEmpty();


### PR DESCRIPTION
Resolve duplicate SO Layout Button in WordPress 5.7:

<img width="938" alt="Edit_Page_‹_SiteOrigin_—_WordPress" src="https://user-images.githubusercontent.com/17275120/110010451-093e1100-7d6a-11eb-9802-ff05e8980081.png">

Note: The selectors needed for this button are too long to do on a single line or I would have used a ternary. A build will be required for this change to be visible.