### PR TITLE
Live Editor: Resolve Bottom Margin Not Being Removed From Last Widget

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -264,7 +264,7 @@ class SiteOrigin_Panels_Renderer {
 		$css->add_widget_css( $post_id, false, false, false, '', array(
 			'margin-bottom' => apply_filters( 'siteorigin_panels_css_cell_margin_bottom', $settings['margin-bottom'] . 'px', false, false, $panels_data, $post_id )
 		) );
-		$css->add_widget_css( $post_id, false, false, false, ':last-child', array(
+		$css->add_widget_css( $post_id, false, false, false, ':last-of-type', array(
 			'margin-bottom' => apply_filters( 'siteorigin_panels_css_cell_last_margin_bottom', '0px', false, false, $panels_data, $post_id )
 		) );
 


### PR DESCRIPTION
This PR will resolve an issue in the live editor (or if the user were to add a `style` element using the [siteorigin_panels_inside_cell_after](https://siteorigin.com/docs/page-builder/hooks/html/#heading-inside-cells-before-and-after ) filter) which results in the bottom margin not being removed. This happens due to certain widgets, such as the SIteOrigin Hero, or SiteOrigin Button, loading adding their custom styling using a `style` element rather than the typical stylesheet. This prevents `.so-panel:last-child` from working as expected.

This issue will affect all layouts, but the easiest way to test it is to import the Staggered Prebuilt layout due to how obvious the gap is in the Live Editor when compared to the normal page.