### PR TITLE
SO Layouts Block: 5.8 Widgets Area Notice FIx

### DIFF
--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -37,12 +37,14 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 			$panels_admin->enqueue_admin_scripts();
 			$panels_admin->enqueue_admin_styles();
 			$panels_admin->js_templates();
-			
+
+			$current_screen = get_current_screen();
 			wp_enqueue_script(
 				'siteorigin-panels-layout-block',
 				plugins_url( 'js/siteorigin-panels-layout-block' . SITEORIGIN_PANELS_JS_SUFFIX . '.js', __FILE__ ),
 				array(
-					'wp-editor',
+					// The WP 5.8 Widget Area requires a speciic editor script to be used.
+					$current_screen->base == 'widgets' ? 'wp-edit-widgets' : 'wp-editor',
 					'wp-blocks',
 					'wp-i18n',
 					'wp-element',
@@ -52,8 +54,7 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 				),
 				SITEORIGIN_PANELS_VERSION
 			);
-			
-			$current_screen = get_current_screen();
+
 			$is_panels_post_type = in_array( $current_screen->id, siteorigin_panels_setting( 'post-types' ) );
 			wp_localize_script(
 				'siteorigin-panels-layout-block',


### PR DESCRIPTION
To test this PR please open the 5.8 widget area while WP_DEBUG_LOG is enabled.

`( ! ) Notice: wp_enqueue_script() was called <strong>incorrectly</strong>. "wp-editor" script should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets). Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.8.0.) in C:\Users\Alex\Documents\local-sites\wp-nightly\app\public\wp-includes\functions.php on line 5535`