### PR TITLE
Modern Parallax: Resolve "back" Causing Image Not to Parallax

### DIFF
--- a/js/styling.js
+++ b/js/styling.js
@@ -55,9 +55,7 @@ jQuery( function ( $ ) {
 	}
 	stretchFullWidthRows();
 
-	$( window ).on( 'resize load', function() {
-		stretchFullWidthRows();
-
+	var modernParallax = function() {
 		if (
 			typeof parallaxStyles != 'undefined' &&
 			typeof simpleParallax != 'undefined' &&
@@ -71,6 +69,12 @@ jQuery( function ( $ ) {
 				scale: parallaxStyles['scale'] < 1.1 ? 1.1 : parallaxStyles['scale'],
 			} );
 		}
+	}
+	modernParallax();
+
+	$( window ).on( 'resize load', function() {
+		stretchFullWidthRows();
+		modernParallax();
 	} );
 
 	// This should have been done in the footer, but run it here just incase.


### PR DESCRIPTION
This PR resolves a sizing issue while using the Modern Parallax and pressing the browser "back" button. Steps to replicate:

- Navigate to a page with a Modern Parallax image that's larger than the area it's applied too (this isn't a requirement, it just makes this issue really obvious)
- Navigate to any other page.
- Press the browser back button
- Note the image isn't parallax and significantly larger than it should be.
- Switch to branch and reload the page.
- Navigate away and press the browser back button again.
- Confirm Image is parallaxing and sized as expected.