### PR TITLE
Polylang Compat

### DIFF
--- a/compat/polylang.php
+++ b/compat/polylang.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * When Polylang duplicates a post, copy over panels_data if it exists.
+ *
+ */
+function siteorigin_polylang_include_panels_data( $keys, $sync ) {
+	if ( ! $sync ) {
+		$keys[] = 'panels_data';
+	}
+	return $keys;
+}
+add_filter( 'pll_copy_post_metas', 'siteorigin_polylang_include_panels_data', 10, 2 );

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -235,6 +235,10 @@ class SiteOrigin_Panels {
 		if ( siteorigin_panels_setting( 'parallax-type' ) == 'modern' && class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/jetpack.php';
 		}
+
+		if ( class_exists( 'Polylang' ) ) {
+			require_once plugin_dir_path( __FILE__ ) . 'compat/polylang.php';
+		}
 	}
 
 	/**


### PR DESCRIPTION
[Reported here](https://siteorigin.com/thread/the-template-isnt-duplicated-when-uising-polylang/).

Include `panels_data` when duplicating pages.