### PR TITLE
Layout Builder: Add Builder Instance data to widgets

### DIFF
--- a/inc/widgets/layout.php
+++ b/inc/widgets/layout.php
@@ -31,6 +31,7 @@ class SiteOrigin_Panels_Widgets_Layout extends WP_Widget {
 		if( ! empty( $instance['panels_data']['widgets'] ) ) {
 			foreach( $instance['panels_data']['widgets'] as & $widget ) {
 				$widget['panels_info']['class'] = str_replace( '&#92;', '\\', $widget['panels_info']['class'] );
+				$widget['panels_info']['builder'] = true;
 			}
 		}
 		


### PR DESCRIPTION
Requires https://github.com/siteorigin/so-widgets-bundle/pull/1362

This PR prevent WB from including page ids in file names. Pre-existing layout builders don't need to be re-saved.