### PR TITLE
Prevent Row/Cell Styles Data Mismatch

### DIFF
--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -719,27 +719,8 @@ module.exports = panels.view.dialog.extend({
 			}
 		}
 
-
-		if ( this.styles.stylesLoaded ) {
-			// If the styles view has loaded.
-			var newStyles = {};
-			try {
-				newStyles = this.getFormValues( '.so-sidebar .so-visual-styles' ).style;
-			}
-			catch ( e ) {
-			}
-
-			// Have there been any Style changes?
-			if ( JSON.stringify( this.model.attributes.style ) !== JSON.stringify( newStyles ) ) {
-				this.model.set( 'style', newStyles );
-				this.model.trigger( 'change:styles' );
-				this.model.trigger( 'change:styles-row' );
-			}
-		}
-
-
 		// Update the cell styles if any are showing.
-		if (!_.isUndefined(this.cellStyles) && this.cellStyles.stylesLoaded) {
+		if ( !_.isUndefined( this.cellStyles ) && this.cellStyles.stylesLoaded ) {
 
 			var newStyles = {};
 			try {
@@ -749,10 +730,9 @@ module.exports = panels.view.dialog.extend({
 				console.log('Error retrieving cell styles - ' + err.message);
 			}
 
-			this.cellStyles.model.set( 'style', newStyles );
 			// Has there been any Style changes?
 			if ( JSON.stringify( this.model.attributes.style ) !== JSON.stringify( newStyles ) ) {
-				this.model.set( 'style', newStyles );
+				this.cellStyles.model.set( 'style', newStyles );
 				this.model.trigger( 'change:styles' );
 				this.model.trigger( 'change:styles-cell' );
 			}

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -701,14 +701,14 @@ module.exports = panels.view.dialog.extend({
 		}
 
 		// Update the row styles if they've loaded
-		if (!_.isUndefined(this.styles) && this.styles.stylesLoaded) {
+		if ( ! _.isUndefined( this.styles ) && this.styles.stylesLoaded ) {
 			// This is an edit dialog, so there are styles
 			var newStyles = {};
 			try {
 				newStyles = this.getFormValues( '.so-sidebar .so-visual-styles.so-row-styles' ).style;
 			}
 			catch (err) {
-				console.log('Error retrieving row styles - ' + err.message);
+				console.log( 'Error retrieving row styles - ' + err.message );
 			}
 
 			// Have there been any Style changes?


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/changing-the-number-of-columns-when-editing-a-row-will-reset-the-style/)

To test this, please follow the user-provided steps to replicate this:

```
1) Click "Add Row" button to add a row.
2) Open the "Edit Row" window and add Row Class to "Row Styles".
3) Click on the left column area and close the pop-up window by clicking on the "Done" button while "Cell 1 Style" is displayed on the right.
4) Open "Edit Row" again and check Row Class in "Row Styles", and you will see that the class name you set is gone.
```

You'll need to do a build and add a new row upon switching to this branch as this fix isn't retroactive.