### PR TITLE
Cells: Fix Undefined `style` error

### DIFF
--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -749,7 +749,7 @@ module.exports = panels.view.dialog.extend({
 				console.log('Error retrieving cell styles - ' + err.message);
 			}
 
-			this.cellStyles.model.set('style', style);
+			this.cellStyles.model.set( 'style', newStyles );
 			// Has there been any Style changes?
 			if ( JSON.stringify( this.model.attributes.style ) !== JSON.stringify( newStyles ) ) {
 				this.model.set( 'style', newStyles );


### PR DESCRIPTION
This PR will require a build to test.

To test:

- Open a row
- Select a cell
- Change any cell style.
- Save the row.

Prior to this PR, an error would occur. After this PR, no error will occur and it'll save as expected.