### PR TITLE
Lazy Load Compat

### DIFF
--- a/compat/lazy-load-backgrounds.php
+++ b/compat/lazy-load-backgrounds.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Apply background and LazyLoad attributes/classes to rows, cells and widgets.
+ * Apply background and Lazy Load attributes/classes to rows, cells and widgets.
  *
  * @param $attributes
  * @param $style
@@ -8,7 +8,7 @@
  * @return array $attributes
  */
 
-function siteorigin_apply_lazyload_attributes( $attributes, $style ) {
+function siteorigin_apply_lazy_load_attributes( $attributes, $style ) {
 	if (
 		! empty( $style['background_display'] ) &&
 		! empty( $style['background_image_attachment'] ) &&
@@ -27,7 +27,7 @@ function siteorigin_apply_lazyload_attributes( $attributes, $style ) {
 			}
 
 			// Other lazy loads can sometimes use an inline background image.
-			if ( apply_filters( 'siteorigin_lazyload_inline_background', false ) ) {
+			if ( apply_filters( 'siteorigin_lazy_load_inline_background', false ) ) {
 				$attributes['style'] = 'background-image: url(' . $url[0] . ')';
 			}
 		}
@@ -35,9 +35,9 @@ function siteorigin_apply_lazyload_attributes( $attributes, $style ) {
 
 	return $attributes;
 }
-add_filter( 'siteorigin_panels_row_style_attributes', 'siteorigin_apply_lazyload_attributes', 10, 2 );
-add_filter( 'siteorigin_panels_cell_style_attributes', 'siteorigin_apply_lazyload_attributes', 10, 2 );
-add_filter( 'siteorigin_panels_widget_style_attributes', 'siteorigin_apply_lazyload_attributes', 10, 2 );
+add_filter( 'siteorigin_panels_row_style_attributes', 'siteorigin_apply_lazy_load_attributes', 10, 2 );
+add_filter( 'siteorigin_panels_cell_style_attributes', 'siteorigin_apply_lazy_load_attributes', 10, 2 );
+add_filter( 'siteorigin_panels_widget_style_attributes', 'siteorigin_apply_lazy_load_attributes', 10, 2 );
 
 /**
  * Prevent background image from being added using CSS.

--- a/compat/lazyload-backgrounds.php
+++ b/compat/lazyload-backgrounds.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Apply background and LazyLoad attributes/classes to rows, cells and widgets.
+ *
+ * @param $attributes
+ * @param $style
+ *
+ * @return array $attributes
+ */
+
+function siteorigin_apply_lazyload_attributes( $attributes, $style ) {
+	if (
+		! empty( $style['background_display'] ) &&
+		! empty( $style['background_image_attachment'] ) &&
+		$style['background_display'] != 'parallax' &&
+		$style['background_display'] != 'parallax-original'
+	) {
+		$url = SiteOrigin_Panels_Styles::get_attachment_image_src( $style['background_image_attachment'], 'full' );
+
+		if ( ! empty( $url ) ) {
+			$attributes['class'][] = 'lazy';
+			$attributes['data-bg'] = $url[0];
+
+			// WP Rocket uses a different lazy load class.
+			if ( defined( 'ROCKET_LL_VERSION' ) ) {
+				$attributes['class'][] = 'rocket-lazyload';
+			}
+
+			// Other lazy loads can sometimes use an inline background image.
+			if ( apply_filters( 'siteorigin_lazyload_inline_background', false ) ) {
+				$attributes['style'] = 'background-image: url(' . $url[0] . ')';
+			}
+		}
+	}
+
+	return $attributes;
+}
+add_filter( 'siteorigin_panels_row_style_attributes', 'siteorigin_apply_lazyload_attributes', 10, 2 );
+add_filter( 'siteorigin_panels_cell_style_attributes', 'siteorigin_apply_lazyload_attributes', 10, 2 );
+add_filter( 'siteorigin_panels_widget_style_attributes', 'siteorigin_apply_lazyload_attributes', 10, 2 );
+
+/**
+ * Prevent background image from being added using CSS.
+ *
+ * @param $css
+ * @param $style
+ *
+ * @return mixed
+ */
+function siteorigin_prevent_background_css( $css, $style ) {
+	if (
+		! empty( $css['background-image'] ) &&
+		$style['background_display'] != 'parallax' &&
+		$style['background_display'] != 'parallax-original'
+	) {
+		unset( $css['background-image'] );
+	}
+
+	return $css;
+}
+add_filter( 'siteorigin_panels_row_style_css', 'siteorigin_prevent_background_css', 10, 2 );
+add_filter( 'siteorigin_panels_cell_style_css', 'siteorigin_prevent_background_css', 10, 2 );
+add_filter( 'siteorigin_panels_widget_style_css', 'siteorigin_prevent_background_css', 10, 2 );

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -212,7 +212,10 @@ class SiteOrigin_Panels {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/amp.php';
 		}
 
-		if ( defined( 'ROCKET_LL_VERSION' ) || apply_filters( 'siteorigin_lazy_load_compat', false ) ) {
+		$lazy_load_settings = get_option( 'rocket_lazyload_options' );
+		$load_lazy_load_compat = defined( 'ROCKET_LL_VERSION' ) && ! empty( $lazy_load_settings ) && ! empty( $lazy_load_settings['images'] );
+		
+		if ( $load_lazy_load_compat || apply_filters( 'siteorigin_lazyload_compat', false ) ) {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/lazy-load-backgrounds.php';
 		}
 	}

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -211,6 +211,10 @@ class SiteOrigin_Panels {
 		if ( is_admin() && function_exists( 'amp_bootstrap_plugin' ) ) {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/amp.php';
 		}
+
+		if ( defined( 'ROCKET_LL_VERSION' ) || apply_filters( 'siteorigin_lazyload_compat', false ) ) {
+			require_once plugin_dir_path( __FILE__ ) . 'compat/lazyload-backgrounds.php';
+		}
 	}
 
 	/**

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -213,7 +213,7 @@ class SiteOrigin_Panels {
 		}
 
 		if ( defined( 'ROCKET_LL_VERSION' ) || apply_filters( 'siteorigin_lazy_load_compat', false ) ) {
-			require_once plugin_dir_path( __FILE__ ) . 'compat/lazy_load-backgrounds.php';
+			require_once plugin_dir_path( __FILE__ ) . 'compat/lazy-load-backgrounds.php';
 		}
 	}
 

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -212,8 +212,8 @@ class SiteOrigin_Panels {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/amp.php';
 		}
 
-		if ( defined( 'ROCKET_LL_VERSION' ) || apply_filters( 'siteorigin_lazyload_compat', false ) ) {
-			require_once plugin_dir_path( __FILE__ ) . 'compat/lazyload-backgrounds.php';
+		if ( defined( 'ROCKET_LL_VERSION' ) || apply_filters( 'siteorigin_lazy_load_compat', false ) ) {
+			require_once plugin_dir_path( __FILE__ ) . 'compat/lazy_load-backgrounds.php';
 		}
 	}
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/850

This PR allows for plugins/themes that add [LazyLoad](https://github.com/verlok/vanilla-lazyload) to be able to lazy load row, cell, and widget backgrounds. Backgrounds set to parallax will not be lazy loaded.

To this please install [Lazy Load](https://wordpress.org/plugins/rocket-lazy-load/)
Once installed please navigate to **Settings > LazyLoad** and enable **Images**.

Filters:
Enable Lazy Load Compat if Lazy Load plugin isn't installed.:
`add_filter( 'siteorigin_lazy_load_compat', '__return_true' );`

Inline Background Image (requires first snippet if LazyLoad plugin isn't enabled):
`add_filter( 'siteorigin_lazy_load_inline_background', '__return_true' );`

You can test the second snippet while lazy loading is enabled by commenting out the following line:
`$attributes['data-bg'] = $url[0];`


(that plugin picks up on both and will favour the `data-bg`)