### PR TITLE
Widget Title: If valid title detected, don't look for anymore

### DIFF
--- a/js/siteorigin-panels/model/widget.js
+++ b/js/siteorigin-panels/model/widget.js
@@ -231,7 +231,7 @@ module.exports = Backbone.Model.extend( {
 
 		// Check titleFields for valid titles.
 		_.each( titleFields, function( title ) {
-			if ( thisView.isValidTitle( values[ title ] ) ) {
+			if ( ! widgetTitle && thisView.isValidTitle( values[ title ] ) ) {
 				widgetTitle = thisView.cleanTitle( values[ title ] );
 				return false;
 			}


### PR DESCRIPTION
This PR will resolve an issue introduced by https://github.com/siteorigin/siteorigin-panels/pull/899 that resulted in widgets that have both a title and a text field (as in, the name of the field not the type) the text field would always take priority.

To test this PR:
- Please add a SiteOrigin Editor widget and set a title and add some text.
- Confirm the text field takes prioity.
- Switch to this branch and run `build:dev`
- Confirm the title field takes priority.