### PR TITLE
PHP 8 lessc.inc.php Fixes

### DIFF
--- a/widgets/lib/lessc.inc.php
+++ b/widgets/lib/lessc.inc.php
@@ -654,7 +654,7 @@ class lessc {
 					if ($suffix !== null &&
 						$subProp[0] == "assign" &&
 						is_string($subProp[1]) &&
-						$subProp[1]{0} != $this->vPrefix)
+						$subProp[1][0] != $this->vPrefix)
 					{
 						$subProp[2] = array(
 							'list', ' ',
@@ -1621,7 +1621,7 @@ class lessc {
 		$this->pushEnv();
 		$parser = new lessc_parser($this, __METHOD__);
 		foreach ($args as $name => $strValue) {
-			if ($name{0} != '@') $name = '@'.$name;
+			if ($name[0] != '@') $name = '@'.$name;
 			$parser->count = 0;
 			$parser->buffer = (string)$strValue;
 			if (!$parser->propertyValue($value)) {
@@ -2278,7 +2278,7 @@ class lessc_parser {
 				$hidden = true;
 				if (!isset($block->args)) {
 					foreach ($block->tags as $tag) {
-						if (!is_string($tag) || $tag{0} != $this->lessc->mPrefix) {
+						if (!is_string($tag) || $tag[0] != $this->lessc->mPrefix) {
 							$hidden = false;
 							break;
 						}
@@ -2332,7 +2332,7 @@ class lessc_parser {
 	protected function fixTags($tags) {
 		// move @ tags out of variable namespace
 		foreach ($tags as &$tag) {
-			if ($tag{0} == $this->lessc->vPrefix)
+			if ($tag[0] == $this->lessc->vPrefix)
 				$tag[0] = $this->lessc->mPrefix;
 		}
 		return $tags;
@@ -3062,7 +3062,7 @@ class lessc_parser {
 	protected function end() {
 		if ($this->literal(';')) {
 			return true;
-		} elseif ($this->count == strlen($this->buffer) || $this->buffer{$this->count} == '}') {
+		} elseif ($this->count == strlen($this->buffer) || $this->buffer($this->count) == '}') {
 			// if there is end of file or a closing block next then we don't need a ;
 			return true;
 		}


### PR DESCRIPTION
Resolves the following fatal errors when using the Page Builder Legacy Widgets:

```
( ! ) Fatal error: Array and string offset access syntax with curly braces is no longer supported in C:\Users\Alex S\Local Sites\so\app\public\wp-content\plugins\siteorigin-panels\widgets\lib\lessc.inc.php on line 657

( ! ) Fatal error: Array and string offset access syntax with curly braces is no longer supported in C:\Users\Alex S\Local Sites\so\app\public\wp-content\plugins\siteorigin-panels\widgets\lib\lessc.inc.php on line 1624

( ! ) Fatal error: Array and string offset access syntax with curly braces is no longer supported in C:\Users\Alex S\Local Sites\so\app\public\wp-content\plugins\siteorigin-panels\widgets\lib\lessc.inc.php on line 2281

( ! ) Fatal error: Array and string offset access syntax with curly braces is no longer supported in C:\Users\Alex S\Local Sites\so\app\public\wp-content\plugins\siteorigin-panels\widgets\lib\lessc.inc.php on line 2335

( ! ) Fatal error: Array and string offset access syntax with curly braces is no longer supported in C:\Users\Alex S\Local Sites\so\app\public\wp-content\plugins\siteorigin-panels\widgets\lib\lessc.inc.php on line 3065

```