### PR TITLE
isBlockEditor JS: Add Body Class Check

### DIFF
--- a/js/siteorigin-panels/helpers/editor.js
+++ b/js/siteorigin-panels/helpers/editor.js
@@ -1,6 +1,6 @@
 module.exports = {
 	isBlockEditor: function() {
-		return typeof wp.blocks !== 'undefined';
+		return typeof wp.blocks !== 'undefined' && jQuery( '.block-editor-page' ).length
 	},
 
 	isClassicEditor: function( builder ) {


### PR DESCRIPTION
This PR will resolve a situation where isBlockEditor will return when the current editor is actually the Classic Editor. This issue is caused by a plugin/theme loading `wp.blocks`.

This PR modifies PB Core JS files so a build is required.

Testing the original will require a plugin that loads `wp.blocks` in the Classic Editor. You can also test this PR doesn't result in any issues by loading Page Builder in the Classic Editor and Block Editor, and confirming it loaded as expected.