### PR TITLE
Legacy Widgets: Change $adjustedEndCount to buffer length

### DIFF
--- a/widgets/lib/lessc.inc.php
+++ b/widgets/lib/lessc.inc.php
@@ -3063,7 +3063,7 @@ class lessc_parser {
 
 	// consume an end of statement delimiter
 	protected function end() {
-		$adjustedEndCount = $this->count++;
+		$adjustedEndCount = strlen( $this->buffer );
 		if ($this->literal(';')) {
 			return true;
 		} elseif (


### PR DESCRIPTION
It's possible for the $count to be wrong, and this commit prevents that.

Please test this PR using [this layout](https://drive.google.com/uc?id=1qFGraea6DQNBGlZEGVskkmjDwrqJMTY5). Prior to this PR, the following error will occur:

`Notice: Undefined property: lessc::$buffer in /wp-content/plugins/siteorigin-panels/widgets/lib/lessc.inc.php on line 1651`
