### PR TITLE
Automatic Excerpt: Add Support for Block Editor

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -384,9 +384,23 @@ class SiteOrigin_Panels {
 		}
 
 		$post_id = $this->get_post_id();
-
-		// Check if this post has panels_data
 		$panels_data = get_post_meta( $post_id, 'panels_data', true );
+
+		// If no panels_data is detected, check if the post has blocks.
+		if ( empty( $panels_data ) ) {
+			if ( has_blocks( get_the_content() ) ) {
+				$parsed_content = parse_blocks( get_the_content() );
+				// Check if the first block is an SO Layout Block, and extract panels_data if it is.
+				if (
+					$parsed_content[0]['blockName'] == 'siteorigin-panels/layout-block' &&
+					isset( $parsed_content[0]['attrs'] ) &&
+					! empty( $parsed_content[0]['attrs']['panelsData'] )
+				) {
+					$panels_data = $parsed_content[0]['attrs']['panelsData'];
+				}
+			}
+		}
+
 		if ( $panels_data && ! empty( $panels_data['widgets'] ) ) {
 			$raw_excerpt = '';
 			$excerpt_length = apply_filters( 'excerpt_length', 55 );


### PR DESCRIPTION
This PR extends the automatic excerpt generation to support the Block Editor. The first block has to be a SiteOrigin Layout Block for the content to be extracted.