### PR TITLE
Allow Layout Title to Extend Panel Height

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1655,7 +1655,6 @@
 					}
 
 					.so-screenshot {
-						flex: 3 auto;
 						margin-bottom: 10px;
 						cursor: pointer;
 
@@ -1687,7 +1686,6 @@
 					}
 
 					.so-description {
-						flex: 1 auto;
 						font-size: 0.9em;
 						color: #666;
 						margin-bottom: 10px;
@@ -1698,14 +1696,11 @@
 					.so-bottom {
 						flex: 1 auto;
 						position: relative;
-						max-height: 50px;
 
 						.so-title {
 							margin: 0;
 							padding: 16px 10px;
 							cursor: pointer;
-							overflow: hidden;
-							white-space: nowrap;
 						}
 
 						.so-buttons {


### PR DESCRIPTION
Resolve #848

![Screenshot_2021-03-16 Edit Page ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/111202905-27302f00-8610-11eb-80d2-c4dba8e22a76.png)