### PR TITLE
CSS Container: Account for all Row Layouts When Outputting Full Width JS

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -118,7 +118,8 @@ class SiteOrigin_Panels_Renderer {
 				! empty( $row['style']['row_stretch'] ) &&
 				 (
 				 	$row['style']['row_stretch'] == 'full' ||
-				 	$row['style']['row_stretch'] == 'stretch'
+				 	$row['style']['row_stretch'] == 'full-stretched' ||
+				 	$row['style']['row_stretch'] == 'full-stretched-padded'
 				 )
 			) {
 				$this->container['full_width'] = true;


### PR DESCRIPTION
This PR is in response to https://github.com/siteorigin/siteorigin-panels/pull/958. That PR unintentionally broke support for rows set to Full Width Stretched or Full Width Stretched Padded if there isn't another row with either a standard or full width row layout.

To test this PR:

- Activate Corp and add [the Corp CSS Container Breaker snippet](https://github.com/siteorigin/siteorigin-panels/pull/929).
- Create a new page and add one row with an Archives widget. Give the row a background and set the **Row Layout** to **Full Width Stretched**.
- Save, and view the page. The Row won't be the full width of the page.
- Activate this PR and the row will display as expected.