### PR TITLE
ACF Compat: Use `panelsopen` for more consistent loading

### DIFF
--- a/compat/js/acf-widgets.js
+++ b/compat/js/acf-widgets.js
@@ -1,5 +1,5 @@
 ( function( $ ) {
-	$( document ).on( 'open_dialog', function( e, view ) {
+	$( document ).on( 'panelsopen', function(e) {
 		setTimeout( function() {
 			acf.doAction( 'append', $( '.so-content' ) );
 		}, 1250 )

--- a/compat/js/acf-widgets.js
+++ b/compat/js/acf-widgets.js
@@ -1,5 +1,5 @@
 ( function( $ ) {
-	$( document ).on( 'panelsopen', function(e) {
+	$( document ).on( 'panelsopen', function() {
 		setTimeout( function() {
 			acf.doAction( 'append', $( '.so-content' ) );
 		}, 1250 )


### PR DESCRIPTION
This PR will prevent a situation where fields that have special JS associated with them (such as the Image field) aren't always detected.

To test this PR please follow these steps:

- Add an Image field to Widgets.
- Open any Page Builder powered page and add an archives widget.
- Open the Archives widget and set an Image
- Save, and reload.
- Open the Archives widget and attempt to change the Image.

Prior to This PR, you may or may not be able to edit the image. How often it previously worked appears to be related to server performance and/or how fast you open the widget;