### PR TITLE
(Optional) Container Breaker Using CSS Rather Than JS

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -308,7 +308,7 @@ class SiteOrigin_Panels_Renderer {
 			$css->add_css(
 				'.so-panels-full-wrapper, .panel-grid.panel-no-style, .panel-row-style:not([data-stretch-type])',
 				array(
-					'max-width' => (int) $this->container['width'] . 'px',
+					'max-width' => esc_attr( $this->container['width'] ),
 					'margin' => '0 auto',
 				),
 				1920

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -109,7 +109,7 @@ class SiteOrigin_Panels_Renderer {
 
 			// If the CSS Container Breaker is enabled, and this row is using it,
 			// we need to remove the cell widths on mobile.
-			$css_container_cutoff = $this->container['css_override'] && isset( $row['style']['row_stretch'] ) && $row['style']['row_stretch'] == 'full' ? ":$panels_mobile_width" : '';
+			$css_container_cutoff = $this->container['css_override'] && isset( $row['style']['row_stretch'] ) && $row['style']['row_stretch'] == 'full' ? ":$panels_mobile_width" : 1920;
 
 			// Add the cell sizing
 			foreach ( $row['cells'] as $ci => $cell ) {

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -107,6 +107,10 @@ class SiteOrigin_Panels_Renderer {
 
 			$cell_count = count( $row['cells'] );
 
+			// If the CSS Container Breaker is enabled, and this row is using it,
+			// we need to remove the cell widths on mobile.
+			$css_container_cutoff = $this->container['css_override'] && isset( $row['style']['row_stretch'] ) && $row['style']['row_stretch'] == 'full' ? ":$panels_mobile_width" : '';
+
 			// Add the cell sizing
 			foreach ( $row['cells'] as $ci => $cell ) {
 				$weight = apply_filters( 'siteorigin_panels_css_cell_weight', $cell['weight'], $row, $ri, $cell, $ci - 1, $panels_data, $post_id );
@@ -122,7 +126,7 @@ class SiteOrigin_Panels_Renderer {
 						str_replace( ',', '.', $rounded_width ),
 						str_replace( ',', '.', (int) $gutter ? $calc_width : '' ), // Exclude if there's a zero gutter
 					)
-				) );
+				), $css_container_cutoff );
 				
 				// Add in any widget specific CSS
 				foreach ( $cell['widgets'] as $wi => $widget ) {
@@ -325,6 +329,15 @@ class SiteOrigin_Panels_Renderer {
 					'width' => '100%',
 				),
 				1920
+			);
+
+			// Ensure cells inside of .so-panels-full-wrapper are full width when collapsed.
+			$css->add_css(
+				'.so-panels-full-wrapper .panel-grid-cell',
+				array(
+					'width' => '100%',
+				),
+				siteorigin_panels_setting( 'mobile-width' )				
 			);
 		}
 

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -865,7 +865,7 @@ class SiteOrigin_Panels_Renderer {
 		if (
 			$this->container['css_override'] &&
 			isset( $row['style']['row_stretch'] ) &&
-			$row['style']['row_stretch'] != 'full'
+			$row['style']['row_stretch'] == 'full'
 		) {
 			echo '</div>';
 		}

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -166,8 +166,6 @@ class SiteOrigin_Panels_Settings {
 		$defaults['margin-bottom-last-row']   = false;
 		$defaults['margin-sides']             = 30;
 		$defaults['full-width-container']     = 'body';
-		$defaults['container-selector']       = '';
-		$defaults['container-width']          = '';
 		$defaults['output-css-header']        = 'auto';
 
 		// Content fields
@@ -493,21 +491,6 @@ class SiteOrigin_Panels_Settings {
 			'label'       => __( 'Full Width Container', 'siteorigin-panels' ),
 			'description' => __( 'The container used for the full width layout.', 'siteorigin-panels' ),
 			'keywords'    => 'full width, container, stretch',
-		);
-
-		$fields['layout']['fields']['container-selector'] = array(
-			'type'        => 'text',
-			'label'       => __( 'Theme Container Selector', 'siteorigin-panels' ),
-			'description' => __( 'Used to override theme container on the fly.', 'siteorigin-panels' ),
-			'keywords'    => 'full width, cls, performance, container, stretch',
-		);
-
-		$fields['layout']['fields']['container-width'] = array(
-			'type'        => 'number',
-			'unit'        => 'px',
-			'label'       => __( 'Theme Container Width', 'siteorigin-panels' ),
-			'description' => __( 'This width is used with a custom container applied for standard and full width rows.', 'siteorigin-panels' ),
-			'keywords'    => 'full width, cls, performance, container, stretch',
 		);
 
 		$fields['layout']['fields']['output-css-header'] = array(

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -166,6 +166,8 @@ class SiteOrigin_Panels_Settings {
 		$defaults['margin-bottom-last-row']   = false;
 		$defaults['margin-sides']             = 30;
 		$defaults['full-width-container']     = 'body';
+		$defaults['container-selector']       = '';
+		$defaults['container-width']          = '';
 		$defaults['output-css-header']        = 'auto';
 
 		// Content fields
@@ -491,6 +493,21 @@ class SiteOrigin_Panels_Settings {
 			'label'       => __( 'Full Width Container', 'siteorigin-panels' ),
 			'description' => __( 'The container used for the full width layout.', 'siteorigin-panels' ),
 			'keywords'    => 'full width, container, stretch',
+		);
+
+		$fields['layout']['fields']['container-selector'] = array(
+			'type'        => 'text',
+			'label'       => __( 'Theme Container Selector', 'siteorigin-panels' ),
+			'description' => __( 'Used to override theme container on the fly.', 'siteorigin-panels' ),
+			'keywords'    => 'full width, cls, performance, container, stretch',
+		);
+
+		$fields['layout']['fields']['container-width'] = array(
+			'type'        => 'number',
+			'unit'        => 'px',
+			'label'       => __( 'Theme Container Width', 'siteorigin-panels' ),
+			'description' => __( 'This width is used with a custom container applied for standard and full width rows.', 'siteorigin-panels' ),
+			'keywords'    => 'full width, cls, performance, container, stretch',
 		);
 
 		$fields['layout']['fields']['output-css-header'] = array(

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -718,10 +718,26 @@ class SiteOrigin_Panels_Styles {
 
 			// Add in flexbox alignment to the main row element
 			if ( siteorigin_panels_setting( 'legacy-layout' ) != 'always' && ! SiteOrigin_Panels::is_legacy_browser() && ! empty( $row['style']['cell_alignment'] ) ) {
+
+				$selector = array();
+				$container_settings = SiteOrigin_Panels::container_settings();
+				// What selector we use is dependent on their row setup.
+				if ( empty( $row['style'] ) ) {
+					$selector[] = '.panel-no-style';
+				} elseif ( // Is CSS Container Breaker is enabled, and is the row full width?
+					$container_settings['css_override'] &&
+					isset( $row['style']['row_stretch'] ) &&
+					$row['style']['row_stretch'] == 'full'
+				) {
+					$selector[] = '.panel-has-style > .panel-row-style > .so-panels-full-wrapper';
+				} else {
+					$selector[] = '.panel-has-style > .panel-row-style';
+				}
+
 				$css->add_row_css(
 					$post_id,
 					$ri,
-					array( '.panel-no-style', '.panel-has-style > .panel-row-style' ),
+					$selector,
 					array(
 						'-webkit-align-items' => $row['style']['cell_alignment'],
 						'align-items'         => $row['style']['cell_alignment'],
@@ -806,6 +822,11 @@ class SiteOrigin_Panels_Styles {
 					if ( ! empty( $widget['panels_info']['style']['link_color'] ) ) {
 						$css->add_widget_css( $post_id, $ri, $ci, $wi, ' a', array(
 							'color' => $widget['panels_info']['style']['link_color']
+						) );
+					}
+					if ( ! empty( $widget['panels_info']['style']['link_color_hover'] ) ) {
+						$css->add_widget_css( $post_id, $ri, $ci, $wi, ' a:hover', array(
+							'color' => $widget['panels_info']['style']['link_color_hover']
 						) );
 					}
 				}

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -61,8 +61,11 @@ class SiteOrigin_Panels_Styles {
 			array( 'jquery' ),
 			SITEORIGIN_PANELS_VERSION
 		);
+
+		$container_settings = SiteOrigin_Panels::container_settings();
 		wp_localize_script( 'siteorigin-panels-front-styles', 'panelsStyles', array(
 			'fullContainer' => apply_filters( 'siteorigin_panels_full_width_container', siteorigin_panels_setting( 'full-width-container' ) ),
+			'stretchRows' => ! $container_settings['css_override'],
 		) );
 
 		if ( siteorigin_panels_setting( 'parallax-type' ) == 'modern' ) {

--- a/js/styling.js
+++ b/js/styling.js
@@ -2,61 +2,65 @@
 
 jQuery( function ( $ ) {
 
-	// Stretch all the full width rows
-	var stretchFullWidthRows = function () {
-		var fullContainer = $( panelsStyles.fullContainer );
-		if ( fullContainer.length === 0 ) {
-			fullContainer = $( 'body' );
-		}
-
-		var $panelsRow = $( '.siteorigin-panels-stretch.panel-row-style' );
-		$panelsRow.each( function () {
-			var $$ = $( this );
-			
-			var stretchType = $$.data( 'stretch-type' );
-			var defaultSidePadding = stretchType === 'full-stretched-padded' ? '' : 0;
-			
-			// Reset all the styles associated with row stretching
-			$$.css( {
-				'margin-left': 0,
-				'margin-right': 0,
-				'padding-left': defaultSidePadding,
-				'padding-right': defaultSidePadding
-			} );
-
-			var leftSpace = $$.offset().left - fullContainer.offset().left,
-				rightSpace = fullContainer.outerWidth() - leftSpace - $$.parent().outerWidth();
-
-			$$.css( {
-				'margin-left': - leftSpace + 'px',
-				'margin-right': - rightSpace + 'px',
-				'padding-left': stretchType === 'full' ? leftSpace + 'px' : defaultSidePadding,
-				'padding-right': stretchType === 'full' ? rightSpace + 'px': defaultSidePadding
-			} );
-
-			var cells = $$.find( '> .panel-grid-cell' );
-
-			if ( stretchType === 'full-stretched' && cells.length === 1 ) {
-				cells.css( {
-					'padding-left': 0,
-					'padding-right': 0
-				} );
+	if ( panelsStyles.stretchRows ) {
+		// Stretch all the full width rows
+		var stretchFullWidthRows = function () {
+			var fullContainer = $( panelsStyles.fullContainer );
+			if ( fullContainer.length === 0 ) {
+				fullContainer = $( 'body' );
 			}
 
-			$$.css( {
-				'border-left': defaultSidePadding,
-				'border-right': defaultSidePadding
-			} );
-		} );
+			var $panelsRow = $( '.siteorigin-panels-stretch.panel-row-style' );
+			$panelsRow.each( function () {
+				var $$ = $( this );
+				
+				var stretchType = $$.data( 'stretch-type' );
+				var defaultSidePadding = stretchType === 'full-stretched-padded' ? '' : 0;
+				
+				// Reset all the styles associated with row stretching
+				$$.css( {
+					'margin-left': 0,
+					'margin-right': 0,
+					'padding-left': defaultSidePadding,
+					'padding-right': defaultSidePadding
+				} );
 
-		if ( $panelsRow.length ) {
-			$( window ).trigger( 'panelsStretchRows' );
+				var leftSpace = $$.offset().left - fullContainer.offset().left,
+					rightSpace = fullContainer.outerWidth() - leftSpace - $$.parent().outerWidth();
+
+				$$.css( {
+					'margin-left': - leftSpace + 'px',
+					'margin-right': - rightSpace + 'px',
+					'padding-left': stretchType === 'full' ? leftSpace + 'px' : defaultSidePadding,
+					'padding-right': stretchType === 'full' ? rightSpace + 'px': defaultSidePadding
+				} );
+
+				var cells = $$.find( '> .panel-grid-cell' );
+
+				if ( stretchType === 'full-stretched' && cells.length === 1 ) {
+					cells.css( {
+						'padding-left': 0,
+						'padding-right': 0
+					} );
+				}
+
+				$$.css( {
+					'border-left': defaultSidePadding,
+					'border-right': defaultSidePadding
+				} );
+			} );
+
+			if ( $panelsRow.length ) {
+				$( window ).trigger( 'panelsStretchRows' );
+			}
 		}
+		stretchFullWidthRows();
 	}
-	stretchFullWidthRows();
 
 	$( window ).on( 'resize load', function() {
-		stretchFullWidthRows();
+		if ( panelsStyles.stretchRows ) {
+			stretchFullWidthRows();
+		}
 
 		if (
 			typeof parallaxStyles != 'undefined' &&

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -530,6 +530,10 @@ class SiteOrigin_Panels {
 		if( self::is_home() ) $classes[] = 'siteorigin-panels-home';
 		if( self::is_live_editor() ) $classes[] = 'siteorigin-panels-live-editor';
 
+		if ( $this->container['override'] ) {
+			$classes[] = 'siteorigin-panels-css-container';
+		}
+
 		return $classes;
 	}
 

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -530,7 +530,8 @@ class SiteOrigin_Panels {
 		if( self::is_home() ) $classes[] = 'siteorigin-panels-home';
 		if( self::is_live_editor() ) $classes[] = 'siteorigin-panels-live-editor';
 
-		if ( $this->container['override'] ) {
+		$this->container = SiteOrigin_Panels::container_settings();
+		if ( ! empty( $this->container ) && $this->container['override'] ) {
 			$classes[] = 'siteorigin-panels-css-container';
 		}
 

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -287,6 +287,16 @@ class SiteOrigin_Panels {
 		return $preview_url;
 	}
 
+	public static function container_settings() {
+		$container = array(
+			'selector' => ! empty( siteorigin_panels_setting( 'container-selector' ) ) ? siteorigin_panels_setting( 'container-selector' ) : apply_filters( 'siteorigin_panels_theme_container_selector', '' ),
+			'width' => ! empty( siteorigin_panels_setting( 'container-width' ) ) ? siteorigin_panels_setting( 'container-width' ) : apply_filters( 'siteorigin_panels_theme_container_width', '' ),
+		);
+		$container['css_override'] = ! empty( $container['selector'] ) && ! empty( $container['width'] );
+
+		return $container;
+	}
+
 	/**
 	 * Get the Page Builder data for the home page.
 	 *

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -289,8 +289,8 @@ class SiteOrigin_Panels {
 
 	public static function container_settings() {
 		$container = array(
-			'selector' => ! empty( siteorigin_panels_setting( 'container-selector' ) ) ? siteorigin_panels_setting( 'container-selector' ) : apply_filters( 'siteorigin_panels_theme_container_selector', '' ),
-			'width' => ! empty( siteorigin_panels_setting( 'container-width' ) ) ? siteorigin_panels_setting( 'container-width' ) : apply_filters( 'siteorigin_panels_theme_container_width', '' ),
+			'selector' => apply_filters( 'siteorigin_panels_theme_container_selector', '' ),
+			'width' => apply_filters( 'siteorigin_panels_theme_container_width', '' ),
 		);
 		$container['css_override'] = ! empty( $container['selector'] ) && ! empty( $container['width'] );
 

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -531,7 +531,7 @@ class SiteOrigin_Panels {
 		if( self::is_live_editor() ) $classes[] = 'siteorigin-panels-live-editor';
 
 		$this->container = SiteOrigin_Panels::container_settings();
-		if ( ! empty( $this->container ) && $this->container['override'] ) {
+		if ( ! empty( $this->container ) && $this->container['css_override'] ) {
 			$classes[] = 'siteorigin-panels-css-container';
 		}
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/866

This PR introduces the two filters outlined in the initial PR. It no longer includes settings as it has been decided this change is a little bit too tricky to manage without assistance. To test this PR please configure the 

`siteorigin_panels_theme_container_width` filter (int) and `siteorigin_panels_theme_container_selector` (CSS selector). For example, here's a snippet for Corp:

```
add_filter( 'siteorigin_panels_theme_container_width', function( $container ) {
	return '1170px';
} );

add_filter( 'siteorigin_panels_theme_container_selector', function( $selector ) {
	return '.site-content .corp-container';
} );
```

To test this please add four rows with each of the row layouts selected and confirm:

- Standard row is the expected width.
- Full Width has a special container wrapper applied inside of the row.
- Full Width rows still have a full width background.
- Full Width Stretch doesn't have any container applied at all.

([here's a test layout](https://drive.google.com/uc?id=1t8KdPQXSeZ4LcaZqJ3v-p5YmM23oyg-r))