### PR TITLE
Modern Parallax: Prevent Overflow Using CSS

### DIFF
--- a/css/front-flex.less
+++ b/css/front-flex.less
@@ -24,6 +24,10 @@
 			z-index: 1;
 		}
 
+		.simpleParallax {
+ 			overflow: hidden;
+		}
+
 		.simpleParallax,
 		img[data-siteorigin-parallax] {
 			bottom: 0;

--- a/css/front-legacy.less
+++ b/css/front-legacy.less
@@ -12,6 +12,10 @@
 			z-index: 1;
 		}
 
+		.simpleParallax {
+			overflow: hidden;
+		}
+
 		.simpleParallax,
 		img[data-siteorigin-parallax] {
 			bottom: 0;


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/885

To test this please right-click a modern parallax that's using an image that larger than the area it's applied too , and disable the inline `overflow: hidden;`. If the parallax doesn't exceed the row/widget the CSS works as expected.