### PR TITLE
Yoast OpenGraph: Bypass PB As Needed To Improve Compatibility

### DIFF
--- a/compat/yoast.php
+++ b/compat/yoast.php
@@ -1,4 +1,23 @@
 <?php
+/**
+ * If Yoast OpenGraph is enabled, we'll need disable PB when it gets the excerpt 
+ * to avoid conflicts with other plugins.
+ *
+ */
+function siteorigin_yoast_opengraph_panels_disable( $content ) {
+	global $wp_current_filter;
+	if ( count( $wp_current_filter ) > 2 && $wp_current_filter[1] == 'wpseo_head' ) {
+		// Temporarily disable Page Builder for this instance of the_content.
+		add_filter( 'siteorigin_panels_filter_content_enabled', '__return_false' );
+	} else {
+		add_filter( 'siteorigin_panels_filter_content_enabled', '__return_true' );
+	}
+	return $content;
+}
+// If Yoast OpenGraph is enabled, disable Page Builder as needed.
+if ( class_exists( 'WPSEO_Options' ) && WPSEO_Options::get( 'opengraph' ) ) {
+	add_filter( 'the_content', 'siteorigin_yoast_opengraph_panels_disable', 1 );
+}
 
 /**
  * Returns a list of all images added using Page Builder.

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -204,7 +204,7 @@ class SiteOrigin_Panels {
 
 		// Compatibility with Yoast Sitemap.
 		if ( defined( 'WPSEO_FILE' ) ) {
-			require_once plugin_dir_path( __FILE__ ) . 'compat/yoast-sitemap.php';
+			require_once plugin_dir_path( __FILE__ ) . 'compat/yoast.php';
 		}
 
 		// Compatibility with AMP plugin


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/679 & Ninja Form reCAPTCHA error.

When a meta description isn't set, Yoast will render a version of the page to generate the excerpt using `get_the_excerpt`. This is the correct way of doing this, but it can be problematic when plugins account for situations where their plugin is rendered multiple times this which Forminator and Ninja Form both do . This is also compounded by the fact that Page Builder will override `the_content` to replace the fallback content with the generated page builder layout. This PR resolves this entire issue by selectively disabling Page Builder when Yoast is generating the OpenGraph meta description.

To test this PR please set up Forminator form as outlined in #679. Ninja Forms can also be tested but it will require setting up reCAPTCHA so testing it is a bit more involved - I should note that the premium user who reported this conflict has confirmed that fix has worked.

On merge, remove [the Forminator paragraph on this page](https://siteorigin.com/page-builder/troubleshooting-problems/).