### PR TITLE
Set .panel-no-style separately

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -771,7 +771,8 @@ class SiteOrigin_Panels_Styles {
 				) {
 					$selector[] = '.panel-has-style > .panel-row-style > .so-panels-full-wrapper';
 				} else {
-					$selector[] = '.panel-has-style > .panel-row-style, .panel-no-style';
+					$selector[] = '.panel-has-style > .panel-row-style';
+					$selector[] = '.panel-no-style';
 				}
 
 				$css->add_row_css(


### PR DESCRIPTION
This PR will prevent the last row from dedicating the default cell vertical alignment of rows.

To test this:

- Add a row with two columns.
- Add an archives widget to the left column, and two archives to the right.
- Duplicate the row and set the cell vertical alignment of one of the rows to Center.

You'll note that whichever row is last will control the cell vertical alignment so try swapping them around. Once confirmed, load this PR and you'll see that's no longer happening.