### PR TITLE
Automatic Excerpt: Add Support for Excerpt

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -406,6 +406,14 @@ class SiteOrigin_Panels {
 					if ( $this->get_localized_word_count( $text ) >= $excerpt_length ) {
 						break;
 					}
+
+					// Check for more quicktag.
+					if ( strpos( $text, '<!--more' ) !== false ) {
+						// Only return everything prior to more quicktag.
+						$raw_excerpt = explode( '<!--more', $text )[0];
+						$excerpt_length = $this->get_localized_word_count( $raw_excerpt );
+						break;
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR adds support for the more quicktag. It doesn't however add support for custom more text as automatic WP excerpts don't allow for HTML. Prior to this PR the more quicktag would be ignored.