### PR TITLE
Widget Styles: Pass Widget To Server

### DIFF
--- a/js/siteorigin-panels/view/styles.js
+++ b/js/siteorigin-panels/view/styles.js
@@ -40,6 +40,10 @@ module.exports = Backbone.View.extend( {
 			builderType: args.builderType
 		};
 
+		if ( stylesType === 'widget' ) {
+			postArgs.widget = this.model.get( 'class' );
+		}
+
 		if ( stylesType === 'cell') {
 			postArgs.index = args.index;
 		}


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/159

This PR allows developers to filter fields based on the widget the user is editing. This is done using the pre-existing `siteorigin_panels_widget_style_fields` filter.

The following test snippet will remove the Widget ID widget from the WordPress Archives widget.

```
add_filter( 'siteorigin_panels_widget_style_fields', function( $fields, $post_id, $args ) {
	if ( isset( $args['widget'] ) && $args['widget'] == 'WP_Widget_Archives' ) {
		unset( $fields['id'] );
	}
	return $fields;
}, 10, 3 );
```