### PR TITLE
WP 5.9 Compat: Account for updated jQuery UI Sortable appendTo change

### DIFF
--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -408,8 +408,9 @@ module.exports = Backbone.View.extend( {
 		var builderID = builderView.$el.attr( 'id' );
 
 		// Create the sortable for the rows
-		this.rowsSortable = this.$( '.so-rows-container' ).sortable( {
-			appendTo: '#wpwrap',
+		var wpVersion = $( 'body' ).attr( 'class' ).match( /branch-([0-9-]+)/ )[0].replace( /\D/g,'' );
+		this.rowsSortable = this.$( '.so-rows-container:not(.sow-row-color)' ).sortable( {
+			appendTo: wpVersion >= 59 ? 'parent' : '#wpwrap',
 			items: '.so-row-container',
 			handle: '.so-row-move',
 			// For the block editor, where it's possible to have multiple Page Builder blocks on a page.


### PR DESCRIPTION
This PR will resolve an issue that prevents the row re-ordering from working as expected. It resulted in a loss of styling and the row being incorrectly positioned making re-ordering really tricky to do. This issue was introduced in the updated jQuery UI Sortable update in 5.9.