### PR TITLE
Add Mobile Cell Margins Seting

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -271,7 +271,7 @@ class SiteOrigin_Panels_Renderer {
 						$css->add_cell_css( $post_id, $ri, $ci, '', array(
 							'margin-bottom' => apply_filters(
 								'siteorigin_panels_css_cell_mobile_margin_bottom',
-								$settings['margin-bottom'] . 'px',
+								$settings['mobile-cell-margin'] . 'px',
 								$cell,
 								$ci,
 								$row,

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -129,6 +129,7 @@ class SiteOrigin_Panels_Settings {
 			// New install.
 			$parallax_type = 'modern';
 			$live_editor_close_after = true;
+			$mobile_cell_margin = 30;
 		} else {
 			$live_editor_close_after = false;
 			// Parallax Type.
@@ -142,8 +143,8 @@ class SiteOrigin_Panels_Settings {
 				// If all else fails, fallback to modern.
 				$parallax_type = 'modern';
 			}
+			$mobile_cell_margin = isset( $so_settings['margin-bottom'] ) ? $so_settings['margin-bottom'] : 30;
 		}
-
 
 		// The general fields
 		$defaults['post-types']                         = array( 'page', 'post' );
@@ -167,17 +168,18 @@ class SiteOrigin_Panels_Settings {
 		$defaults['instant-open-widgets'] = true;
 
 		// The layout fields
-		$defaults['responsive']               = true;
-		$defaults['tablet-layout']            = false;
-		$defaults['legacy-layout']            = 'auto';
-		$defaults['tablet-width']             = 1024;
-		$defaults['mobile-width']             = 780;
-		$defaults['margin-bottom']            = 30;
-		$defaults['row-mobile-margin-bottom'] = '';
-		$defaults['margin-bottom-last-row']   = false;
-		$defaults['margin-sides']             = 30;
-		$defaults['full-width-container']     = 'body';
-		$defaults['output-css-header']        = 'auto';
+		$defaults['responsive']                 = true;
+		$defaults['tablet-layout']               = false;
+		$defaults['legacy-layout']               = 'auto';
+		$defaults['tablet-width']                = 1024;
+		$defaults['mobile-width']                = 780;
+		$defaults['margin-bottom']               = 30;
+		$defaults['row-mobile-margin-bottom']    = '';
+		$defaults['mobile-cell-margin']          = $mobile_cell_margin;
+		$defaults['margin-bottom-last-row']      = false;
+		$defaults['margin-sides']                = 30;
+		$defaults['full-width-container']        = 'body';
+		$defaults['output-css-header']           = 'auto';
 
 		// Content fields
 		$defaults['copy-content'] = true;
@@ -492,6 +494,13 @@ class SiteOrigin_Panels_Settings {
 			'type'        => 'checkbox',
 			'label'       => __( 'Last Row With Margin', 'siteorigin-panels' ),
 			'description' => __( 'Allow margin below the last row.', 'siteorigin-panels' ),
+		);
+
+		$fields['layout']['fields']['mobile-cell-margin'] = array(
+			'type'        => 'number',
+			'unit'        => 'px',
+			'label'       => __( 'Mobile Cell Margins', 'siteorigin-panels' ),
+			'description' => __( 'The default vertical space between cells in a collapsed mobile row.', 'siteorigin-panels' ),
 		);
 
 		$fields['layout']['fields']['margin-sides'] = array(

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -503,6 +503,7 @@ class SiteOrigin_Panels_Settings {
 			'unit'        => 'px',
 			'label'       => __( 'Mobile Cell Margins', 'siteorigin-panels' ),
 			'description' => __( 'The default vertical space between cells in a collapsed mobile row.', 'siteorigin-panels' ),
+		);
 
 		$fields['layout']['fields']['widget-mobile-margin-bottom'] = array(
 			'type'        => 'number',

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -487,7 +487,7 @@ class SiteOrigin_Panels_Settings {
 		$fields['layout']['fields']['row-mobile-margin-bottom'] = array(
 			'type'        => 'number',
 			'unit'        => 'px',
-			'label'       => __( 'Row Mobile Bottom Margin', 'siteorigin-panels' ),
+			'label'       => __( 'Mobile Row Bottom Margin', 'siteorigin-panels' ),
 			'description' => __( 'The default margin below rows on mobile.', 'siteorigin-panels' ),
 		);
 
@@ -501,7 +501,7 @@ class SiteOrigin_Panels_Settings {
 		$fields['layout']['fields']['mobile-cell-margin'] = array(
 			'type'        => 'number',
 			'unit'        => 'px',
-			'label'       => __( 'Mobile Cell Margins', 'siteorigin-panels' ),
+			'label'       => __( 'Mobile Cell Bottom Margin', 'siteorigin-panels' ),
 			'description' => __( 'The default vertical space between cells in a collapsed mobile row.', 'siteorigin-panels' ),
 		);
 

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -344,7 +344,7 @@ class SiteOrigin_Panels_Styles {
 		);
 		
 		$fields['mobile_cell_margin'] = array(
-			'name'        => __( 'Mobile Cell Margins', 'siteorigin-panels' ),
+			'name'        => __( 'Mobile Cell Bottom Margin', 'siteorigin-panels' ),
 			'type'        => 'measurement',
 			'group'       => 'mobile_layout',
 			'description' => sprintf( __( 'Vertical space between cells in a collapsed mobile row. Default is %spx.', 'siteorigin-panels' ), ! empty( siteorigin_panels_setting( 'mobile-cell-margin' ) ) ? siteorigin_panels_setting( 'mobile-cell-margin' ) : siteorigin_panels_setting( 'margin-bottom' ) ),

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -347,7 +347,7 @@ class SiteOrigin_Panels_Styles {
 			'name'        => __( 'Mobile Cell Margins', 'siteorigin-panels' ),
 			'type'        => 'measurement',
 			'group'       => 'mobile_layout',
-			'description' => sprintf( __( 'Vertical space between cells in a collapsed mobile row. Default is %spx.', 'siteorigin-panels' ), siteorigin_panels_setting( 'margin-bottom' ) ),
+			'description' => sprintf( __( 'Vertical space between cells in a collapsed mobile row. Default is %spx.', 'siteorigin-panels' ), ! empty( siteorigin_panels_setting( 'mobile-cell-margin' ) ) ? siteorigin_panels_setting( 'mobile-cell-margin' ) : siteorigin_panels_setting( 'margin-bottom' ) ),
 			'priority'    => 5,
 		);
 		


### PR DESCRIPTION
[Requested here](https://wordpress.org/support/topic/new-setting-request/)

This PR adds a new global setting that acts as a default for the `Mobile Cell Margins` row setting. The default value is 30px and if the user upgraded, the default changes to the same value as the `Row/Widget Bottom Margin` setting.

To test this PR:

- Firstly, set a non-standard `Row/Widget Bottom Margin` value (something other than 30). As that'll allow you to confirm the `Mobile Cell Margins` default is correctly set based on that.
- Add a two rows with two columns each. Add an archive widget to column.
- Open the first row in the editor and go over to the Row Styles sidebar. Open the Mobile Layout settings group and set the Mobile Cell Margin setting to anything but the default (or blank).
- Save, and view the page.
- Confirm override is working (row 1), and default is being used (row 2).