### PR TITLE
Lazy Load: Add Support for Main WP Rocket Plugin

### DIFF
--- a/compat/lazy-load-backgrounds.php
+++ b/compat/lazy-load-backgrounds.php
@@ -22,7 +22,7 @@ function siteorigin_apply_lazy_load_attributes( $attributes, $style ) {
 			$attributes['data-bg'] = $url[0];
 
 			// WP Rocket uses a different lazy load class.
-			if ( defined( 'ROCKET_LL_VERSION' ) ) {
+			if ( defined( 'ROCKET_LL_VERSION' ) || function_exists( 'get_rocket_option' ) ) {
 				$attributes['class'][] = 'rocket-lazyload';
 			}
 

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -212,10 +212,17 @@ class SiteOrigin_Panels {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/amp.php';
 		}
 
-		$lazy_load_settings = get_option( 'rocket_lazyload_options' );
-		$load_lazy_load_compat = defined( 'ROCKET_LL_VERSION' ) && ! empty( $lazy_load_settings ) && ! empty( $lazy_load_settings['images'] );
+		$load_lazy_load_compat = false;
+		// LazyLoad by WP Rocket.
+		if ( defined( 'ROCKET_LL_VERSION' ) ) {
+			$lazy_load_settings = get_option( 'rocket_lazyload_options' );
+			$load_lazy_load_compat = ! empty( $lazy_load_settings ) && ! empty( $lazy_load_settings['images'] );
+		// WP Rocket
+		} elseif ( function_exists( 'get_rocket_option' ) && ! defined( 'DONOTROCKETOPTIMIZE' ) ) {
+			$load_lazy_load_compat = get_rocket_option( 'lazyload' ) && apply_filters( 'do_rocket_lazyload', true );
+		}
 		
-		if ( $load_lazy_load_compat || apply_filters( 'siteorigin_lazyload_compat', false ) ) {
+		if ( apply_filters( 'siteorigin_lazyload_compat', $load_lazy_load_compat ) ) {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/lazy-load-backgrounds.php';
 		}
 	}


### PR DESCRIPTION
This PR adds support for the main WP Rocket plugin's Lazy Load.

- DONOTROCKETOPTIMIZE will be set by WP Rocket (or a developer) if the current context doesn't allow for optimization. By default, this happens when logged into an account so you'll need to either enable optimizations for logged in users or view the page while logged out for the background to lazy load.
- The `do_rocket_lazyload` filter is the method recommended by WP Rocket for disabling Lazy Load on a page by page basis.