### PR TITLE
Widget/row Styles Removed Undefined Notice

### DIFF
--- a/js/siteorigin-panels/view/row.js
+++ b/js/siteorigin-panels/view/row.js
@@ -109,6 +109,9 @@ module.exports = Backbone.View.extend( {
 	 */
 	toggleVisibilityFade: function() {
 		var currentRowStyle = this.model.attributes.style;
+		if ( typeof currentRowStyle == 'undefined' ) {
+			return;
+		}
 		if (
 			this.checkIfStyleExists( currentRowStyle, 'disable_row' ) ||
 			this.checkIfStyleExists( currentRowStyle, 'disable_desktop' ) ||

--- a/js/siteorigin-panels/view/row.js
+++ b/js/siteorigin-panels/view/row.js
@@ -108,17 +108,17 @@ module.exports = Backbone.View.extend( {
 	 * Toggle Visibility: Check if row is hidden and apply fade as needed.
 	 */
 	toggleVisibilityFade: function() {
-		var currentRowStyle = this.model.attributes.style;
-		if ( typeof currentRowStyle == 'undefined' ) {
+		var styles = this.model.attributes.style;
+		if ( typeof styles == 'undefined' ) {
 			return;
 		}
 		if (
-			this.checkIfStyleExists( currentRowStyle, 'disable_row' ) ||
-			this.checkIfStyleExists( currentRowStyle, 'disable_desktop' ) ||
-			this.checkIfStyleExists( currentRowStyle, 'disable_tablet' ) ||
-			this.checkIfStyleExists( currentRowStyle, 'disable_mobile' ) ||
-			this.checkIfStyleExists( currentRowStyle, 'disable_logged_in' ) ||
-			this.checkIfStyleExists( currentRowStyle, 'disable_logged_out' )
+			this.checkIfStyleExists( styles, 'disable_row' ) ||
+			this.checkIfStyleExists( styles, 'disable_desktop' ) ||
+			this.checkIfStyleExists( styles, 'disable_tablet' ) ||
+			this.checkIfStyleExists( styles, 'disable_mobile' ) ||
+			this.checkIfStyleExists( styles, 'disable_logged_in' ) ||
+			this.checkIfStyleExists( styles, 'disable_logged_out' )
 		) {
 			this.$el.addClass( 'so-hidden-row' );
 		} else {

--- a/js/siteorigin-panels/view/widget.js
+++ b/js/siteorigin-panels/view/widget.js
@@ -97,17 +97,17 @@ module.exports = Backbone.View.extend( {
 	 * Toggle Visibility: Check if row is hidden and apply fade as needed.
 	 */
 	toggleVisibilityFade: function() {
-		var currentRowStyle = this.model.attributes.style;
-		if ( typeof currentRowStyle == 'undefined' ) {
+		var styles = this.model.attributes.style;
+		if ( typeof styles == 'undefined' ) {
 			return;
 		}
 		if (
-			this.checkIfStyleExists( currentRowStyle, 'disable_widget' ) ||
-			this.checkIfStyleExists( currentRowStyle, 'disable_desktop' ) ||
-			this.checkIfStyleExists( currentRowStyle, 'disable_tablet' ) ||
-			this.checkIfStyleExists( currentRowStyle, 'disable_mobile' ) ||
-			this.checkIfStyleExists( currentRowStyle, 'disable_logged_in' ) ||
-			this.checkIfStyleExists( currentRowStyle, 'disable_logged_out' )
+			this.checkIfStyleExists( styles, 'disable_widget' ) ||
+			this.checkIfStyleExists( styles, 'disable_desktop' ) ||
+			this.checkIfStyleExists( styles, 'disable_tablet' ) ||
+			this.checkIfStyleExists( styles, 'disable_mobile' ) ||
+			this.checkIfStyleExists( styles, 'disable_logged_in' ) ||
+			this.checkIfStyleExists( styles, 'disable_logged_out' )
 		) {
 			this.$el.addClass( 'so-hidden-widget' );
 		} else {

--- a/js/siteorigin-panels/view/widget.js
+++ b/js/siteorigin-panels/view/widget.js
@@ -98,6 +98,9 @@ module.exports = Backbone.View.extend( {
 	 */
 	toggleVisibilityFade: function() {
 		var currentRowStyle = this.model.attributes.style;
+		if ( typeof currentRowStyle == 'undefined' ) {
+			return;
+		}
 		if (
 			this.checkIfStyleExists( currentRowStyle, 'disable_widget' ) ||
 			this.checkIfStyleExists( currentRowStyle, 'disable_desktop' ) ||


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/disabled-fields-js-error-cant-access-property-disable_widget/)

To test this PR, add the following code snippet to remove all Widget Styles:

```
add_filter( 'siteorigin_panels_widget_style_fields', function($fields) {
	$fields = [];
	return $fields;
}, 1000 );
```

Now open any widget, and check the console for the following error (line numbers may differ):

> Uncaught TypeError: can't access property "disable_widget", e is undefined in siteorigin-panels.min.js:8:68283

Once you switch to this PR, this notice won't occur.