### PR TITLE
jQuery `ready` Compatibility Fix

### DIFF
--- a/js/siteorigin-panels/main.js
+++ b/js/siteorigin-panels/main.js
@@ -177,7 +177,7 @@ jQuery( function ( $ ) {
 
 // WP 5.7+: Prevent undesired "restore content" notice.
 if ( typeof window.wp.autosave !== 'undefined' && jQuery( '#siteorigin-panels-metabox' ).length ) {
-	jQuery( document ).on( 'ready', function( e ) {
+	jQuery( function( e ) {
 		var blog_id = typeof window.autosaveL10n !== 'undefined' && window.autosaveL10n.blog_id;
 		
 		// Ensure sessionStorage is working, and we were able to find a blog id.

--- a/js/siteorigin-panels/model/widget.js
+++ b/js/siteorigin-panels/model/widget.js
@@ -199,7 +199,6 @@ module.exports = Backbone.Model.extend( {
 			} else if ( typeof fields == 'object' ) {
 				for ( var i = 0; i < fields.length; i++ ) {
 					if ( k == fields[i] ) {
-						console.log( values[ k ] );
 						widgetTitle = thisView.cleanTitle( values[ k ] )
 						break;
 					}


### PR DESCRIPTION
This PR will resolve a jQuery Migrate notice and potential error in newer versions of WordPress.

`ready event is deprecated Plugin: Page Builder by SiteOrigin `