### PR TITLE
Jetpack Image Accelerator: Exclude Modern Parallax Images

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -467,8 +467,30 @@ class SiteOrigin_Panels_Styles {
 		return $attributes;
 	}
 
-	function jetpack_photon_exclude_modern_parallax( $skip, $src, $tag) {
-		if ( strpos( $tag, 'data-siteorigin-parallax') !== false ) {
+	/**
+	 * Prevent Photon from overriding image URL.
+	 * This is done using a method to prevent conflicting with other usage of this filter.
+	 *
+	 * @param $skip
+	 * @param $args
+	 *
+	 * @return true
+	 */
+	function jetpack_photon_exclude_modern_parallax_downsize( $skip, $args ) {
+		return true;
+	}
+
+	/**
+	 * Prevent Photon from overriding parallax images when it calculates srcset and filters the_content.
+	 *
+	 * @param $skip
+	 * @param $src
+	 * @param $tag
+	 *
+	 * @return bool
+	 */
+	function jetpack_photon_exclude_modern_parallax_content( $skip, $src, $tag ) {
+		if ( strpos( $tag, 'data-siteorigin-parallax' ) !== false ) {
 			$skip = true;
 		}
 		return $skip;
@@ -484,8 +506,11 @@ class SiteOrigin_Panels_Styles {
 				// Jetpack Image Accelerator (Photon) can result in the parallax being incorrectly sized so we need to exclude it.
 				$photon_exclude = class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' );
 				if ( $photon_exclude ) {
-					add_filter( 'jetpack_photon_skip_image', '__return_true' );
+					add_filter( 'jetpack_photon_override_image_downsize', array( $this, 'jetpack_photon_exclude_modern_parallax_downsize' ), 10, 2 );
+					// Prevent Photon from overriding the image URL later.
+					add_filter( 'jetpack_photon_skip_image', array( $this, 'jetpack_photon_exclude_modern_parallax_content' ), 10, 3 );
 				}
+
 				$image_html = wp_get_attachment_image(
 					$context['style']['background_image_attachment'],
 					'full',
@@ -497,8 +522,8 @@ class SiteOrigin_Panels_Styles {
 				);
 
 				if ( $photon_exclude ) {
-					// Restore Photon and prevent it from overriding the image URL later.
-					add_filter( 'jetpack_photon_skip_image', array( $this, 'jetpack_photon_exclude_modern_parallax' ), 10, 3 );
+					// Restore photon.
+					remove_filter( 'jetpack_photon_override_image_downsize', array( $this, 'jetpack_photon_exclude_modern_parallax_downsize' ), 10 );
 				}
 
 				if ( ! empty( $image_html ) ) {


### PR DESCRIPTION
Jetpack Image Accelerator (Photon) can result in the parallax being incorrectly sized so this PR will exclude the image. To test this PR:

- Enable Photon (must be on a web-accessible server) by navigating to **Jetpack > Settings**, open the **Performance** tab, and tick "Speed up image load times".
- Ensure Parallax Type is set to Modern.
- Add a Parallax to a row/widget and then save.
- Check the resulting output of the page to ensure the image isn't being served locally and not from wp.com.