### PR TITLE
Prevent Collapse Point From Preventing Tablet Row Collapse

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -170,7 +170,7 @@ class SiteOrigin_Panels_Renderer {
 					$settings['tablet-layout'] &&
 					$cell_count >= 3 &&
 					$panels_tablet_width > $panels_mobile_width &&
-					$collapse_point != ''
+					empty( $collapse_point )
 				) {
 					// Tablet responsive css for the row
 


### PR DESCRIPTION
To test, enable the PB Tablet Layout setting and then add a four-column row. If it collapses as expected, it worked. You can test that the collapse point filter still works as expected by using the snippet in [the initial PR](https://github.com/siteorigin/siteorigin-panels/pull/873).