### PR TITLE
Sidebar Emulator: Account for potential notice when setting widget id

### DIFF
--- a/inc/sidebars-emulator.php
+++ b/inc/sidebars-emulator.php
@@ -50,7 +50,7 @@ class SiteOrigin_Panels_Sidebars_Emulator {
 						if ( $instance_class == $widget_class && ! empty( $sidebar_id ) ) {
 							//The option value uses only the widget id number as keys
 							preg_match( '/-([0-9]+$)/', $sidebar_id, $num_match );
-							if ( ! empty( $num_match ) && count( $num_match ) > 1  ) {
+							if ( ! empty( $num_match ) ) {
 								$args[0][ $num_match[1] ] = $widget_instance;
 							}
 						}

--- a/inc/sidebars-emulator.php
+++ b/inc/sidebars-emulator.php
@@ -50,7 +50,9 @@ class SiteOrigin_Panels_Sidebars_Emulator {
 						if ( $instance_class == $widget_class && ! empty( $sidebar_id ) ) {
 							//The option value uses only the widget id number as keys
 							preg_match( '/-([0-9]+$)/', $sidebar_id, $num_match );
-							$args[0][ $num_match[1] ] = $widget_instance;
+							if ( ! empty( $num_match ) && count( $num_match ) > 1  ) {
+								$args[0][ $num_match[1] ] = $widget_instance;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/962

To test this PR please enable the Sidebar Emulator setting, add a bunch of WordPress and SiteOrigin Widgets to the sidebar and if no errors are logged, it worked as expected.