### PR TITLE
Links Hover Color

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -347,7 +347,7 @@ class SiteOrigin_Panels_Styles {
 		);
 
 		$fields['link_color'] = array(
-			'name'        => __( 'Links Color', 'siteorigin-panels' ),
+			'name'        => __( 'Link Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
 			'description' => __( 'Color of links inside this cell.', 'siteorigin-panels' ),
@@ -355,7 +355,7 @@ class SiteOrigin_Panels_Styles {
 		);
 
 		$fields['link_color_hover'] = array(
-			'name'        => __( 'Links Hover Color', 'siteorigin-panels' ),
+			'name'        => __( 'Link Hover Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
 			'description' => __( 'Color of links inside this widget when hovered.', 'siteorigin-panels' ),
@@ -395,7 +395,7 @@ class SiteOrigin_Panels_Styles {
 		);
 
 		$fields['link_color'] = array(
-			'name'        => __( 'Links Color', 'siteorigin-panels' ),
+			'name'        => __( 'Link Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
 			'description' => __( 'Color of links inside this widget.', 'siteorigin-panels' ),
@@ -403,7 +403,7 @@ class SiteOrigin_Panels_Styles {
 		);
 
 		$fields['link_color_hover'] = array(
-			'name'        => __( 'Links Hover Color', 'siteorigin-panels' ),
+			'name'        => __( 'Link Hover Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
 			'description' => __( 'Color of links inside this widget when hovered.', 'siteorigin-panels' ),

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -354,6 +354,14 @@ class SiteOrigin_Panels_Styles {
 			'priority'    => 16,
 		);
 
+		$fields['link_color_hover'] = array(
+			'name'        => __( 'Links Hover Color', 'siteorigin-panels' ),
+			'type'        => 'color',
+			'group'       => 'design',
+			'description' => __( 'Color of links inside this widget when hovered.', 'siteorigin-panels' ),
+			'priority'    => 17,
+		);
+
 		return $fields;
 	}
 
@@ -392,6 +400,14 @@ class SiteOrigin_Panels_Styles {
 			'group'       => 'design',
 			'description' => __( 'Color of links inside this widget.', 'siteorigin-panels' ),
 			'priority'    => 16,
+		);
+
+		$fields['link_color_hover'] = array(
+			'name'        => __( 'Links Hover Color', 'siteorigin-panels' ),
+			'type'        => 'color',
+			'group'       => 'design',
+			'description' => __( 'Color of links inside this widget when hovered.', 'siteorigin-panels' ),
+			'priority'    => 17,
 		);
 
 		return $fields;
@@ -774,6 +790,11 @@ class SiteOrigin_Panels_Styles {
 					if ( ! empty( $widget['panels_info']['style']['link_color'] ) ) {
 						$css->add_widget_css( $post_id, $ri, $ci, $wi, ' a', array(
 							'color' => $widget['panels_info']['style']['link_color']
+						) );
+					}
+					if ( ! empty( $widget['panels_info']['style']['link_color_hover'] ) ) {
+						$css->add_widget_css( $post_id, $ri, $ci, $wi, ' a:hover', array(
+							'color' => $widget['panels_info']['style']['link_color_hover']
 						) );
 					}
 				}


### PR DESCRIPTION
This PR adds the Links Hover Color setting. Previously, when a user altered the link color, the color wouldn't change on hover and this setting will avoid that situation by allowing them to also set the Links Hover Color.

Links Hover Color is not tied to any setting and can be set independently to the Links Color setting. There are widgets that will have more specific CSS than this setting, and there's no way of really getting around that without potential display issues.