### PR TITLE
Layout Block: Restore Live Editor & History

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -52,7 +52,7 @@ class SiteOriginPanelsLayoutBlock extends wp.element.Component {
 			editorType: 'standalone',
 	        loadLiveEditor: false,
 	        postId: window.soPanelsBlockEditorAdmin.postId,
-	        liveEditorPreview: window.soPanelsBlockEditorAdmin.liveEditor,
+	        editorPreview: window.soPanelsBlockEditorAdmin.liveEditor,
 		};
 		
 		var builderModel = new panels.model.builder();


### PR DESCRIPTION
This PR will restore the Live Editor and History buttons for the SIteOrigin Layouts block.
To test this PR you'll need to make a build.