### PR TITLE
CSS Container Breaker: Only Remove Containers `max-width` on Pages With Non-Standard Row Layouts

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -111,6 +111,19 @@ class SiteOrigin_Panels_Renderer {
 			// we need to remove the cell widths on mobile.
 			$css_container_cutoff = $this->container['css_override'] && isset( $row['style']['row_stretch'] ) && $row['style']['row_stretch'] == 'full' ? ":$panels_mobile_width" : 1920;
 
+			if (
+				$this->container['css_override'] &&
+				! $this->container['full_width'] &&
+				! empty( $row['style'] ) &&
+				! empty( $row['style']['row_stretch'] ) &&
+				 (
+				 	$row['style']['row_stretch'] == 'full' ||
+				 	$row['style']['row_stretch'] == 'stretch'
+				 )
+			) {
+				$this->container['full_width'] = true;
+			}
+
 			// Add the cell sizing
 			foreach ( $row['cells'] as $ci => $cell ) {
 				$weight = apply_filters( 'siteorigin_panels_css_cell_weight', $cell['weight'], $row, $ri, $cell, $ci - 1, $panels_data, $post_id );
@@ -332,7 +345,11 @@ class SiteOrigin_Panels_Renderer {
 			), $panels_mobile_width );
 		}
 
-		if ( $this->container['css_override'] ) {
+		// Do we need to remove the theme container on this page?
+		if (
+			$this->container['css_override'] &&
+			$this->container['full_width'] // Does this layout have full width layouts?
+		 ) {
 			$css->add_css(
 				esc_html( $this->container['selector'] ),
 				array(

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -299,6 +299,7 @@ class SiteOrigin_Panels {
 		$container = array(
 			'selector' => apply_filters( 'siteorigin_panels_theme_container_selector', '' ),
 			'width' => apply_filters( 'siteorigin_panels_theme_container_width', '' ),
+			'full_width' => false,
 		);
 		$container['css_override'] = ! empty( $container['selector'] ) && ! empty( $container['width'] );
 


### PR DESCRIPTION
This PR will ensure only pages with non-standard row layouts have the theme container removed.