### PR TITLE
Add `siteorigin_panels_default_row_columns` to Allow Overriding default Row Columns

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -353,6 +353,14 @@ class SiteOrigin_Panels_Admin {
 				'copy_content'              => siteorigin_panels_setting( 'copy-content' ),
 				'cache'						=> array(),
 				'instant_open'              => siteorigin_panels_setting( 'instant-open-widgets' ),
+				'default_columns'           => apply_filters( 'siteorigin_panels_default_row_columns', array(
+					array(
+						'weight' => 0.5,
+					),
+					array(
+						'weight' => 0.5,
+					),
+				) ),
 
 				// Settings for the contextual menu
 				'contextual'                => array(

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -67,7 +67,7 @@ module.exports = panels.view.dialog.extend({
 
 		// This is the default row layout
 		this.row = {
-			cells: new panels.collection.cells([{weight: 0.5}, {weight: 0.5}]),
+			cells: new panels.collection.cells( panelsOptions.default_columns ),
 			style: {}
 		};
 

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -579,7 +579,7 @@ module.exports = Backbone.View.extend( {
 	 */
 	displayAddRowDialog: function () {
 		var row = new panels.model.row();
-		var cells = new panels.collection.cells( [ { weight: 0.5 }, { weight: 0.5 } ] );
+		var cells = new panels.collection.cells( panelsOptions.default_columns );
 		cells.each( function ( cell ) {
 			cell.row = row;
 		} );


### PR DESCRIPTION
[Requested here](https://github.com/siteorigin/siteorigin-panels/pull/888#issuecomment-860242510)

This PR adds a PR that allows you to change the default row columns. For example, the following snippet will change the default row columns to 3 rows with 33.33% width each.

```
add_filter( 'siteorigin_panels_default_row_columns', function( $default_columns ) {
	return array(
		array(
			'weight' => 0.333,
		),
		array(
			'weight' => 0.333,
		),
		array(
			'weight' => 0.333,
		),
	);
} );
```