### PR TITLE
Addon Links: Allow Custom Link Location

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1398,11 +1398,20 @@ class SiteOrigin_Panels_Admin {
 		);
 		$link = $links[ array_rand( $links ) ];
 
-		?>
-		<a href="<?php echo esc_url( $link['url'] ) ?>" target="_blank" rel='noopener noreferrer'>
-			<?php echo esc_html( $link['text'] ) ?>.
-		</a>
-		<?php
+		// If this link has an anchor, it has a custom link location.
+		if ( isset( $link['anchor'] ) ) {
+			echo str_replace(
+				'%link%',
+				'<a href="' . esc_url( $link['url'] ) .'" target="_blank" rel="noopener noreferrer">' . esc_html( $link['anchor'] ) . '</a>',
+				esc_html( $link['text'] )
+			);
+		} else {
+			?>
+			<a href="<?php echo esc_url( $link['url'] ) ?>" target="_blank" rel='noopener noreferrer'>
+				<?php echo esc_html( $link['text'] ) ?>.
+			</a>
+			<?php
+		}
 	}
 
 	public function admin_notices() {


### PR DESCRIPTION
This PR allows you to set a custom link location by adding `%link%` where you would like to output the link and by setting the link anchor using a dedicated `anchor` array. For example:

```
array(
	'text' => __( '%link% Use Page Builder to create custom templates for the Product, Archives, Shop, Cart, Checkout, Thank You, and My Account pages', 'siteorigin-panels' ),
	'url' => SiteOrigin_Panels::premium_url( 'plugin/woocommerce-templates' ),
	'anchor' => __( 'Get the WooCommerce Template Builder Addon', 'siteorigin-panels' ),
),
```

To test this PR, replace all of the `$links` (defined just above the edited section) with the following PHP:

```
$links = array(
	array(
		'text' => __( 'Get an Accordion Addon for SiteOrigin Widgets', 'siteorigin-panels' ),
		'url' => SiteOrigin_Panels::premium_url( 'plugin/accordion' )
	),			
	array(
		'text' => __( '%link% Use Page Builder to create custom templates for the Product, Archives, Shop, Cart, Checkout, Thank You, and My Account pages', 'siteorigin-panels' ),
		'url' => SiteOrigin_Panels::premium_url( 'plugin/woocommerce-templates' ),
		'anchor' => __( 'Get the WooCommerce Template Builder Addon', 'siteorigin-panels' ),
	),
);
```