### PR TITLE
Add checks for has_blocks() before using it

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1378,13 +1378,13 @@ class SiteOrigin_Panels_Admin {
 		}
 
 		$post_types = siteorigin_panels_setting( 'post-types' );
-        global $pagenow;
+		global $pagenow;
 		// If the `$post_type` is set to be used by Page Builder for new posts.
 		$is_new_panels_type = $pagenow == 'post-new.php' && in_array( $post_type, $post_types );
 		$use_classic = siteorigin_panels_setting( 'use-classic' );
 		// For existing posts.
 		global $post;
-		if ( ! empty( $post ) ) {
+		if ( function_exists( 'has_blocks' ) && ! empty( $post ) ) {
 			// If the post has blocks just allow `$use_block_editor` to decide.
 			if ( ! has_blocks( $post ) ) {
 				$panels_data = get_post_meta( $post->ID, 'panels_data', true );

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -388,7 +388,7 @@ class SiteOrigin_Panels {
 
 		// If no panels_data is detected, check if the post has blocks.
 		if ( empty( $panels_data ) ) {
-			if ( has_blocks( get_the_content() ) ) {
+			if ( function_exists( 'has_blocks' ) && has_blocks( get_the_content() ) ) {
 				$parsed_content = parse_blocks( get_the_content() );
 				// Check if the first block is an SO Layout Block, and extract panels_data if it is.
 				if (


### PR DESCRIPTION
The change in siteorigin-panels.php will prevent a potential fatal error on WP pre-5.0 websites.
The change in admin.php is a precautionary change as that line won't result in an error, but there is a small possibility it may trigger one regardless.