### PR TITLE
Customizer: Resolve New Widget Area Notice

### DIFF
--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -36,7 +36,9 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 			$panels_admin = SiteOrigin_Panels_Admin::single();
 			$panels_admin->enqueue_admin_scripts();
 			$panels_admin->enqueue_admin_styles();
-			$panels_admin->js_templates();
+			if ( ! is_customize_preview() ) {
+				$panels_admin->js_templates();
+			}
 
 			$current_screen = get_current_screen();
 			wp_enqueue_script(

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -48,7 +48,7 @@ class SiteOrigin_Panels_Admin {
 		add_action( 'load-post-new.php', array( $this, 'add_help_tab' ), 12 );
 		add_action( 'load-appearance_page_so_panels_home_page', array( $this, 'add_help_tab' ), 12 );
 
-		add_action( 'customize_controls_print_footer_scripts', array( $this, 'js_templates' ) );
+		add_action( 'customize_controls_print_scripts', array( $this, 'js_templates' ) );
 
 		// Register all the admin actions
 		add_action( 'wp_ajax_so_panels_builder_content', array( $this, 'action_builder_content' ) );


### PR DESCRIPTION
This PR will resolve the following notice:

`PHP Warning: Cannot modify header information - headers already sent by (output started at C:\Xampp\htdocs\idee\wp-content\plugins\siteorigin-panels\tpl\js-templates.php:113) in C:\Xampp\htdocs\idee\wp-admin\customize.php on line 126`

Please test (regardless of being able to replicate the above issue) the following things:
- The SiteOrigin Layout Block works in the new Widget Area and Customizer.
- The Layout Builder works as expected in the Widget Area and Customizer.