### PR TITLE
Adjust the tool button padding for the Live Editor

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -2259,6 +2259,10 @@
 
 		// Style the builder differently in the live editor sidebar to make better use of space
 		.siteorigin-panels-builder {
+			.so-builder-toolbar .so-tool-button {
+				padding: 2px 9px 2px 9px;
+			}
+
 			.so-rows-container {
 				padding: 10px 10px 0 10px !important;
 			}


### PR DESCRIPTION
<img width="338" alt="buttons-not-centered" src="https://user-images.githubusercontent.com/789159/121245269-21a95480-c8a0-11eb-9eb3-2dd1dc06564e.png">

The toolbar icons are a little out of alignment in the Live Editor, this PR adjusts the padding for the Live Editor.