### PR TITLE
Fix nested html attribute escaping to not break rendering via shortco…

### DIFF
--- a/inc/widget-shortcode.php
+++ b/inc/widget-shortcode.php
@@ -106,7 +106,7 @@ class SiteOrigin_Panels_Widget_Shortcode {
 	}
 
 	static function encode_data( $data ){
-		return '<input type="hidden" value="' . esc_attr( json_encode( $data, JSON_UNESCAPED_UNICODE ) ) . '" />';
+		return '<input type="hidden" value="' . esc_textarea( json_encode( $data, JSON_UNESCAPED_UNICODE ) ) . '" />';
 	}
 
 	static function decode_data( $string ){


### PR DESCRIPTION
I was debugging a site for a client built with the SiteOrigin Page Builder, when I kept seeing countless warnings and notices of unfound indices in my log file, that I couldn't reproduce in production. The only difference was that the prod site was running v2.11.0 of siteorigin-panels, and I was running v2.14.1 locally.

I narrowed down the issue to a specific interaction between the Page Builder and the Yoast SEO plugin. When editing a page, Yoast will request the `post_content` from the database (including the `[siteorigin_widget]` shortcodes), and then trigger `SiteOrigin_Panels_Widget_Shortcode::shortcode()`, which would always fail to decode the JSON stored in the hidden `<input>`.

After some messing about, I determined the cause of the issue to be commit #840, which replaced the built-in `htmlentities()` function with the WordPress alternative `esc_attr()`. The `esc_attr()` function is deliberately designed to not nest html entities if they're already encoded, unlike the PHP equivalent. Somewhere in the rendering logic, the `before_widget` and `after_widget` keys in `$attr` contain inline HTML. Specifically, what triggered this in my local install was this value:
` [before_widget] => <div id="panel-24237-0-0-0" class="so-panel widget widget_ms-content-fullwidth panel-first-child panel-last-child" data-index="0" data-style="{&quot;background_image_attachment&quot;:false,&quot;background_display&quot;:&quot;tile&quot;}" >`

In order to produce well-formed JSON, the ampersands in &quot need to be double-escaped as &amp, which `esc_attr()` deliberately doesn't do(!) - resulting in malformed JSON every time.

The fix turned out to be incredibly simple, and was already [well-documented in this comment](https://developer.wordpress.org/reference/functions/esc_attr/#comment-2473) by Michael Nelson in the `esc_attr()` documentation: replace `esc_attr()` with `esc_textarea()` to properly encode the `before_widget` JSON inside the entire JSON to be parsed by `decode_data()`.

`esc_textarea()` simply seems to be a wrapper for the PHP `htmlspecialchars()` function, which also would have fixed the issue in #840, since it only encodes conflicting characters, leaving other utf-8 chars searchable.

In my testing, everything works great with this fix.

Thank you for considering my pull request. It's been a pleasure working with your Page Builder and widgets compared to the ocean of crap Wordpress plugins out there.