### PR TITLE
Add identifiers to style fields to allow future UI customisation

### DIFF
--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -160,7 +160,7 @@ class SiteOrigin_Panels_Styles_Admin {
 
 						if ( $field['group'] == $group_id ) {
 							?>
-							<div class="style-field-wrapper">
+							<div class="style-field-wrapper <?php echo $field_id ?>">
 								<?php if ( ! empty( $field['name'] ) ) : ?>
 									<label><?php echo $field['name'] ?></label>
 								<?php endif; ?>

--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -160,7 +160,7 @@ class SiteOrigin_Panels_Styles_Admin {
 
 						if ( $field['group'] == $group_id ) {
 							?>
-							<div class="style-field-wrapper <?php echo esc_attr( $field_id ); ?>">
+							<div class="style-field-wrapper so-field-<?php echo esc_attr( $field_id ); ?>">
 								<?php if ( ! empty( $field['name'] ) ) : ?>
 									<label><?php echo $field['name'] ?></label>
 								<?php endif; ?>

--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -160,7 +160,7 @@ class SiteOrigin_Panels_Styles_Admin {
 
 						if ( $field['group'] == $group_id ) {
 							?>
-							<div class="style-field-wrapper <?php echo $field_id ?>">
+							<div class="style-field-wrapper <?php echo esc_attr( $field_id ); ?>">
 								<?php if ( ! empty( $field['name'] ) ) : ?>
 									<label><?php echo $field['name'] ?></label>
 								<?php endif; ?>


### PR DESCRIPTION
It seemed useful to have a class name that can be used to modify the various style fields that appear. Unfortunately I haven't yet worked out how to hook into the 'open_dialog_complete' event that is triggered once the dialog has opened.