### PR TITLE
Add Widget  "Mobile Margin" setting

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -155,6 +155,30 @@ class SiteOrigin_Panels_Renderer {
 						1920,
 						true
 					);
+
+					$panels_mobile_widget_mobile_margin = apply_filters(
+						'siteorigin_panels_css_widget_mobile_margin',
+						 ! empty( $widget['panels_info']['style']['mobile_margin'] ) ? $widget['panels_info']['style']['mobile_margin'] : false,
+						$widget,
+						$wi,
+						$panels_data,
+						$post_id 
+					);
+
+					if ( ! empty( $panels_mobile_widget_mobile_margin ) ) {
+						$css->add_widget_css(
+							$post_id,
+							$ri,
+							$ci,
+							$wi,
+							'',
+							array(
+								'margin' => $panels_mobile_widget_mobile_margin
+							),
+							$panels_mobile_width,
+							true
+						);
+					}
 				}
 			}
 

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -40,8 +40,10 @@ class SiteOrigin_Panels_Styles {
 
 		// Filtering specific attributes
 		add_filter( 'siteorigin_panels_css_row_margin_bottom', array( $this, 'filter_row_bottom_margin' ), 10, 2 );
-		add_filter( 'siteorigin_panels_css_cell_mobile_margin_bottom', array( $this, 'filter_row_cell_bottom_margin' ), 10, 5 );
 		add_filter( 'siteorigin_panels_css_row_mobile_margin_bottom', array( $this, 'filter_row_mobile_bottom_margin' ), 10, 2 );
+		add_filter( 'siteorigin_panels_css_cell_mobile_margin_bottom', array( $this, 'filter_row_cell_bottom_margin' ), 10, 5 );
+		add_filter( 'siteorigin_panels_css_widget_mobile_margin', array( $this, 'filter_widget_mobile_margin' ), 10, 5 );
+
 		add_filter( 'siteorigin_panels_css_row_gutter', array( $this, 'filter_row_gutter' ), 10, 2 );
 		add_filter( 'siteorigin_panels_css_widget_css', array( $this, 'filter_widget_style_css' ), 10, 2 );
 
@@ -168,6 +170,17 @@ class SiteOrigin_Panels_Styles {
 		}
 
 		// Mobile layout fields
+		if ( $label == 'Widget' ) {
+			$fields['mobile_margin'] = array(
+				'name'        => __( 'Mobile Margin', 'siteorigin-panels' ),
+				'type'        => 'measurement',
+				'group'       => 'mobile_layout',
+				'description' => __( 'Margins around the widget when on mobile devices.', 'siteorigin-panels' ),
+				'priority'    => 8,
+				'multiple'    => true
+			);
+		}
+
 		$fields['mobile_padding'] = array(
 			'name'        => __( 'Mobile Padding', 'siteorigin-panels' ),
 			'type'        => 'measurement',
@@ -929,6 +942,15 @@ class SiteOrigin_Panels_Styles {
 			$margin = $row['style']['mobile_cell_margin'];
 		}
 		
+		return $margin;
+	}
+
+
+	static function filter_widget_mobile_margin( $margin, $widget, $wi, $panels_data, $post_id ) {
+		if ( ! empty( $widget['style']['mobile_margin'] ) ) {
+			$margin = $widget['style']['mobile_margin'];
+		}
+
 		return $margin;
 	}
 	


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/937 https://github.com/siteorigin/siteorigin-panels/issues/931

This PR adds a new setting to the Widget Mobile Layout that allows users to override the margin on mobile. This setting will respect the user's input and will apply bottom margin even if the widget is in the last widget in the cell.

You're also able to globally adjust the widget mobile margin by using the `siteorigin_panels_css_widget_mobile_margin` filter. For example, the following PHP will give all rows without a Mobile Margin set 200px margin.

```
add_filter( 'siteorigin_panels_css_widget_mobile_margin', function( $margin, $widget, $wi, $panels_data, $post_id ) {
	if ( empty( $margin ) ) {
		$margin = '200px';
	}
	return $margin;
}, 20, 5 );
```