### PR TITLE
Don't cheap for repeated rendering if $panels_data was supplied

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -305,8 +305,9 @@ class SiteOrigin_Panels_Renderer {
 		}
 
 		global $siteorigin_panels_current_post;
-		// If the post being processed is the same as the last one, don't process it.
+		// If $panels_data is empty, and the current post being processed is the same as the last one, don't process it.
 		if (
+			empty( $panels_data ) &&
 			! empty( $siteorigin_panels_current_post ) &&
 			apply_filters( 'siteorigin_panels_renderer_current_post_check', true ) &&
 			$siteorigin_panels_current_post == $post_id


### PR DESCRIPTION
We don't automatically provide `$panels_data` anywhere in Page Builder so checking if `$panels_data` exists prior to checking for repeated rendering will account for more developer use cases. To test this you'll need to render a page builder layout on a page and then render another one with $panels_data supplied. That could look like this:

```
var_dump( SiteOrigin_Panels::renderer()->render() );
var_dump( SiteOrigin_Panels::renderer()->render( false, true, get_post_meta( POST_ID_HERE, 'panels_data', true )) ); // Prior to PR, will output nothing
```

Replace `POST_ID_HERE` with the id of a page with page builder data.
