### PR TITLE
Individual row collapse value

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -161,8 +161,6 @@ class SiteOrigin_Panels_Renderer {
 
 			$collapse_order = ! empty( $row['style']['collapse_order'] ) ? $row['style']['collapse_order'] : ( ! is_rtl() ? 'left-top' : 'right-top' );
 
-			
-			// Gets rows set collapse point
 			// Let other themes and plugins change the row collapse point.
 			$collapse_point = apply_filters( 'siteorigin_panels_css_row_collapse_point', '', $row, $ri, $panels_data );
 
@@ -216,7 +214,7 @@ class SiteOrigin_Panels_Renderer {
 				}
 
 				// Mobile Responsive
-				// Uses rows custom collapse point or sets mobile collapse point set on settings page
+				// Uses rows custom collapse point or sets mobile collapse point set on settings page.
 				$css->add_row_css( $post_id, $ri, array(
 					'.panel-no-style',
 					'.panel-has-style > .panel-row-style'
@@ -224,16 +222,14 @@ class SiteOrigin_Panels_Renderer {
 					'-webkit-flex-direction' => $collapse_order == 'left-top' ? 'column' : 'column-reverse',
 					'-ms-flex-direction'     => $collapse_order == 'left-top' ? 'column' : 'column-reverse',
 					'flex-direction'         => $collapse_order == 'left-top' ? 'column' : 'column-reverse',
-				), (($collapse_point != '') ? $collapse_point : $panels_mobile_width));
+				), $collapse_point != '' ? $collapse_point : $panels_mobile_width );
 
-				// Uses rows custom collapse point or sets mobile collapse point set on settings page
+				// Uses rows custom collapse point or sets mobile collapse point set on settings page.
 				$css->add_cell_css( $post_id, $ri, false, '', array(
 					'width' => '100%',
 					'margin-right' => 0,
-				), (($collapse_point != '') ? $collapse_point : $panels_mobile_width));
+				), $collapse_point != '' ? $collapse_point : $panels_mobile_width );
 
-							
-				
 				foreach ( $row['cells'] as $ci => $cell ) {
 					if ( ( $collapse_order == 'left-top' && $ci != $cell_count - 1 ) || ( $collapse_order == 'right-top' && $ci !== 0 ) ) {
 						$css->add_cell_css( $post_id, $ri, $ci, '', array(

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -214,6 +214,7 @@ class SiteOrigin_Panels_Renderer {
 				}
 
 				// Mobile Responsive
+				$collapse_point = ! empty( $collapse_point ) ? $collapse_point : $panels_mobile_width;
 				// Uses rows custom collapse point or sets mobile collapse point set on settings page.
 				$css->add_row_css( $post_id, $ri, array(
 					'.panel-no-style',
@@ -222,13 +223,13 @@ class SiteOrigin_Panels_Renderer {
 					'-webkit-flex-direction' => $collapse_order == 'left-top' ? 'column' : 'column-reverse',
 					'-ms-flex-direction'     => $collapse_order == 'left-top' ? 'column' : 'column-reverse',
 					'flex-direction'         => $collapse_order == 'left-top' ? 'column' : 'column-reverse',
-				), $collapse_point != '' ? $collapse_point : $panels_mobile_width );
+				), $collapse_point );
 
 				// Uses rows custom collapse point or sets mobile collapse point set on settings page.
 				$css->add_cell_css( $post_id, $ri, false, '', array(
 					'width' => '100%',
 					'margin-right' => 0,
-				), $collapse_point != '' ? $collapse_point : $panels_mobile_width );
+				), $collapse_point );
 
 				foreach ( $row['cells'] as $ci => $cell ) {
 					if ( ( $collapse_order == 'left-top' && $ci != $cell_count - 1 ) || ( $collapse_order == 'right-top' && $ci !== 0 ) ) {
@@ -243,7 +244,7 @@ class SiteOrigin_Panels_Renderer {
 								$panels_data,
 								$post_id
 							)
-						), $panels_mobile_width );
+						), $collapse_point );
 					}
 				}
 				
@@ -251,7 +252,7 @@ class SiteOrigin_Panels_Renderer {
 					// If we need a different bottom margin for
 					$css->add_row_css( $post_id, $ri, '', array(
 						'margin-bottom' => $panels_mobile_margin_bottom
-					), $panels_mobile_width );
+					), $collapse_point );
 				}
 					
 				

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -161,12 +161,18 @@ class SiteOrigin_Panels_Renderer {
 
 			$collapse_order = ! empty( $row['style']['collapse_order'] ) ? $row['style']['collapse_order'] : ( ! is_rtl() ? 'left-top' : 'right-top' );
 
+			
+			// Gets rows set collapse point
+			// Let other themes and plugins change the row collapse point.
+			$collapse_point = apply_filters( 'siteorigin_panels_css_row_collapse_point', '', $row, $ri, $panels_data );
+
 			if ( $settings['responsive'] && empty( $row['style']['collapse_behaviour'] ) ) {
 				// The default collapse behaviour
 				if (
 					$settings['tablet-layout'] &&
 					$cell_count >= 3 &&
-					$panels_tablet_width > $panels_mobile_width
+					$panels_tablet_width > $panels_mobile_width &&
+					$collapse_point != ''
 				) {
 					// Tablet responsive css for the row
 
@@ -210,6 +216,7 @@ class SiteOrigin_Panels_Renderer {
 				}
 
 				// Mobile Responsive
+				// Uses rows custom collapse point or sets mobile collapse point set on settings page
 				$css->add_row_css( $post_id, $ri, array(
 					'.panel-no-style',
 					'.panel-has-style > .panel-row-style'
@@ -217,13 +224,15 @@ class SiteOrigin_Panels_Renderer {
 					'-webkit-flex-direction' => $collapse_order == 'left-top' ? 'column' : 'column-reverse',
 					'-ms-flex-direction'     => $collapse_order == 'left-top' ? 'column' : 'column-reverse',
 					'flex-direction'         => $collapse_order == 'left-top' ? 'column' : 'column-reverse',
-				), $panels_mobile_width );
+				), (($collapse_point != '') ? $collapse_point : $panels_mobile_width));
 
+				// Uses rows custom collapse point or sets mobile collapse point set on settings page
 				$css->add_cell_css( $post_id, $ri, false, '', array(
 					'width' => '100%',
 					'margin-right' => 0,
-				), $panels_mobile_width );
-				
+				), (($collapse_point != '') ? $collapse_point : $panels_mobile_width));
+
+							
 				
 				foreach ( $row['cells'] as $ci => $cell ) {
 					if ( ( $collapse_order == 'left-top' && $ci != $cell_count - 1 ) || ( $collapse_order == 'right-top' && $ci !== 0 ) ) {

--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -279,10 +279,10 @@ class SiteOrigin_Panels_Styles_Admin {
 				?><input type="text" name="<?php echo esc_attr( $field_name ) ?>"
 				         value="<?php echo esc_attr( $current ) ?>" class="widefat" /><?php
 				break;
-			// Adds a number finput field
+
 			case 'number' :
-				?><input type="number" name="<?php echo esc_attr( $field_name ) ?>"
-				         value="<?php echo esc_attr( $current ) ?>" class="widefat" /><?php
+				?><input type="number" name="<?php echo esc_attr( $field_name ); ?>"
+				         value="<?php echo esc_attr( $current ); ?>" class="widefat" /><?php
 				break;
 
 			case 'checkbox' :

--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -279,6 +279,11 @@ class SiteOrigin_Panels_Styles_Admin {
 				?><input type="text" name="<?php echo esc_attr( $field_name ) ?>"
 				         value="<?php echo esc_attr( $current ) ?>" class="widefat" /><?php
 				break;
+			// Adds a number finput field
+			case 'number' :
+				?><input type="number" name="<?php echo esc_attr( $field_name ) ?>"
+				         value="<?php echo esc_attr( $current ) ?>" class="widefat" /><?php
+				break;
 
 			case 'checkbox' :
 				$current = (bool) $current;

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -41,9 +41,6 @@ class SiteOrigin_Panels_Styles {
 		add_filter( 'siteorigin_panels_css_row_gutter', array( $this, 'filter_row_gutter' ), 10, 2 );
 		add_filter( 'siteorigin_panels_css_widget_css', array( $this, 'filter_widget_style_css' ), 10, 2 );
 
-		// Add in collapse point filter
-		add_filter( 'siteorigin_panels_css_row_collapse_point', array( $this, 'filter_row_collapse_point' ), 10, 2 );
-
 		// New Parallax.
 		if ( siteorigin_panels_setting( 'parallax-type' ) == 'modern' ) {
 			add_filter( 'siteorigin_panels_inside_row_before', array( $this, 'add_parallax' ), 10, 2 );
@@ -255,15 +252,6 @@ class SiteOrigin_Panels_Styles {
 				'full-stretched-padded' => __( 'Full Width Stretched Padded', 'siteorigin-panels' ),
 			),
 			'priority' => 10,
-		);
-
-		// Add in collapse point input field
-		$fields['collapse_point'] = array(
-			'name'        => __( 'Row Collapse Point', 'siteorigin-panels' ),
-			'type'        => 'number',	
-			'group'       => 'layout',
-			'description' => sprintf( __( 'Row Collapse point. Default is %spx.', 'siteorigin-panels' ), siteorigin_panels_setting( 'mobile-width' )),
-			'priority'    => 11,
 		);
 
 		$fields['collapse_behaviour'] = array(
@@ -822,22 +810,6 @@ class SiteOrigin_Panels_Styles {
 		}
 
 		return $gutter;
-	}
-
-	/**
-	 * Add in custom styles for a row's collapse point
-	 *
-	 * @param $point
-	 * @param $grid
-	 *
-	 * @return mixed
-	 */
-	static function filter_row_collapse_point( $collapse_point, $grid ) {
-		if ( ! empty( $grid['style']['collapse_point'] ) ) {
-			$collapse_point = $grid['style']['collapse_point'];
-		}
-
-		return $collapse_point;
 	}
 	
 	/**

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -41,6 +41,9 @@ class SiteOrigin_Panels_Styles {
 		add_filter( 'siteorigin_panels_css_row_gutter', array( $this, 'filter_row_gutter' ), 10, 2 );
 		add_filter( 'siteorigin_panels_css_widget_css', array( $this, 'filter_widget_style_css' ), 10, 2 );
 
+		// Add in collapse point filter
+		add_filter( 'siteorigin_panels_css_row_collapse_point', array( $this, 'filter_row_collapse_point' ), 10, 2 );
+
 		// New Parallax.
 		if ( siteorigin_panels_setting( 'parallax-type' ) == 'modern' ) {
 			add_filter( 'siteorigin_panels_inside_row_before', array( $this, 'add_parallax' ), 10, 2 );
@@ -252,6 +255,15 @@ class SiteOrigin_Panels_Styles {
 				'full-stretched-padded' => __( 'Full Width Stretched Padded', 'siteorigin-panels' ),
 			),
 			'priority' => 10,
+		);
+
+		// Add in collapse point input field
+		$fields['collapse_point'] = array(
+			'name'        => __( 'Row Collapse Point', 'siteorigin-panels' ),
+			'type'        => 'number',	
+			'group'       => 'layout',
+			'description' => sprintf( __( 'Row Collapse point. Default is %spx.', 'siteorigin-panels' ), siteorigin_panels_setting( 'mobile-width' )),
+			'priority'    => 11,
 		);
 
 		$fields['collapse_behaviour'] = array(
@@ -810,6 +822,22 @@ class SiteOrigin_Panels_Styles {
 		}
 
 		return $gutter;
+	}
+
+	/**
+	 * Add in custom styles for a row's collapse point
+	 *
+	 * @param $point
+	 * @param $grid
+	 *
+	 * @return mixed
+	 */
+	static function filter_row_collapse_point( $collapse_point, $grid ) {
+		if ( ! empty( $grid['style']['collapse_point'] ) ) {
+			$collapse_point = $grid['style']['collapse_point'];
+		}
+
+		return $collapse_point;
 	}
 	
 	/**


### PR DESCRIPTION
Ability to create an individual rows collapse point. 

This allows rows to collapse at individual values vs having to use the mobile collapse point that is set. If no value is set for the row it will use the mobile collapse point as a default value. 

An additional "number" field type is also added to the available admin field types.

Edit: This PR adds the `siteorigin_panels_css_row_collapse_point` filter. This allows you to override the collapse point of a row on a row by row basis.

The following test snippet will add a setting called "Row Collapse Point" to the Row Styles Layout settings group. This will allow you to confirm this setting works without needing to use code:

```
// Add in collapse point input field.
add_filter( 'siteorigin_panels_row_style_fields', function( $fields ) {
	$fields['collapse_point'] = array(
		'name'        => __( 'Row Collapse Point', 'siteorigin-panels' ),
		'type'        => 'number',	
		'group'       => 'layout',
		'description' => sprintf( __( 'Row Collapse point. Default is %spx.', 'custom-text-domain' ), siteorigin_panels_setting( 'mobile-width' ) ),
		'priority'    => 11,
	);

	return $fields;
}, 20 );

// Override the rows collapse point as needed.
add_filter( 'siteorigin_panels_css_row_collapse_point', function( $collapse_point, $grid ) {
	if ( ! empty( $grid['style']['collapse_point'] ) ) {
		$collapse_point = $grid['style']['collapse_point'];
	}

	return $collapse_point;
}, 10, 2 );
```