### PR TITLE
Layouts Block: Force Draft Before Allowing Live Editor

### DIFF
--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -670,7 +670,29 @@ module.exports = Backbone.View.extend( {
 
 		// Display the live editor button in the toolbar
 		if ( this.liveEditor.hasPreviewUrl() ) {
-			this.$( '.so-builder-toolbar .so-live-editor' ).show();
+			var addLEButton = false;
+			if ( ! panels.helpers.editor.isBlockEditor() ) {
+				addLEButton = true;
+			} else if ( wp.data.select( 'core/editor' ).getEditedPostAttribute( 'status' ) != 'auto-draft' ) {
+				addLEButton = true;
+			} else {
+				// Block Editor powered page that's an auto draft. To avoid a 404, we need to save the draft.
+				$( '.editor-post-save-draft' ).trigger( 'click' );
+				var openLiveEditorAfterSave = setInterval( function() {
+					if (
+						! wp.data.select('core/editor').isSavingPost() &&
+						! wp.data.select('core/editor').isAutosavingPost() &&
+						wp.data.select('core/editor').didPostSaveRequestSucceed()
+					) {
+						clearInterval( openLiveEditorAfterSave );
+						this.$( '.so-builder-toolbar .so-live-editor' ).show();
+					}
+				}.bind( this ), 250 );
+			}
+
+			if ( addLEButton ) {
+				this.$( '.so-builder-toolbar .so-live-editor' ).show();
+			}
 		}
 
 		this.trigger( 'builder_live_editor_added' );


### PR DESCRIPTION
This PR will prevent a 404 that can occur when creating a new page using the Block Editor. Basically, Block Editor auto drafts aren't able to be viewed until converted to a draft so this PR will force the page to be saved as a draft before allowing access to the Live Editor.

To test this PR:

- Create a new block editor page (don't save)
- Quickly add a SiteOrigin Layouts Block and Archives widget
- Open the Live Editor

Prior to this PR, the above steps will result in a 404 when the Live Editor displays the preview. After switching to this branch the Live Editor simply won't be accessible (due to the Live Editor Button not being visible) until the page able to be viewed.

This PR modifies core PB JS files so a build is required.