### PR TITLE
Prevent undesired "restore content" prompt

### DIFF
--- a/js/siteorigin-panels/main.js
+++ b/js/siteorigin-panels/main.js
@@ -172,3 +172,26 @@ jQuery( function ( $ ) {
 		}
 	});
 } );
+
+// WP 5.7+: Prevent undesired "restore content" notice.
+if ( typeof window.wp.autosave !== 'undefined' && jQuery( '#siteorigin-panels-metabox' ).length ) {
+	jQuery( document ).on( 'ready', function( e ) {
+		var blog_id = typeof window.autosaveL10n !== 'undefined' && window.autosaveL10n.blog_id;
+		
+		// Ensure sessionStorage is working, and we were able to find a blog id.
+		if ( typeof window.sessionStorage != 'object' && ! blog_id ) {
+			return;
+		}
+
+		stored_obj = window.sessionStorage.getItem( 'wp-autosave-' + blog_id );
+		if ( stored_obj ) {
+			stored_obj = JSON.parse( stored_obj );
+			var storedPostData = stored_obj[ 'post_' + jQuery( '#post_ID' ).val() ]
+
+			if ( typeof storedPostData == 'object' ) {
+				// Override existing store with stored session data. The content is exactly the same.
+				jQuery( '#content' ).val( storedPostData.content );
+			}
+		}
+	} );
+}


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/894

At least partially related https://github.com/siteorigin/siteorigin-panels/issues/846. The new changes implemented in 5.6 is resulting in this notice appearing and this PR will prevent us from always failing the check.

To test this PR:

- Create a build
- Open any Page Builder page and wait a few seconds after the page has finished loading.
- Refresh the page.

Please note that this PR will require a build to be created to be tested.
