### PR TITLE
Photon: Prevent Validation to ensure Photon isn't able to affect Modern Parallax

### DIFF
--- a/compat/jetpack.php
+++ b/compat/jetpack.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Prevent Photon from filtering srcset.
+ * This is done using a method to prevent conflicting with other usage of this filter.
+ *
+ * @param $valid
+ * @param $url
+ * @param $parsed_url
+ *
+ * @return false
+ */
+function siteorigin_panels_photon_exclude_parallax_srcset( $valid, $url, $parsed_url ) {
+	return false;
+}
+
+/**
+ * Prevent Photon from overriding parallax images when it calculates srcset and filters the_content.
+ *
+ * @param $skip Whether to exclude the iamge from Photon.
+ * @param $src The URL of the current image
+ * @param $tag This parameter is unrelaible as it can contain the image tag, or an array containing image values.
+ *
+ * @return bool
+ */
+function siteorigin_panels_photon_exclude_parallax( $skip, $src, $tag ) {
+	if ( ! is_array( $tag ) && strpos( $tag, 'data-siteorigin-parallax' ) !== false ) {
+		$skip = true;
+	}
+	return $skip;
+}

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -467,35 +467,6 @@ class SiteOrigin_Panels_Styles {
 		return $attributes;
 	}
 
-	/**
-	 * Prevent Photon from overriding image URL.
-	 * This is done using a method to prevent conflicting with other usage of this filter.
-	 *
-	 * @param $skip
-	 * @param $args
-	 *
-	 * @return true
-	 */
-	function jetpack_photon_exclude_modern_parallax_downsize( $skip, $args ) {
-		return true;
-	}
-
-	/**
-	 * Prevent Photon from overriding parallax images when it calculates srcset and filters the_content.
-	 *
-	 * @param $skip
-	 * @param $src
-	 * @param $tag
-	 *
-	 * @return bool
-	 */
-	function jetpack_photon_exclude_modern_parallax_content( $skip, $src, $tag ) {
-		if ( strpos( $tag, 'data-siteorigin-parallax' ) !== false ) {
-			$skip = true;
-		}
-		return $skip;
-	}
-
 	function add_parallax( $output, $context ) {
 		if (
 			! empty( $context['style']['background_display'] ) &&
@@ -506,9 +477,9 @@ class SiteOrigin_Panels_Styles {
 				// Jetpack Image Accelerator (Photon) can result in the parallax being incorrectly sized so we need to exclude it.
 				$photon_exclude = class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' );
 				if ( $photon_exclude ) {
-					add_filter( 'jetpack_photon_override_image_downsize', array( $this, 'jetpack_photon_exclude_modern_parallax_downsize' ), 10, 2 );
+					add_filter( 'photon_validate_image_url', 'siteorigin_panels_photon_exclude_parallax_srcset', 10, 3 );
 					// Prevent Photon from overriding the image URL later.
-					add_filter( 'jetpack_photon_skip_image', array( $this, 'jetpack_photon_exclude_modern_parallax_content' ), 10, 3 );
+					add_filter( 'jetpack_photon_skip_image',  'siteorigin_panels_photon_exclude_parallax', 10, 3 );
 				}
 
 				$image_html = wp_get_attachment_image(
@@ -523,7 +494,7 @@ class SiteOrigin_Panels_Styles {
 
 				if ( $photon_exclude ) {
 					// Restore photon.
-					remove_filter( 'jetpack_photon_override_image_downsize', array( $this, 'jetpack_photon_exclude_modern_parallax_downsize' ), 10 );
+					remove_filter( 'photon_validate_image_url', 'siteorigin_panels_photon_exclude_parallax_downsize', 10 );
 				}
 
 				if ( ! empty( $image_html ) ) {

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -231,6 +231,10 @@ class SiteOrigin_Panels {
 		if ( apply_filters( 'siteorigin_lazyload_compat', $load_lazy_load_compat ) ) {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/lazy-load-backgrounds.php';
 		}
+
+		if ( siteorigin_panels_setting( 'parallax-type' ) == 'modern' && class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
+			require_once plugin_dir_path( __FILE__ ) . 'compat/jetpack.php';
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR will resolve the following notice:

>strpos() expects parameter 1 to be string, array given in /wp-content/plugins/siteorigin-panels/inc/styles.phpon line 493

To replicate that notice, please use an image with at least three other sizes for srcset.

It'll also prevent _any_ chance of Photon altering the URL.  It no longer relies on `jetpack_photon_skip_image` (which is used inconsistently) and instead forces the Photon validation to fail.

I also moved the required functions to a dedicated file because they don't _need_ to be in styles.php.