### PR TITLE
ACF: Ensure at least version 5.7.10 is being used before loading compat

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -73,7 +73,10 @@ class SiteOrigin_Panels_Admin {
 		add_action( 'admin_print_scripts-post-new.php', array( $this, 'enqueue_seo_compat' ), 100 );
 		add_action( 'admin_print_scripts-post.php', array( $this, 'enqueue_seo_compat' ), 100 );
 
-		if ( class_exists( 'ACF' ) ) {
+		if (
+			class_exists( 'ACF' ) &&
+			version_compare( get_option( 'acf_version' ), '5.7.10', '>=' )
+		) {
 			SiteOrigin_Panels_Compat_ACF_Widgets::single();
 		}
 


### PR DESCRIPTION
This PR will prevent an error for those using versions of ACF older than 5.7.10. Version based on [this changelog](https://www.advancedcustomfields.com/blog/acf-5-7-10-release/). It will however mean that the user won't be able to use ACF in widgets.

```
An error of type E_ERROR was caused in line 69 of the file
/home/**/public_html/rhpic/wp-content/plugins/siteorigin-panels/compat/acf-widgets.php.
```