### PR TITLE
Correctly ensure either Background, or fallback is set

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -504,8 +504,8 @@ class SiteOrigin_Panels_Styles {
 		}
 
 		if (
-			! (
-				! empty( $style['background_image_attachment'] ) &&
+			(
+				! empty( $style['background_image_attachment'] ) ||
 				! empty( $style['background_image_attachment_fallback'] )
 			) &&
 			! empty( $style['background_display'] ) &&


### PR DESCRIPTION
This PR is in response to https://wordpress.org/support/topic/fiexed-backgrounds-dissapear-after-upgrading-2-12-0/

The user had a background, an external background, and a background color set so it would always fail this check.