### PR TITLE
5.8 New Widgets Interface Compatibility Changes

### DIFF
--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -32,7 +32,7 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 	}
 	
 	public function enqueue_layout_block_editor_assets() {
-		if (  SiteOrigin_Panels_Admin::is_block_editor() ) {
+		if ( SiteOrigin_Panels_Admin::is_block_editor() || is_customize_preview() ) {
 			$panels_admin = SiteOrigin_Panels_Admin::single();
 			$panels_admin->enqueue_admin_scripts();
 			$panels_admin->enqueue_admin_styles();

--- a/css/admin.less
+++ b/css/admin.less
@@ -2774,8 +2774,10 @@
 		}
 
 		small {
-			color: #333;
-			font-size: 10.5px;
+			color: #999;
+			font-size: 11.7px;
+			font-style: italic;
+			margin-top: .2em;
 		}
 
 		.siteorigin-widget-field {

--- a/css/admin.less
+++ b/css/admin.less
@@ -2766,43 +2766,39 @@
 }
 
 /* 5.8 Widgets Page */
-.widgets-php.block-editor-page {
-	.siteorigin-widget-content {
+.widgets-php.block-editor-page .wp-block-legacy-widget__edit-form .siteorigin-widget-content {
 
-		label {
-			line-height: 1.5;
-		}
-
-		small {
-			color: #999;
-			font-size: 11.7px;
-			font-style: italic;
-			margin-top: .2em;
-		}
-
-		.siteorigin-widget-field {
-			margin-top: 0;
-		}
-
-		select.siteorigin-widget-field {
-			/* 5.7.2 .wp-core-ui select styling */
-			font-size: 14px;
-			line-height: 2;
-			color: #2c3338;
-			border: 1px solid #8c8f94; // Changed border to avoid override by revert.
-			box-shadow: none;
-			border-radius: 3px;
-			padding: 0 24px 0 8px;
-			min-height: 30px;
-			max-width: 25rem;
-			-webkit-appearance: none;
-			background: #fff url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E') no-repeat right 5px top 55%;
-			background-size: auto;
-			background-size: 16px 16px;
-			cursor: pointer;
-			vertical-align: middle;
-		}
-
+	label {
+		line-height: 1.5;
 	}
-	
+
+	small {
+		color: #999;
+		font-size: 11.7px;
+		font-style: italic;
+		margin-top: .2em;
+	}
+
+	.siteorigin-widget-field {
+		margin-top: 0;
+	}
+
+	select.siteorigin-widget-field {
+		/* 5.7.2 .wp-core-ui select styling */
+		font-size: 14px;
+		line-height: 2;
+		color: #2c3338;
+		border: 1px solid #8c8f94; // Changed border to avoid override by revert.
+		box-shadow: none;
+		border-radius: 3px;
+		padding: 0 24px 0 8px;
+		min-height: 30px;
+		max-width: 25rem;
+		-webkit-appearance: none;
+		background: #fff url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E') no-repeat right 5px top 55%;
+		background-size: auto;
+		background-size: 16px 16px;
+		cursor: pointer;
+		vertical-align: middle;
+	}
 }

--- a/css/admin.less
+++ b/css/admin.less
@@ -2803,6 +2803,9 @@
 	a {
 		color: #3c434a;
 		font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+		font-size: 13px;
+		line-height: 1.4;
+	}
 	}
 
 	a {

--- a/css/admin.less
+++ b/css/admin.less
@@ -785,8 +785,8 @@
 
 		.siteorigin-widget-help-link {
 			display: block;
-			margin: 1em 0;
 			font-size: 13px;
+			margin: 1em 0;
 		}
 
 	}
@@ -2763,4 +2763,44 @@
 	&.white {
 		background-image: url('./images/pb-icon_white.svg');
 	}
+}
+
+/* 5.8 Widgets Page */
+.widgets-php.block-editor-page {
+	.siteorigin-widget-content {
+
+		label {
+			line-height: 1.5;
+		}
+
+		small {
+			color: #333;
+			font-size: 10.5px;
+		}
+
+		.siteorigin-widget-field {
+			margin-top: 0;
+		}
+
+		select.siteorigin-widget-field {
+			/* 5.7.2 .wp-core-ui select styling */
+			font-size: 14px;
+			line-height: 2;
+			color: #2c3338;
+			border: 1px solid #8c8f94; // Changed border to avoid override by revert.
+			box-shadow: none;
+			border-radius: 3px;
+			padding: 0 24px 0 8px;
+			min-height: 30px;
+			max-width: 25rem;
+			-webkit-appearance: none;
+			background: #fff url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E') no-repeat right 5px top 55%;
+			background-size: auto;
+			background-size: 16px 16px;
+			cursor: pointer;
+			vertical-align: middle;
+		}
+
+	}
+	
 }

--- a/css/admin.less
+++ b/css/admin.less
@@ -719,7 +719,8 @@
 
 }
 
-.so-panels-dialog, .block-editor {
+.so-panels-dialog,
+.block-editor-page {
 
 	@edge_spacing: 30px;
 

--- a/css/admin.less
+++ b/css/admin.less
@@ -2814,6 +2814,7 @@
 
 		a {
 			color: #2271b1;
+
 			&:hover,
 			&:active {
 				color: #135e96

--- a/css/admin.less
+++ b/css/admin.less
@@ -2766,73 +2766,77 @@
 }
 
 /* 5.8 Widgets Page */
-.widgets-php.block-editor-page .wp-block-legacy-widget__edit-form .siteorigin-widget-content {
-
-	label {
-		line-height: 1.5;
-	}
-
-	small {
-		color: #999;
-		font-size: 11.7px;
-		font-style: italic;
-		margin-top: .2em;
-	}
-
-	.siteorigin-widget-field {
-		display: inline-block;
-		margin-top: 0;
-		width: auto;
-	}
-
-	.siteorigin-widget-field.small-text {
-		width: 50px;
-	}
-
-	.siteorigin-widget-field.widefat {
-		width: 100%;
-	}
-
-	// Revert to 5.7.2 font-family and color wherever possible.
-	&,
-	label,
-	.siteorigin-widget-field,
-	select.siteorigin-widget-field,
-	.button,
-	input,
-	a {
-		color: #3c434a;
-		font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+.widgets-php.block-editor-page {
+	.siteorigin-panels-layout-block-container {
 		font-size: 13px;
-		line-height: 1.4;
 	}
-	}
+	.wp-block-legacy-widget__edit-form .siteorigin-widget-content {
 
-	a {
-		color: #2271b1;
-		&:hover,
-		&:active {
-			color: #135e96
+		label {
+			line-height: 1.5;
 		}
-	}
 
-	select.siteorigin-widget-field {
-		/* 5.7.2 .wp-core-ui select styling */
-		-webkit-appearance: none;
-		background: #fff url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E') no-repeat right 5px top 55%;
-		background-size: auto;
-		background-size: 16px 16px;
-		border: 1px solid #8c8f94; // Changed border to avoid override by revert.
-		border-radius: 3px;
-		box-shadow: none;
-		color: #2c3338;
-		cursor: pointer;
-		font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
-		font-size: 14px;
-		line-height: 2;
-		min-height: 30px;
-		padding: 0 24px 0 8px;
-		vertical-align: middle;
-		width: auto;
+		small {
+			color: #999;
+			font-size: 11.7px;
+			font-style: italic;
+			margin-top: .2em;
+		}
+
+		.siteorigin-widget-field {
+			display: inline-block;
+			margin-top: 0;
+			width: auto;
+		}
+
+		.siteorigin-widget-field.small-text {
+			width: 50px;
+		}
+
+		.siteorigin-widget-field.widefat {
+			width: 100%;
+		}
+
+		// Revert to 5.7.2 font-family and color wherever possible.
+		&,
+		label,
+		.siteorigin-widget-field,
+		select.siteorigin-widget-field,
+		.button,
+		input,
+		a {
+			color: #3c434a;
+			font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+			font-size: 13px;
+			line-height: 1.4;
+		}
+
+		a {
+			color: #2271b1;
+			&:hover,
+			&:active {
+				color: #135e96
+			}
+		}
+
+		select.siteorigin-widget-field {
+			/* 5.7.2 .wp-core-ui select styling */
+			-webkit-appearance: none;
+			background: #fff url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E') no-repeat right 5px top 55%;
+			background-size: auto;
+			background-size: 16px 16px;
+			border: 1px solid #8c8f94; // Changed border to avoid override by revert.
+			border-radius: 3px;
+			box-shadow: none;
+			color: #2c3338;
+			cursor: pointer;
+			font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+			font-size: 14px;
+			line-height: 2;
+			min-height: 30px;
+			padding: 0 24px 0 8px;
+			vertical-align: middle;
+			width: auto;
+		}
 	}
 }

--- a/css/admin.less
+++ b/css/admin.less
@@ -2780,25 +2780,56 @@
 	}
 
 	.siteorigin-widget-field {
+		display: inline-block;
 		margin-top: 0;
+		width: auto;
+	}
+
+	.siteorigin-widget-field.small-text {
+		width: 50px;
+	}
+
+	.siteorigin-widget-field.widefat {
+		width: 100%;
+	}
+
+	// Revert to 5.7.2 font-family and color wherever possible.
+	&,
+	label,
+	.siteorigin-widget-field,
+	select.siteorigin-widget-field,
+	.button,
+	input,
+	a {
+		color: #3c434a;
+		font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+	}
+
+	a {
+		color: #2271b1;
+		&:hover,
+		&:active {
+			color: #135e96
+		}
 	}
 
 	select.siteorigin-widget-field {
 		/* 5.7.2 .wp-core-ui select styling */
-		font-size: 14px;
-		line-height: 2;
-		color: #2c3338;
-		border: 1px solid #8c8f94; // Changed border to avoid override by revert.
-		box-shadow: none;
-		border-radius: 3px;
-		padding: 0 24px 0 8px;
-		min-height: 30px;
-		max-width: 25rem;
 		-webkit-appearance: none;
 		background: #fff url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E') no-repeat right 5px top 55%;
 		background-size: auto;
 		background-size: 16px 16px;
+		border: 1px solid #8c8f94; // Changed border to avoid override by revert.
+		border-radius: 3px;
+		box-shadow: none;
+		color: #2c3338;
 		cursor: pointer;
+		font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+		font-size: 14px;
+		line-height: 2;
+		min-height: 30px;
+		padding: 0 24px 0 8px;
 		vertical-align: middle;
+		width: auto;
 	}
 }

--- a/css/admin.less
+++ b/css/admin.less
@@ -783,6 +783,12 @@
 			display: none;
 		}
 
+		.siteorigin-widget-help-link {
+			display: block;
+			margin: 1em 0;
+			font-size: 13px;
+		}
+
 	}
 
 	.so-title-bar {

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1127,17 +1127,24 @@ class SiteOrigin_Panels_Admin {
 			wp_die();
 		}
 
-		if ( ! current_user_can( 'edit_post', $_POST['post_id'] ) ) {
-			wp_die();
+		if ( ! empty( $_POST['post_id'] ) ) {
+			// This is a post so ensure the user is able to edit it.
+			if ( ! current_user_can( 'edit_post', $_POST['post_id'] ) ) {
+				wp_die();
+			}
+			$old_panels_data = get_post_meta( $_POST['post_id'], 'panels_data', true );
+		} else {
+			// This isn't a post, add default data to skip post speciifc checks.
+			$old_panels_data = array();
+			 $_POST['post_id'] = 0;
 		}
-
-		if ( empty( $_POST['post_id'] ) || empty( $_POST['panels_data'] ) ) {
+		
+		if ( empty( $_POST['panels_data'] ) ) {
 			echo json_encode($return);
 			wp_die();
 		}
 
 		// echo the content
-		$old_panels_data        = get_post_meta( $_POST['post_id'], 'panels_data', true );
 		$panels_data            = json_decode( wp_unslash( $_POST['panels_data'] ), true );
 		$panels_data['widgets'] = $this->process_raw_widgets(
 			$panels_data['widgets'],

--- a/inc/widgets/layout.php
+++ b/inc/widgets/layout.php
@@ -103,6 +103,11 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 		}
 
 		$builder_supports = apply_filters( 'siteorigin_panels_layout_builder_supports', array(), $instance['panels_data'] );
+
+		// Prep panels_data for output.
+		$panels_data = wp_check_invalid_utf8( $instance['panels_data'] );
+		$panels_data = _wp_specialchars( $panels_data, ENT_QUOTES, null, true );
+		$panels_data = apply_filters( 'attribute_escape', $panels_data, $instance['panels_data'] );
 		?>
 		<div class="siteorigin-page-builder-widget" id="siteorigin-page-builder-widget-<?php echo esc_attr( $form_id ) ?>"
 			data-builder-id="<?php echo esc_attr( $form_id ) ?>"
@@ -117,7 +122,7 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 				type="hidden"
 				data-panels-filter="json_parse"
 				class="panels-data"
-				value="<?php echo esc_js( $instance['panels_data'] ); ?>"
+				value="<?php echo $panels_data; ?>"
 				name="<?php echo $this->get_field_name('panels_data') ?>"
 				id="<?php echo $this->get_field_id('panels_data') ?>"
 			/>

--- a/inc/widgets/layout.php
+++ b/inc/widgets/layout.php
@@ -113,15 +113,15 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 				<button class="button-secondary siteorigin-panels-display-builder" ><?php _e('Open Builder', 'siteorigin-panels') ?></button>
 			</p>
 			
-			<input type="hidden" data-panels-filter="json_parse" value="" class="panels-data" name="<?php echo $this->get_field_name('panels_data') ?>" id="<?php echo $this->get_field_id('panels_data') ?>" />
-			
-			<script type="text/javascript">
-				( function( panelsData ){
-					// Create the panels_data input
-					document.getElementById('<?php echo $this->get_field_id('panels_data') ?>').value = JSON.stringify( panelsData );
-				} )( <?php echo $instance['panels_data']; ?> );
-			</script>
-			
+			<input
+				type="hidden"
+				data-panels-filter="json_parse"
+				class="panels-data"
+				value="<?php echo esc_js( $instance['panels_data'] ); ?>"
+				name="<?php echo $this->get_field_name('panels_data') ?>"
+				id="<?php echo $this->get_field_id('panels_data') ?>"
+			/>
+
 			<input type="hidden" value="<?php echo esc_attr( $instance['builder_id'] ) ?>" name="<?php echo $this->get_field_name('builder_id') ?>" />
 		</div>
 		<script type="text/javascript">

--- a/inc/widgets/layout.php
+++ b/inc/widgets/layout.php
@@ -76,9 +76,8 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 		return $new;
 	}
 	
-	function form( $instance ){
-		
-		if ( ! is_admin() ) {
+	function form( $instance ){		
+		if ( ! is_admin() && ! defined( 'REST_REQUEST' ) ) {
 			?>
 			<p>
 				<?php _e( 'This widget can currently only be used in the WordPress admin interface.', 'siteorigin-panels' ) ?>

--- a/inc/widgets/post-content.php
+++ b/inc/widgets/post-content.php
@@ -63,14 +63,16 @@ class SiteOrigin_Panels_Widgets_PostContent extends WP_Widget {
 		));
 		
 		?>
-		<p>
-			<label for="<?php echo $this->get_field_id( 'type' ) ?>"><?php _e( 'Display Content', 'siteorigin-panels' ) ?></label>
-			<select id="<?php echo $this->get_field_id( 'type' ) ?>" name="<?php echo $this->get_field_name( 'type' ) ?>">
-				<?php foreach ($types as $type_id => $title) : ?>
-					<option value="<?php echo esc_attr($type_id) ?>" <?php selected($type_id, $instance['type']) ?>><?php echo esc_html($title) ?></option>
-				<?php endforeach ?>
-			</select>
-		</p>
+		<div class="siteorigin-widget-content">
+			<p>
+				<label for="<?php echo $this->get_field_id( 'type' ) ?>"><?php _e( 'Display Content', 'siteorigin-panels' ) ?></label>
+				<select id="<?php echo $this->get_field_id( 'type' ) ?>" name="<?php echo $this->get_field_name( 'type' ) ?>" class="siteorigin-widget-field">
+					<?php foreach ($types as $type_id => $title) : ?>
+						<option value="<?php echo esc_attr($type_id) ?>" <?php selected($type_id, $instance['type']) ?>><?php echo esc_html($title) ?></option>
+					<?php endforeach ?>
+				</select>
+			</p>
+		</div>
 		<?php
 	}
 }

--- a/inc/widgets/post-loop.php
+++ b/inc/widgets/post-loop.php
@@ -310,7 +310,7 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 				
 				<p>
 					<label for="<?php echo $this->get_field_id('more') ?>"><?php _e('More Link', 'siteorigin-panels') ?></label>
-					<input type="checkbox" class="widefat siteorigin-widget-field" id="<?php echo $this->get_field_id( 'more' ) ?>" name="<?php echo $this->get_field_name( 'more' ) ?>" <?php checked( $instance['more'] ) ?> /><br/>
+					<input type="checkbox" class="siteorigin-widget-field" id="<?php echo $this->get_field_id( 'more' ) ?>" name="<?php echo $this->get_field_name( 'more' ) ?>" <?php checked( $instance['more'] ) ?> /><br/>
 					<small><?php _e('If the template supports it, cut posts and display the more link.', 'siteorigin-panels') ?></small>
 				</p>
 				<?php

--- a/inc/widgets/post-loop.php
+++ b/inc/widgets/post-loop.php
@@ -87,7 +87,10 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 	}
 
 	private static function is_legacy_widget_block_preview() {
-		return isset( $_GET['legacy-widget-preview'] ) && $_GET['legacy-widget-preview']['idBase'] == 'siteorigin-panels-postloop';
+		return isset( $_GET['legacy-widget-preview'] ) && (
+			$_GET['legacy-widget-preview']['idBase'] == 'siteorigin-panels-postloop' ||
+			$_GET['legacy-widget-preview']['idBase'] == 'siteorigin-panels-builder'
+		);
 	}
 
 	private static function is_layout_block_preview() {

--- a/inc/widgets/post-loop.php
+++ b/inc/widgets/post-loop.php
@@ -287,108 +287,110 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 			) );
 			
 			?>
-			<p>
-				<label for="<?php echo $this->get_field_id( 'title' ) ?>"><?php _e( 'Title', 'siteorigin-panels' ) ?></label>
-				<input type="text" class="widefat" name="<?php echo $this->get_field_name( 'title' ) ?>" id="<?php echo $this->get_field_id( 'title' ) ?>" value="<?php echo esc_attr( $instance['title'] ) ?>">
-			</p>
-			<p>
-				<label for="<?php echo $this->get_field_id('template') ?>"><?php _e('Template', 'siteorigin-panels') ?></label>
-				<select id="<?php echo $this->get_field_id( 'template' ) ?>" name="<?php echo $this->get_field_name( 'template' ) ?>">
-					<?php foreach($templates as $template) : ?>
-						<option value="<?php echo esc_attr($template) ?>" <?php selected($instance['template'], $template) ?>>
-							<?php
-							$headers = get_file_data( self::locate_template($template), array(
-								'loop_name' => 'Loop Name',
-							) );
-							echo esc_html(!empty($headers['loop_name']) ? $headers['loop_name'] : $template);
-							?>
-						</option>
-					<?php endforeach; ?>
-				</select>
-			</p>
-			
-			<p>
-				<label for="<?php echo $this->get_field_id('more') ?>"><?php _e('More Link', 'siteorigin-panels') ?></label>
-				<input type="checkbox" class="widefat" id="<?php echo $this->get_field_id( 'more' ) ?>" name="<?php echo $this->get_field_name( 'more' ) ?>" <?php checked( $instance['more'] ) ?> /><br/>
-				<small><?php _e('If the template supports it, cut posts and display the more link.', 'siteorigin-panels') ?></small>
-			</p>
-			<?php
-			
-			if ( ! empty( $instance['posts'] ) ) {
-				$instance = wp_parse_args( $instance['posts'] , $instance );
-				unset( $instance['posts'] );
-				//unset post__in and taxonomies?
-			}
-			// Get all the loop template files
-			$post_types = get_post_types(array('public' => true));
-			$post_types = array_values($post_types);
-			$post_types = array_diff($post_types, array('attachment', 'revision', 'nav_menu_item'));
-			?>
-			<p>
-				<label for="<?php echo $this->get_field_id('post_type') ?>"><?php _e('Post Type', 'siteorigin-panels') ?></label>
-				<select id="<?php echo $this->get_field_id( 'post_type' ) ?>" name="<?php echo $this->get_field_name( 'post_type' ) ?>" value="<?php echo esc_attr($instance['post_type']) ?>">
-					<?php foreach($post_types as $type) : ?>
-						<option value="<?php echo esc_attr($type) ?>" <?php selected($instance['post_type'], $type) ?>><?php echo esc_html($type) ?></option>
-					<?php endforeach; ?>
-				</select>
-			</p>
-			
-			<p>
-				<label for="<?php echo $this->get_field_id('posts_per_page') ?>"><?php _e('Posts Per Page', 'siteorigin-panels') ?></label>
-				<input type="text" class="small-text" id="<?php echo $this->get_field_id( 'posts_per_page' ) ?>" name="<?php echo $this->get_field_name( 'posts_per_page' ) ?>" value="<?php echo esc_attr($instance['posts_per_page']) ?>" />
-			</p>
-			
-			<p>
-				<label <?php echo $this->get_field_id('orderby') ?>><?php _e('Order By', 'siteorigin-panels') ?></label>
-				<select id="<?php echo $this->get_field_id( 'orderby' ) ?>" name="<?php echo $this->get_field_name( 'orderby' ) ?>" value="<?php echo esc_attr($instance['orderby']) ?>">
-					<option value="none" <?php selected($instance['orderby'], 'none') ?>><?php esc_html_e('None', 'siteorigin-panels') ?></option>
-					<option value="ID" <?php selected($instance['orderby'], 'ID') ?>><?php esc_html_e('Post ID', 'siteorigin-panels') ?></option>
-					<option value="author" <?php selected($instance['orderby'], 'author') ?>><?php esc_html_e('Author', 'siteorigin-panels') ?></option>
-					<option value="name" <?php selected($instance['orderby'], 'name') ?>><?php esc_html_e('Name', 'siteorigin-panels') ?></option>
-					<option value="name" <?php selected($instance['orderby'], 'name') ?>><?php esc_html_e('Name', 'siteorigin-panels') ?></option>
-					<option value="date" <?php selected($instance['orderby'], 'date') ?>><?php esc_html_e('Date', 'siteorigin-panels') ?></option>
-					<option value="modified" <?php selected($instance['orderby'], 'modified') ?>><?php esc_html_e('Modified', 'siteorigin-panels') ?></option>
-					<option value="parent" <?php selected($instance['orderby'], 'parent') ?>><?php esc_html_e('Parent', 'siteorigin-panels') ?></option>
-					<option value="rand" <?php selected($instance['orderby'], 'rand') ?>><?php esc_html_e('Random', 'siteorigin-panels') ?></option>
-					<option value="comment_count" <?php selected($instance['orderby'], 'comment_count') ?>><?php esc_html_e('Comment Count', 'siteorigin-panels') ?></option>
-					<option value="menu_order" <?php selected($instance['orderby'], 'menu_order') ?>><?php esc_html_e('Menu Order', 'siteorigin-panels') ?></option>
-					<option value="post__in" <?php selected($instance['orderby'], 'post__in') ?>><?php esc_html_e('Post In Order', 'siteorigin-panels') ?></option>
-				</select>
-			</p>
-			
-			<p>
-				<label for="<?php echo $this->get_field_id('order') ?>"><?php _e('Order', 'siteorigin-panels') ?></label>
-				<select id="<?php echo $this->get_field_id( 'order' ) ?>" name="<?php echo $this->get_field_name( 'order' ) ?>" value="<?php echo esc_attr($instance['order']) ?>">
-					<option value="DESC" <?php selected($instance['order'], 'DESC') ?>><?php esc_html_e('Descending', 'siteorigin-panels') ?></option>
-					<option value="ASC" <?php selected($instance['order'], 'ASC') ?>><?php esc_html_e('Ascending', 'siteorigin-panels') ?></option>
-				</select>
-			</p>
-			
-			<p>
-				<label for="<?php echo $this->get_field_id('sticky') ?>"><?php _e('Sticky Posts', 'siteorigin-panels') ?></label>
-				<select id="<?php echo $this->get_field_id( 'sticky' ) ?>" name="<?php echo $this->get_field_name( 'sticky' ) ?>" value="<?php echo esc_attr($instance['sticky']) ?>">
-					<option value="" <?php selected($instance['sticky'], '') ?>><?php esc_html_e('Default', 'siteorigin-panels') ?></option>
-					<option value="ignore" <?php selected($instance['sticky'], 'ignore') ?>><?php esc_html_e('Ignore Sticky', 'siteorigin-panels') ?></option>
-					<option value="exclude" <?php selected($instance['sticky'], 'exclude') ?>><?php esc_html_e('Exclude Sticky', 'siteorigin-panels') ?></option>
-					<option value="only" <?php selected($instance['sticky'], 'only') ?>><?php esc_html_e('Only Sticky', 'siteorigin-panels') ?></option>
-				</select>
-			</p>
-			
-			<p>
-				<label for="<?php echo $this->get_field_id('additional') ?>"><?php _e('Additional ', 'siteorigin-panels') ?></label>
-				<input type="text" class="widefat" id="<?php echo $this->get_field_id( 'additional' ) ?>" name="<?php echo $this->get_field_name( 'additional' ) ?>" value="<?php echo esc_attr($instance['additional']) ?>" />
-				<small>
-					<?php
-					echo preg_replace(
-						'/1\{ *(.*?) *\}/',
-						'<a href="http://codex.wordpress.org/Function_Reference/query_posts">$1</a>',
-						__('Additional query arguments. See 1{query_posts}.', 'siteorigin-panels')
-					)
-					?>
-				</small>
-			</p>
-			
-			<a href="https://siteorigin.com/page-builder/bundled-widgets/post-loop-widget/" class="siteorigin-widget-help-link siteorigin-panels-help-link" target="_blank" rel="noopener noreferrer"><?php _e('Help', 'so-widgets-bundle') ?></a>
+			<div class="siteorigin-widget-content">
+				<p>
+					<label for="<?php echo $this->get_field_id( 'title' ) ?>"><?php _e( 'Title', 'siteorigin-panels' ) ?></label>
+					<input type="text" class="widefat siteorigin-widget-field" name="<?php echo $this->get_field_name( 'title' ) ?>" id="<?php echo $this->get_field_id( 'title' ) ?>" value="<?php echo esc_attr( $instance['title'] ) ?>">
+				</p>
+				<p>
+					<label for="<?php echo $this->get_field_id('template') ?>"><?php _e('Template', 'siteorigin-panels') ?></label>
+					<select id="<?php echo $this->get_field_id( 'template' ) ?>" name="<?php echo $this->get_field_name( 'template' ) ?>" class="siteorigin-widget-field">
+						<?php foreach($templates as $template) : ?>
+							<option value="<?php echo esc_attr($template) ?>" <?php selected($instance['template'], $template) ?>>
+								<?php
+								$headers = get_file_data( self::locate_template($template), array(
+									'loop_name' => 'Loop Name',
+								) );
+								echo esc_html(!empty($headers['loop_name']) ? $headers['loop_name'] : $template);
+								?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+				</p>
+				
+				<p>
+					<label for="<?php echo $this->get_field_id('more') ?>"><?php _e('More Link', 'siteorigin-panels') ?></label>
+					<input type="checkbox" class="widefat siteorigin-widget-field" id="<?php echo $this->get_field_id( 'more' ) ?>" name="<?php echo $this->get_field_name( 'more' ) ?>" <?php checked( $instance['more'] ) ?> /><br/>
+					<small><?php _e('If the template supports it, cut posts and display the more link.', 'siteorigin-panels') ?></small>
+				</p>
+				<?php
+				
+				if ( ! empty( $instance['posts'] ) ) {
+					$instance = wp_parse_args( $instance['posts'] , $instance );
+					unset( $instance['posts'] );
+					//unset post__in and taxonomies?
+				}
+				// Get all the loop template files
+				$post_types = get_post_types(array('public' => true));
+				$post_types = array_values($post_types);
+				$post_types = array_diff($post_types, array('attachment', 'revision', 'nav_menu_item'));
+				?>
+				<p>
+					<label for="<?php echo $this->get_field_id('post_type') ?>"><?php _e('Post Type', 'siteorigin-panels') ?></label>
+					<select id="<?php echo $this->get_field_id( 'post_type' ) ?>" name="<?php echo $this->get_field_name( 'post_type' ) ?>" class="siteorigin-widget-field" value="<?php echo esc_attr($instance['post_type']) ?>">
+						<?php foreach($post_types as $type) : ?>
+							<option value="<?php echo esc_attr($type) ?>" <?php selected($instance['post_type'], $type) ?>><?php echo esc_html($type) ?></option>
+						<?php endforeach; ?>
+					</select>
+				</p>
+				
+				<p>
+					<label for="<?php echo $this->get_field_id('posts_per_page') ?>"><?php _e('Posts Per Page', 'siteorigin-panels') ?></label>
+					<input type="text" class="small-text siteorigin-widget-field" id="<?php echo $this->get_field_id( 'posts_per_page' ) ?>" name="<?php echo $this->get_field_name( 'posts_per_page' ) ?>" class="siteorigin-widget-field" value="<?php echo esc_attr($instance['posts_per_page']) ?>" />
+				</p>
+				
+				<p>
+					<label <?php echo $this->get_field_id('orderby') ?>><?php _e('Order By', 'siteorigin-panels') ?></label>
+					<select id="<?php echo $this->get_field_id( 'orderby' ) ?>" name="<?php echo $this->get_field_name( 'orderby' ) ?>" class="siteorigin-widget-field" value="<?php echo esc_attr($instance['orderby']) ?>">
+						<option value="none" <?php selected($instance['orderby'], 'none') ?>><?php esc_html_e('None', 'siteorigin-panels') ?></option>
+						<option value="ID" <?php selected($instance['orderby'], 'ID') ?>><?php esc_html_e('Post ID', 'siteorigin-panels') ?></option>
+						<option value="author" <?php selected($instance['orderby'], 'author') ?>><?php esc_html_e('Author', 'siteorigin-panels') ?></option>
+						<option value="name" <?php selected($instance['orderby'], 'name') ?>><?php esc_html_e('Name', 'siteorigin-panels') ?></option>
+						<option value="name" <?php selected($instance['orderby'], 'name') ?>><?php esc_html_e('Name', 'siteorigin-panels') ?></option>
+						<option value="date" <?php selected($instance['orderby'], 'date') ?>><?php esc_html_e('Date', 'siteorigin-panels') ?></option>
+						<option value="modified" <?php selected($instance['orderby'], 'modified') ?>><?php esc_html_e('Modified', 'siteorigin-panels') ?></option>
+						<option value="parent" <?php selected($instance['orderby'], 'parent') ?>><?php esc_html_e('Parent', 'siteorigin-panels') ?></option>
+						<option value="rand" <?php selected($instance['orderby'], 'rand') ?>><?php esc_html_e('Random', 'siteorigin-panels') ?></option>
+						<option value="comment_count" <?php selected($instance['orderby'], 'comment_count') ?>><?php esc_html_e('Comment Count', 'siteorigin-panels') ?></option>
+						<option value="menu_order" <?php selected($instance['orderby'], 'menu_order') ?>><?php esc_html_e('Menu Order', 'siteorigin-panels') ?></option>
+						<option value="post__in" <?php selected($instance['orderby'], 'post__in') ?>><?php esc_html_e('Post In Order', 'siteorigin-panels') ?></option>
+					</select>
+				</p>
+				
+				<p>
+					<label for="<?php echo $this->get_field_id('order') ?>"><?php _e('Order', 'siteorigin-panels') ?></label>
+					<select id="<?php echo $this->get_field_id( 'order' ) ?>" class="siteorigin-widget-field" name="<?php echo $this->get_field_name( 'order' ) ?>" value="<?php echo esc_attr($instance['order']) ?>">
+						<option value="DESC" <?php selected($instance['order'], 'DESC') ?>><?php esc_html_e('Descending', 'siteorigin-panels') ?></option>
+						<option value="ASC" <?php selected($instance['order'], 'ASC') ?>><?php esc_html_e('Ascending', 'siteorigin-panels') ?></option>
+					</select>
+				</p>
+				
+				<p>
+					<label for="<?php echo $this->get_field_id('sticky') ?>"><?php _e('Sticky Posts', 'siteorigin-panels') ?></label>
+					<select id="<?php echo $this->get_field_id( 'sticky' ) ?>" class="siteorigin-widget-field" name="<?php echo $this->get_field_name( 'sticky' ) ?>" value="<?php echo esc_attr($instance['sticky']) ?>">
+						<option value="" <?php selected($instance['sticky'], '') ?>><?php esc_html_e('Default', 'siteorigin-panels') ?></option>
+						<option value="ignore" <?php selected($instance['sticky'], 'ignore') ?>><?php esc_html_e('Ignore Sticky', 'siteorigin-panels') ?></option>
+						<option value="exclude" <?php selected($instance['sticky'], 'exclude') ?>><?php esc_html_e('Exclude Sticky', 'siteorigin-panels') ?></option>
+						<option value="only" <?php selected($instance['sticky'], 'only') ?>><?php esc_html_e('Only Sticky', 'siteorigin-panels') ?></option>
+					</select>
+				</p>
+				
+				<p>
+					<label for="<?php echo $this->get_field_id('additional') ?>"><?php _e('Additional ', 'siteorigin-panels') ?></label>
+					<input type="text" class="widefat siteorigin-widget-field" id="<?php echo $this->get_field_id( 'additional' ) ?>" name="<?php echo $this->get_field_name( 'additional' ) ?>" class="siteorigin-widget-field" value="<?php echo esc_attr($instance['additional']) ?>" />
+					<small>
+						<?php
+						echo preg_replace(
+							'/1\{ *(.*?) *\}/',
+							'<a href="http://codex.wordpress.org/Function_Reference/query_posts">$1</a>',
+							__('Additional query arguments. See 1{query_posts}.', 'siteorigin-panels')
+						)
+						?>
+					</small>
+				</p>
+				
+				<a href="https://siteorigin.com/page-builder/bundled-widgets/post-loop-widget/" class="siteorigin-widget-help-link siteorigin-panels-help-link" target="_blank" rel="noopener noreferrer"><?php _e('Help', 'so-widgets-bundle') ?></a>
+			</div>
 			<?php
 		}
 	}

--- a/inc/widgets/post-loop.php
+++ b/inc/widgets/post-loop.php
@@ -85,6 +85,14 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 			return $new;
 		}
 	}
+
+	private static function is_legacy_widget_block_preview() {
+		return isset( $_GET['legacy-widget-preview'] ) && $_GET['legacy-widget-preview']['idBase'] == 'siteorigin-panels-postloop';
+	}
+
+	private static function is_layout_block_preview() {
+		return isset( $_POST['action'] ) && $_POST['action'] == 'so_panels_layout_block_preview';
+	}
 	
 	/**
 	 * @param array $args
@@ -92,10 +100,12 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 	 */
 	function widget( $args, $instance ) {
 		if( empty( $instance['template'] ) ) return;
-		// The Post Loop widget should only preview in WP Admin if it's Layout Block preview.
-		if ( is_admin() && ! ( isset( $_POST['action'] ) && $_POST['action'] == 'so_panels_layout_block_preview' ) ) {
+
+		// The Post Loop widget should only preview in WP Admin if it's a Layout Block preview, or a legacy Widget Block preview.
+		if ( is_admin() && ! self::is_legacy_widget_block_preview() && ! self::is_layout_block_preview() ) {
 			 return;
 		}
+
 		static $depth = 0;
 		$depth++;
 		if( $depth > 1 ) {


### PR DESCRIPTION
This PR:

- Allows the Layout Builder to be edited.

Previously an error message stating that the widget must be edited via an admin interface would be displayed.

- Changes how the Layout Builder `panels_data` is loaded to resolve an incompatibility with new widgets rendering.

This change is in line with how the WB Builder field handles data so PB is set up to handle this sort of usage already.

This change that the Layout Builder needs to be tested (specifically, the act of loading page builder data after a save) in the old Widgets interface, new widgets interface, SiteOrigin Layouts Block and full SiteOrigin Page Builder interface. This change also needs to be tested on pre-WP 5.8.

To test this change, add a Layout Builder, and add any widget to the Layout Builder. Save. Reload the editor and then attempt to access the added widget.

- Post Loop Preview**

The Post Loop needs to be tested in both the new widgets interface preview, and the SiteOrgin Layouts Block Preview.

---

Some notes:
The Template drop down in the post loop widget has different styling but that field is actually being added by WB so it'll be handled in [this PR](https://github.com/siteorigin/so-widgets-bundle/pull/1332).

It's possible the legacy PB widgets aren't compatible with the new widgets interface. We should recommend users change to our more modern widgets or suggest installing the [Classic Widgets](https://wordpress.org/plugins/classic-widgets/) plugin.
