### PR TITLE
Add Global Setting: Widget Mobile Bottom Margin

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -165,6 +165,10 @@ class SiteOrigin_Panels_Renderer {
 						$post_id 
 					);
 
+					if ( empty( $panels_mobile_widget_mobile_margin ) && ! empty( $settings['cell-mobile-margin-bottom'] ) ) {
+						$panels_mobile_widget_mobile_margin = '0 0 ' . $settings[ 'cell-mobile-margin-bottom'] . 'px';
+					}
+
 					if ( ! empty( $panels_mobile_widget_mobile_margin ) ) {
 						$css->add_widget_css(
 							$post_id,

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -165,8 +165,8 @@ class SiteOrigin_Panels_Renderer {
 						$post_id 
 					);
 
-					if ( empty( $panels_mobile_widget_mobile_margin ) && ! empty( $settings['cell-mobile-margin-bottom'] ) ) {
-						$panels_mobile_widget_mobile_margin = '0 0 ' . $settings[ 'cell-mobile-margin-bottom'] . 'px';
+					if ( empty( $panels_mobile_widget_mobile_margin ) && ! empty( $settings['widget-mobile-margin-bottom'] ) ) {
+						$panels_mobile_widget_mobile_margin = '0 0 ' . $settings[ 'widget-mobile-margin-bottom'] . 'px';
 					}
 
 					if ( ! empty( $panels_mobile_widget_mobile_margin ) ) {

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -167,17 +167,18 @@ class SiteOrigin_Panels_Settings {
 		$defaults['instant-open-widgets'] = true;
 
 		// The layout fields
-		$defaults['responsive']               = true;
-		$defaults['tablet-layout']            = false;
-		$defaults['legacy-layout']            = 'auto';
-		$defaults['tablet-width']             = 1024;
-		$defaults['mobile-width']             = 780;
-		$defaults['margin-bottom']            = 30;
-		$defaults['row-mobile-margin-bottom'] = '';
-		$defaults['margin-bottom-last-row']   = false;
-		$defaults['margin-sides']             = 30;
-		$defaults['full-width-container']     = 'body';
-		$defaults['output-css-header']        = 'auto';
+		$defaults['responsive']                = true;
+		$defaults['tablet-layout']             = false;
+		$defaults['legacy-layout']             = 'auto';
+		$defaults['tablet-width']              = 1024;
+		$defaults['mobile-width']              = 780;
+		$defaults['margin-bottom']             = 30;
+		$defaults['row-mobile-margin-bottom']  = '';
+		$defaults['cell-mobile-margin-bottom'] = '';
+		$defaults['margin-bottom-last-row']    = false;
+		$defaults['margin-sides']              = 30;
+		$defaults['full-width-container']      = 'body';
+		$defaults['output-css-header']         = 'auto';
 
 		// Content fields
 		$defaults['copy-content'] = true;
@@ -492,6 +493,13 @@ class SiteOrigin_Panels_Settings {
 			'type'        => 'checkbox',
 			'label'       => __( 'Last Row With Margin', 'siteorigin-panels' ),
 			'description' => __( 'Allow margin below the last row.', 'siteorigin-panels' ),
+		);
+
+		$fields['layout']['fields']['cell-mobile-margin-bottom'] = array(
+			'type'        => 'number',
+			'unit'        => 'px',
+			'label'       => __( 'Cell Mobile Bottom Margin', 'siteorigin-panels' ),
+			'description' => __( 'The default margin below rows on mobile.', 'siteorigin-panels' ),
 		);
 
 		$fields['layout']['fields']['margin-sides'] = array(

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -499,7 +499,7 @@ class SiteOrigin_Panels_Settings {
 			'type'        => 'number',
 			'unit'        => 'px',
 			'label'       => __( 'Cell Mobile Bottom Margin', 'siteorigin-panels' ),
-			'description' => __( 'The default margin below rows on mobile.', 'siteorigin-panels' ),
+			'description' => __( 'The default widget bottom mobile margin on mobile.', 'siteorigin-panels' ),
 		);
 
 		$fields['layout']['fields']['margin-sides'] = array(

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -167,18 +167,18 @@ class SiteOrigin_Panels_Settings {
 		$defaults['instant-open-widgets'] = true;
 
 		// The layout fields
-		$defaults['responsive']                = true;
-		$defaults['tablet-layout']             = false;
-		$defaults['legacy-layout']             = 'auto';
-		$defaults['tablet-width']              = 1024;
-		$defaults['mobile-width']              = 780;
-		$defaults['margin-bottom']             = 30;
-		$defaults['row-mobile-margin-bottom']  = '';
-		$defaults['cell-mobile-margin-bottom'] = '';
-		$defaults['margin-bottom-last-row']    = false;
-		$defaults['margin-sides']              = 30;
-		$defaults['full-width-container']      = 'body';
-		$defaults['output-css-header']         = 'auto';
+		$defaults['responsive']                 = true;
+		$defaults['tablet-layout']               = false;
+		$defaults['legacy-layout']               = 'auto';
+		$defaults['tablet-width']                = 1024;
+		$defaults['mobile-width']                = 780;
+		$defaults['margin-bottom']               = 30;
+		$defaults['row-mobile-margin-bottom']    = '';
+		$defaults['widget-mobile-margin-bottom'] = '';
+		$defaults['margin-bottom-last-row']      = false;
+		$defaults['margin-sides']                = 30;
+		$defaults['full-width-container']        = 'body';
+		$defaults['output-css-header']           = 'auto';
 
 		// Content fields
 		$defaults['copy-content'] = true;
@@ -495,10 +495,10 @@ class SiteOrigin_Panels_Settings {
 			'description' => __( 'Allow margin below the last row.', 'siteorigin-panels' ),
 		);
 
-		$fields['layout']['fields']['cell-mobile-margin-bottom'] = array(
+		$fields['layout']['fields']['widget-mobile-margin-bottom'] = array(
 			'type'        => 'number',
 			'unit'        => 'px',
-			'label'       => __( 'Cell Mobile Bottom Margin', 'siteorigin-panels' ),
+			'label'       => __( 'Widget Mobile Bottom Margin', 'siteorigin-panels' ),
 			'description' => __( 'The default widget bottom mobile margin on mobile.', 'siteorigin-panels' ),
 		);
 


### PR DESCRIPTION
Requested [here](https://github.com/siteorigin/siteorigin-panels/issues/931#issuecomment-946540772) and [here](https://wordpress.org/support/topic/new-setting-request/).

This PR Adds the `Widget Mobile Bottom Margin` setting which controls the default widget bottom margin for widgets. This setting is overridden by the `Widget Mobile Margin` setting.