### PR TITLE
Restore .panel-no-style alignment

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -764,16 +764,14 @@ class SiteOrigin_Panels_Styles {
 				$selector = array();
 				$container_settings = SiteOrigin_Panels::container_settings();
 				// What selector we use is dependent on their row setup.
-				if ( empty( $row['style'] ) ) {
-					$selector[] = '.panel-no-style';
-				} elseif ( // Is CSS Container Breaker is enabled, and is the row full width?
+				if ( // Is CSS Container Breaker is enabled, and is the row full width?
 					$container_settings['css_override'] &&
 					isset( $row['style']['row_stretch'] ) &&
 					$row['style']['row_stretch'] == 'full'
 				) {
 					$selector[] = '.panel-has-style > .panel-row-style > .so-panels-full-wrapper';
 				} else {
-					$selector[] = '.panel-has-style > .panel-row-style';
+					$selector[] = '.panel-has-style > .panel-row-style, .panel-no-style';
 				}
 
 				$css->add_row_css(


### PR DESCRIPTION
This will prevent rows from being stretched by default. To test this, add a multi-column row and apply a background to one of the cells. Add widgets to the column without the background and then save. The cell with the background will be the full height. Switch to this PR and the cell will be sized normally.