### PR TITLE
Prevent repeated potential rendering of PB Layouts

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -305,6 +305,16 @@ class SiteOrigin_Panels_Renderer {
 		}
 
 		global $siteorigin_panels_current_post;
+		// If the post being processed is the same as the last one, don't process it.
+		if (
+			! empty( $siteorigin_panels_current_post ) &&
+			apply_filters( 'siteorigin_panels_renderer_current_post_check', true ) &&
+			$siteorigin_panels_current_post == $post_id
+		) {
+			trigger_error( __( 'Prevented SiteOrigin layout from repeated rendering.', 'siteorigin-panels' ) );
+			return;
+		}
+
 		$old_current_post = $siteorigin_panels_current_post;
 		$siteorigin_panels_current_post = $post_id;
 


### PR DESCRIPTION
This PR prevents pages from processing twice if the previous page was the same as the current one. When this happens, an error is logged in the error_log, and the renderer fails silently.

[Here's a test plugin](https://drive.google.com/uc?id=14pfrGVuVZ6_Mj4-JmP1oZowIpJOB1w_e). Once installed, add [so_test] to any page that you want to test the PR against. Please note that while this PR isn't active, the page won't work nor will it be editable due to an infinite loop.

This commit adds `siteorigin_panels_renderer_current_post_check` filter to prevent this check. Here's a snippet to test that filter:

`add_filter( 'siteorigin_panels_renderer_current_post_check', '__return_true' );`