### PR TITLE
Live Editor Quick Link: Close After Editing & Improve Update Triggering

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -286,7 +286,22 @@ class SiteOrigin_Panels_Admin {
 			delete_post_meta( $post_id, 'panels_data' );
 		}
 
+		// If this is a Live Editor Quick Edit, setup redirection.
+		if (
+			siteorigin_panels_setting( 'live-editor-quick-link-close-after' ) &&
+			strpos( $_POST['_wp_http_referer'], 'so_live_editor' ) !== false
+		) {
+			add_filter( 'redirect_post_location', array( $this, 'live_editor_redirect_after' ), 10, 2 );
+		}
+
 		$this->in_save_post = false;
+	}
+
+	/*
+	 * Handles Live Editor Quick Link redirection after editing.
+	 */
+	public function live_editor_redirect_after( $location, $post_id ) {
+		return get_permalink( $post_id );
 	}
 
 	/**

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -294,12 +294,12 @@ class SiteOrigin_Panels_Settings {
 
 		$fields['general']['fields']['live-editor-quick-link'] = array(
 			'type'        => 'checkbox',
-			'label'       => __( 'Live Editor Quick Link', 'siteorigin-panels' ),
+			'label'       => __( 'Live Editor Toolbar Link', 'siteorigin-panels' ),
 			'description' => __( 'Display a Live Editor link in the toolbar when viewing site.', 'siteorigin-panels' ),
 		);
 		$fields['general']['fields']['live-editor-quick-link-close-after'] = array(
 			'type'        => 'checkbox',
-			'label'       => __( 'Live Editor Quick Link: Close After Editing', 'siteorigin-panels' ),
+			'label'       => __( 'Live Editor Toolbar Link: Close After Editing', 'siteorigin-panels' ),
 			'description' => __( 'When accessing the Live Editor via the toolbar link, return to the site after saving.', 'siteorigin-panels' ),
 		);
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -295,12 +295,12 @@ class SiteOrigin_Panels_Settings {
 		$fields['general']['fields']['live-editor-quick-link'] = array(
 			'type'        => 'checkbox',
 			'label'       => __( 'Live Editor Quick Link', 'siteorigin-panels' ),
-			'description' => __( 'Display a Live Editor button in the WordPress admin bar.', 'siteorigin-panels' ),
+			'description' => __( 'Display a Live Editor link in the toolbar when viewing site.', 'siteorigin-panels' ),
 		);
 		$fields['general']['fields']['live-editor-quick-link-close-after'] = array(
 			'type'        => 'checkbox',
 			'label'       => __( 'Live Editor Quick Link: Close After Editing', 'siteorigin-panels' ),
-			'description' => __( 'After clicking the Live Editor Quick Link, saving or closing the live editor will result in being redirected back to the page.', 'siteorigin-panels' ),
+			'description' => __( 'When accessing the Live Editor via the toolbar link, return to the site after saving.', 'siteorigin-panels' ),
 		);
 
 		$fields['general']['fields']['admin-post-state'] = array(

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -116,37 +116,48 @@ class SiteOrigin_Panels_Settings {
 		$defaults['load-on-attach']    = false;
 		$defaults['use-classic']       = true;
 
-		// The Parallax Type default depends on whether a different setting settings is set.
-		// This is done here rather than using `siteorigin_panels_version_changed` as
-		// that hook is triggered after the settings are loaded.
+		/**
+		 * Certain settings have different defaults depending on if this is a new
+		 * install, or not. 
+		 *
+		 * This is done here rather than using `siteorigin_panels_version_changed` as
+		 * that hook is triggered after the settings are loaded.
+		 */
 		$so_settings = get_option( 'siteorigin_panels_settings' );
 
 		if ( empty( $so_settings ) ) {
 			// New install.
 			$parallax_type = 'modern';
-		} elseif ( isset( $so_settings['parallax-type'] ) ) {
-			// If parallax-type already exists, use the existing value to prevent a potential override.
-			$parallax_type = $so_settings['parallax-type'];
-		} elseif ( isset( $so_settings['parallax-delay'] ) ) {
-			// User is upgrading.
-			$parallax_type = 'legacy';
+			$live_editor_close_after = true;
 		} else {
-			// If all else fails, fallback to modern.
-			$parallax_type = 'modern';
+			$live_editor_close_after = false;
+			// Parallax Type.
+			if ( isset( $so_settings['parallax-type'] ) ) {
+				// If parallax-type already exists, use the existing value to prevent a potential override.
+				$parallax_type = $so_settings['parallax-type'];
+			} elseif ( isset( $so_settings['parallax-delay'] ) ) {
+				// User is upgrading.
+				$parallax_type = 'legacy';
+			} else {
+				// If all else fails, fallback to modern.
+				$parallax_type = 'modern';
+			}
 		}
 
+
 		// The general fields
-		$defaults['post-types']             = array( 'page', 'post' );
-		$defaults['live-editor-quick-link'] = true;
-		$defaults['admin-post-state']       = true;
-		$defaults['admin-widget-count']     = false;
-		$defaults['parallax-type']          = $parallax_type;
-		$defaults['parallax-mobile']        = false;
-		$defaults['parallax-motion']        = ''; // legacy parallax
-		$defaults['parallax-delay']         = 0.4;
-		$defaults['parallax-scale']         = 1.2;
-		$defaults['sidebars-emulator']      = true;
-		$defaults['layout-block-default-mode'] = 'preview';
+		$defaults['post-types']                         = array( 'page', 'post' );
+		$defaults['live-editor-quick-link']             = true;
+		$defaults['live-editor-quick-link-close-after'] = $live_editor_close_after;
+		$defaults['admin-post-state']                   = true;
+		$defaults['admin-widget-count']                 = false;
+		$defaults['parallax-type']                      = $parallax_type;
+		$defaults['parallax-mobile']                    = false;
+		$defaults['parallax-motion']                    = ''; // legacy parallax
+		$defaults['parallax-delay']                     = 0.4;
+		$defaults['parallax-scale']                     = 1.2;
+		$defaults['sidebars-emulator']                  = true;
+		$defaults['layout-block-default-mode']          = 'preview';
 
 		// Widgets fields
 		$defaults['title-html']           = '<h3 class="widget-title">{{title}}</h3>';
@@ -285,6 +296,11 @@ class SiteOrigin_Panels_Settings {
 			'type'        => 'checkbox',
 			'label'       => __( 'Live Editor Quick Link', 'siteorigin-panels' ),
 			'description' => __( 'Display a Live Editor button in the WordPress admin bar.', 'siteorigin-panels' ),
+		);
+		$fields['general']['fields']['live-editor-quick-link-close-after'] = array(
+			'type'        => 'checkbox',
+			'label'       => __( 'Live Editor Quick Link: Close After Editing', 'siteorigin-panels' ),
+			'description' => __( 'After clicking the Live Editor Quick Link, saving or closing the live editor will result in being redirected back to the page.', 'siteorigin-panels' ),
 		);
 
 		$fields['general']['fields']['admin-post-state'] = array(

--- a/js/siteorigin-panels/main.js
+++ b/js/siteorigin-panels/main.js
@@ -86,8 +86,9 @@ jQuery( function ( $ ) {
 			builderType: $panelsMetabox.data( 'builder-type' ),
 			builderSupports: $panelsMetabox.data( 'builder-supports' ),
 			loadOnAttach: panelsOptions.loadOnAttach && $( '#auto_draft' ).val() == 1,
-			loadLiveEditor: $panelsMetabox.data('live-editor') == 1,
-			liveEditorPreview: container.data('preview-url')
+			loadLiveEditor: $panelsMetabox.data( 'live-editor' ) == 1,
+			liveEditorCloseAfter: $panelsMetabox.data( 'live-editor-close' ) == 1,
+			liveEditorPreview: container.data( 'preview-url' )
 		};
 	}
 	else if ( $( '.siteorigin-panels-builder-form' ).length ) {
@@ -105,6 +106,7 @@ jQuery( function ( $ ) {
 			builderType: $$.data( 'type' ),
 			builderSupports: $$.data( 'builder-supports' ),
 			loadLiveEditor: false,
+			liveEditorCloseAfter: false,
 			liveEditorPreview: $$.data( 'preview-url' )
 		};
 	}

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -41,6 +41,7 @@ module.exports = Backbone.View.extend( {
 
 		this.config = _.extend( {
 			loadLiveEditor: false,
+			liveEditorCloseAfter: false,
 			builderSupports: {}
 		}, options.config );
 

--- a/js/siteorigin-panels/view/live-editor.js
+++ b/js/siteorigin-panels/view/live-editor.js
@@ -170,7 +170,11 @@ module.exports = Backbone.View.extend( {
 	closeAndSave: function(){
 		this.close( false );
 		// Finds the submit input for saving without publishing draft posts.
-		$( '#submitdiv input[type="submit"][name="save"]' ).trigger( 'click' );
+		if ( $( '.block-editor-page' ).length ) {
+			$( '.editor-post-publish-button' )[0].click();
+		} else {
+			$( '#submitdiv input[type="submit"][name="save"]' )[0].click();
+		}
 	},
 
 	/**

--- a/js/siteorigin-panels/view/live-editor.js
+++ b/js/siteorigin-panels/view/live-editor.js
@@ -142,8 +142,16 @@ module.exports = Backbone.View.extend( {
 	/**
 	 * Close the Live Editor
 	 */
-	close: function () {
+	close: function ( closeAfter = true ) {
 		if ( ! this.$el.is( ':visible' ) ) {
+			return this;
+		}
+
+		if ( closeAfter && this.builder.config.liveEditorCloseAfter ) {
+			// Live Editor is set to be closed upon saving the page.
+			// This is done using a trigger rather than a redirect to confirm if
+			// the user wants to save.
+			$( '#wp-admin-bar-view a' )[0].click(); // JS click.
 			return this;
 		}
 
@@ -160,7 +168,7 @@ module.exports = Backbone.View.extend( {
 	 * Close the Live Editor and save the post.
 	 */
 	closeAndSave: function(){
-		this.close();
+		this.close( false );
 		// Finds the submit input for saving without publishing draft posts.
 		$( '#submitdiv input[type="submit"][name="save"]' ).trigger( 'click' );
 	},

--- a/settings/admin-settings.js
+++ b/settings/admin-settings.js
@@ -151,7 +151,7 @@ jQuery( function($){
             $('#panels-settings-search .results').fadeOut('fast');
         } );
 
-    var handleParallaxVisibility = function() {
+    var handleSettingVisibility = function() {
         if ( $( 'select[name="panels_setting[parallax-type]"]' ).val() == 'modern' ) {
             $( 'input[name="panels_setting[parallax-motion]"]' ).parent().parent().hide();
             $( 'input[name="panels_setting[parallax-delay]"], input[name="panels_setting[parallax-scale]"]' ).parent().parent().show();
@@ -159,9 +159,15 @@ jQuery( function($){
             $( 'input[name="panels_setting[parallax-delay]"], input[name="panels_setting[parallax-scale]"]' ).parent().parent().hide();
             $( 'input[name="panels_setting[parallax-motion]"]' ).parent().parent().show();
         }
+
+        if ( $( 'input[name="panels_setting[live-editor-quick-link]' ).prop( 'checked' ) ) {
+            $( 'input[name="panels_setting[live-editor-quick-link-close-after]"]' ).parents( '.panels-setting' ).show();
+        } else {
+            $( 'input[name="panels_setting[live-editor-quick-link-close-after]"]' ).parents( '.panels-setting' ).hide();
+        }
     }
-    handleParallaxVisibility();
-    $( 'select[name="panels_setting[parallax-type]"]' ).on( 'change', handleParallaxVisibility );
+    handleSettingVisibility();
+    $( '.panels-setting select, .panels-setting input' ).on( 'change', handleSettingVisibility );
 } );
 
 // Fitvids

--- a/tpl/metabox-panels.php
+++ b/tpl/metabox-panels.php
@@ -3,7 +3,10 @@
 	data-preview-url="<?php echo $preview_url; ?>"
 	data-preview-markup="<?php echo esc_attr( json_encode( $preview_content ) ); ?>"
 	data-builder-supports="<?php echo esc_attr( json_encode( $builder_supports ) ) ?>"
-	<?php if( !empty( $_GET['so_live_editor'] ) ) echo 'data-live-editor="1"' ?>
+	<?php if ( ! empty( $_GET['so_live_editor'] ) ) : ?>
+	data-live-editor="1"
+	data-live-editor-close="<?php echo siteorigin_panels_setting( 'live-editor-quick-link' ); ?>"
+	<?php endif; ?>
 	>
 	<?php do_action('siteorigin_panels_before_interface') ?>
 	<?php wp_nonce_field('save', '_sopanels_nonce') ?>


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/359

Workflow:

- User Views page and click Live Editor Quick Link.
- User decides against editing, and clicks close OR user makes edits and then clicks Update to Save Changes
- Live Editor is closed.

New Setting added after the Live Editor Quick Link setting.
Live Editor Quick Link: Close After Editing
Requires Live Editor Quick Link to be enabled to be visible.
If the user upgrades from an older version, the Live Editor Quick Link: Close After Editing setting will be disabled to prevent a potential disruption for existing users. New installs will have it enabled by default.

To test this:

- Open the Live Editor via the Quick Link, make a change, and then click Update.
- Open the Live Editor via the Quick Link, and click Close.
- Open the Live Editor, make a change, and then click Update.
- Open the Live Editor, and click Close.
- Please confirm the Block Editor saves without issue when using the Live Editor.

---

https://github.com/siteorigin/siteorigin-panels/pull/922/commits/7d68bcf409cb459c0204ffec33eac21c5452303a will ensure that the Update button works in both the Classic Editor, and the SiteOrgin Layout Block. Prior to that commit, there was a change the Live Editor would close but not actually save. That change is tested by the above test instructions.
