### PR TITLE
Prebuilt Layouts: Check for JSON MIME

### DIFF
--- a/inc/admin-layouts.php
+++ b/inc/admin-layouts.php
@@ -97,7 +97,9 @@ class SiteOrigin_Panels_Admin_Layouts {
 						$mime_type = mime_content_type( $file );
 						
 						// Valid if text files.
-						$valid_file_type = strpos( $mime_type, 'text/' ) === 0;
+
+						// Valid if text or json file.
+						$valid_file_type = strpos( $mime_type, '/json' ) || strpos( $mime_type, 'text/' ) > -1;
 					} else {
 						// If `mime_content_type` isn't available, just check file extension.
 						$ext = pathinfo( $file, PATHINFO_EXTENSION );


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/853

This PR resolves an issue caused by using .json files with [the proper JSON MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) instead of a text mime type. This issue resulted in the layout being committed from the prebuilt layout list.