### PR TITLE
CSS Container Breaker: Don't add Container Breaker pre-JS CSS

### DIFF
--- a/css/front-flex.less
+++ b/css/front-flex.less
@@ -73,7 +73,7 @@
 	}
 }
 
-body.siteorigin-panels-before-js {
+body.siteorigin-panels-before-js:not(.siteorigin-panels-css-container) {
 	overflow-x: hidden;
 
 	.siteorigin-panels-stretch {


### PR DESCRIPTION
This PR will prevent a jump that can occur on load that can still result in a CLS being triggered. There's no reason for this CSS to be used when the CSS container Breaker is used so this prevents it. It doesn't remove the body class as someone could be using that.