### PR TITLE
Remove Add Layout button height: 100% to avoid sizing issue

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -2102,7 +2102,6 @@
 		margin-right: auto;
 		
 		> button {
-			height: 100%;
 			padding: 5px 10px;
 			font-size: 16px;
 			


### PR DESCRIPTION
Fixes a situation where the Add Layout button may be larger than expected.

<img width="1357" alt="Add_New_Page_‹_SiteOrigin_—_WordPress" src="https://user-images.githubusercontent.com/17275120/113561088-666a0280-9647-11eb-981b-1e9cbe149965.png">
