### PR TITLE
Modern Parallax: Use Image attachment if possible

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -472,17 +472,31 @@ class SiteOrigin_Panels_Styles {
 			! empty( $context['style']['background_display'] ) &&
 			self::is_background_parallax( $context['style']['background_display'] )
 		) {
+			$parallax = false;
 			if ( ! empty( $context['style']['background_image_attachment'] ) ) {
-				$url = self::get_attachment_image_src( $context['style']['background_image_attachment'], 'full' )[0];
+				$image_html = wp_get_attachment_image(
+					$context['style']['background_image_attachment'],
+					'full',
+					false,
+					array(
+						'data-siteorigin-parallax' => 'true',
+						'loading' => 'eager',
+					),
+				);
+
+				if ( ! empty( $image_html ) ) {
+					$parallax = true;
+					$output .= $image_html;
+				}
 			}
 
-			if ( empty( $url ) && ! empty( $context['style']['background_image_attachment_fallback'] ) ) {
-				$url = $context['style']['background_image_attachment_fallback'];
+			if ( ! $parallax && ! empty( $context['style']['background_image_attachment_fallback'] ) ) {
+				$parallax = true;
+				$output .= '<img src=' . esc_url( $context['style']['background_image_attachment_fallback'] ) . ' data-siteorigin-parallax="true">';
 			}
 
-			if ( ! empty( $url ) ) {
+			if ( $parallax ) {
 				wp_enqueue_script( 'simpleParallax' );
-				$output .= '<img src=' . esc_url( $url ) . ' data-siteorigin-parallax="true">';
 			}
 		}
 

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -481,7 +481,7 @@ class SiteOrigin_Panels_Styles {
 					array(
 						'data-siteorigin-parallax' => 'true',
 						'loading' => 'eager',
-					),
+					)
 				);
 
 				if ( ! empty( $image_html ) ) {


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/879

This will ensure any local images have the following attributes set:
- srcset
- sizes
- alt (if applicable)
- title (if applicable)
- loading