### PR TITLE
Parallax Type: Re-do default value detection

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -121,12 +121,26 @@ class SiteOrigin_Panels_Settings {
 		// that hook is triggered after the settings are loaded.
 		$so_settings = get_option( 'siteorigin_panels_settings' );
 
+		if ( empty( $so_settings ) ) {
+			// New install.
+			$parallax_type = 'modern';
+		} elseif ( isset( $so_settings['parallax-type'] ) ) {
+			// If parallax-type already exists, use the existing value to prevent a potential override.
+			$parallax_type = $so_settings['parallax-type'];
+		} elseif ( isset( $so_settings['parallax-delay'] ) ) {
+			// User is upgrading.
+			$parallax_type = 'legacy';
+		} else {
+			// If all else fails, fallback to modern.
+			$parallax_type = 'modern';
+		}
+
 		// The general fields
 		$defaults['post-types']             = array( 'page', 'post' );
 		$defaults['live-editor-quick-link'] = true;
 		$defaults['admin-post-state']       = true;
 		$defaults['admin-widget-count']     = false;
-		$defaults['parallax-type']          = ! empty( $so_settings ) && ! isset( $so_settings['parallax-delay'] ) ? 'legacy' : 'modern';
+		$defaults['parallax-type']          = $parallax_type;
 		$defaults['parallax-mobile']        = false;
 		$defaults['parallax-motion']        = ''; // legacy parallax
 		$defaults['parallax-delay']         = 0.4;


### PR DESCRIPTION
This PR to prevent a situation where legacy isn't used after upgrading, and to avoid a potential override.
A user reported that their parallax had unexpectedly changed after an upgrade and it was due to the parallax being set to modern. This PR implements further checks to prevent that and to prevent a potential setting overridden.

You can test this PR by clearing certain settings.

**To test the override prevention** is working, add the following to [this line](https://github.com/siteorigin/siteorigin-panels/blob/afc61d9fa72b0ce9468fdb27268b4feb2efae9f8/inc/settings.php#L137):

`var_dump( $parallax_type );`

`parallax-type` will be will always equal to exactly the same value you have parallax-type set to so change the parallax type via the settings a few times to ensure this variable is updating correctly.

**To test the upgrade process** add the following to [this line](https://github.com/siteorigin/siteorigin-panels/blob/afc61d9fa72b0ce9468fdb27268b4feb2efae9f8/inc/settings.php#L123).

`unset( $so_settings['parallax-type'] );`

That'll clear the existing `parallax-type` and clearing it isn't required if actually upgrading for testing purposes. You can simulate a upgrade by adding `unset( $current_settings['parallax-type'] );` to [this line](https://github.com/siteorigin/siteorigin-panels/blob/afc61d9fa72b0ce9468fdb27268b4feb2efae9f8/inc/settings.php#L75).
`parallax-type` will be `legacy`.

**To test new install** settings, add:

`unset( $so_settings );`

`parallax-type` will be `modern`.

[**The general fallback**](https://github.com/siteorigin/siteorigin-panels/pull/898/files#diff-d1fc3e16afc6476c7f6323a308fbc467625e9ba3413d990c5a58414eefa3d204R133-R136) really should never be used, it's more of a catch-all just in case I've overlooked something - in other words, I don't know how to actually trigger it).