### PR TITLE
Add `panels_title_check_sub_fields` to Allow for Sub Field Detection

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -819,6 +819,10 @@ class SiteOrigin_Panels_Admin {
 			if ( isset( $widget_obj->widget_options['panels_title'] ) ) {
 				$widgets[ $class ]['panels_title'] = $widget_obj->widget_options['panels_title'];
 			}
+			if ( isset( $widget_obj->widget_options['panels_title_check_sub_fields'] ) ) {
+				$widgets[ $class ]['panels_title_check_sub_fields'] = $widget_obj->widget_options['panels_title_check_sub_fields'];
+			}
+
 			if ( isset( $widget_obj->widget_options['panels_groups'] ) ) {
 				$widgets[ $class ]['groups'] = $widget_obj->widget_options['panels_groups'];
 			}

--- a/js/siteorigin-panels/model/widget.js
+++ b/js/siteorigin-panels/model/widget.js
@@ -178,20 +178,39 @@ module.exports = Backbone.Model.extend( {
 	 * Iterate an array and find a valid field we can use for a title. Supports multidimensional arrays.
 	 *
 	 * @param values An array containing field values.
+	 * @returns object thisView The current widget instance.
+	 * @returns object fields The fields we're specifically check for.
+	 * @param object check_sub_fields Whether we should check sub fields.
+	 *
 	 * @returns string The title we found. If we weren't able to find one, it returns false.
 	 */
-	getTitleFromValues: function( values, thisView ) {
+	getTitleFromValues: function( values, thisView, fields = false, check_sub_fields = true ) {
 		var widgetTitle = false;
 		for ( const k in values ) {
 			if ( typeof values[ k ] == 'object' ) {
-				// Field is an array, check child for valid titles.
-				widgetTitle = thisView.getTitleFromValues( values[ k ], thisView );
+				if ( check_sub_fields ) {
+					// Field is an object, check child for valid titles.
+					widgetTitle = thisView.getTitleFromValues( values[ k ], thisView, fields );
+					if ( widgetTitle ) {
+						break;
+					}
+				}
+			// Check for any 
+			} else if ( typeof fields == 'object' ) {
+				for ( var i = 0; i < fields.length; i++ ) {
+					if ( k == fields[i] ) {
+						console.log( values[ k ] );
+						widgetTitle = thisView.cleanTitle( values[ k ] )
+						break;
+					}
+				}
 				if ( widgetTitle ) {
 					break;
 				}
 			// Ensure field isn't a required WB field, and if its not, confirm it's valid.
 			} else if (
-				k.charAt(0) !== '_' &&
+				typeof fields != 'object' &&
+				k.charAt( 0 ) !== '_' &&
 				k !== 'so_sidebar_emulator_id' &&
 				k !== 'option_name' &&
 				thisView.isValidTitle( values[ k ] )
@@ -230,15 +249,15 @@ module.exports = Backbone.Model.extend( {
 		var widgetTitle = false;
 
 		// Check titleFields for valid titles.
-		_.each( titleFields, function( title ) {
-			if ( ! widgetTitle && thisView.isValidTitle( values[ title ] ) ) {
-				widgetTitle = thisView.cleanTitle( values[ title ] );
-				return false;
-			}
-		} );
+		widgetTitle = this.getTitleFromValues(
+			values,
+			thisView,
+			titleFields,
+			typeof widgetData.panels_title_check_sub_fields != 'undefined' ? widgetData.panels_title_check_sub_fields : false
+		);
 
 		if ( ! widgetTitle && ! titleFieldOnly ) {
-			// No titles were found. Let's check the rest of the fields for a valid title..
+			// No titles were found. Let's check the rest of the fields for a valid title.
 			widgetTitle = this.getTitleFromValues( values, thisView );
 		}
 

--- a/js/siteorigin-panels/model/widget.js
+++ b/js/siteorigin-panels/model/widget.js
@@ -195,7 +195,7 @@ module.exports = Backbone.Model.extend( {
 						break;
 					}
 				}
-			// Check for any 
+			// Check for predefined title fields.
 			} else if ( typeof fields == 'object' ) {
 				for ( var i = 0; i < fields.length; i++ ) {
 					if ( k == fields[i] ) {


### PR DESCRIPTION
This PR will allow for widgets with a predefined panels_title to check sub fields. This allows for a situation where the repeater is set by the first valid instance in a repeater. To enable this, you need to set `panels_title_check_sub_fields` to `true`.

To test this PR, open widgets/features/features.php and find:

`'help'         => 'https://siteorigin.com/widgets-bundle/features-widget-documentation/',`

Add to the next line:

`'panels_title' => 'icon_title',
'panels_title_check_sub_fields' => true,`

Now add a Features widget to a page, add a feature, and set an Icon Title. Note that the description isn't updated.
Save, and then switch to this PR. You'll now note that the `icon_title` is picked up.

Please ensure standard `panel_title` works as expected by adding the Editor and updating the `title` and `text` settings picked up as expected - `title` should always take prioity.