### PR TITLE
Move PB Metabox PHP Outside of Template

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -204,6 +204,9 @@ class SiteOrigin_Panels_Admin {
 		$panels_data = $this->get_current_admin_panels_data();
 		$preview_url = SiteOrigin_Panels::preview_url();
 		$preview_content = $this->generate_panels_preview( $post->ID, $panels_data );
+		$builder_id = uniqid();
+		$builder_type = apply_filters( 'siteorigin_panels_post_builder_type', 'editor_attached', $post, $panels_data );
+		$builder_supports = apply_filters( 'siteorigin_panels_builder_supports', array(), $post, $panels_data );
 		include plugin_dir_path( __FILE__ ) . '../tpl/metabox-panels.php';
 	}
 

--- a/tpl/metabox-panels.php
+++ b/tpl/metabox-panels.php
@@ -1,10 +1,3 @@
-<?php
-global $post;
-$builder_id = uniqid();
-$builder_type = apply_filters( 'siteorigin_panels_post_builder_type', 'editor_attached', $post, $panels_data );
-$builder_supports = apply_filters( 'siteorigin_panels_builder_supports', array(), $post, $panels_data );
-?>
-
 <div id="siteorigin-panels-metabox"
 	data-builder-type="<?php echo esc_attr( $builder_type ) ?>"
 	data-preview-url="<?php echo $preview_url; ?>"


### PR DESCRIPTION
This PR will move the PHP outside of the Metabox template into the admin.php file. It also resolves https://github.com/siteorigin/siteorigin-premium/issues/506