### PR TITLE
Disable Fixed Background on Tablet

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -562,7 +562,7 @@ class SiteOrigin_Panels_Renderer {
 		}
 
 		$style_wrapper = '';
-		if ( ! empty( $attributes ) || ! empty( $standard_css ) || ! empty( $mobile_css ) ) {
+		if ( ! empty( $attributes ) || ! empty( $standard_css )  || ! empty( $tablet_css )|| ! empty( $mobile_css ) ) {
 			if ( empty( $attributes['class'] ) ) {
 				$attributes['class'] = array();
 			}

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -684,6 +684,14 @@ class SiteOrigin_Panels_Styles {
 			$css['padding'] = $style[ 'tablet_padding' ];
 		}
 
+		if (
+			! empty( $style['background_display'] ) &&
+			 $style['background_display'] == 'fixed'  &&
+			 ! ( empty( $style['background_image_attachment'] ) && empty( $style['background_image_attachment_fallback'] ) )
+		) {
+			$css[ 'background-attachment' ] = 'scroll';
+		}
+
 		return $css;
 	}
 


### PR DESCRIPTION
This PR will prevent background images set to Fixed from appearing as fixed on mobile. This is to avoid a long term (and still existing) iOS bug that results in the image being zoomed in and the length of the entire page.