### PR TITLE
CSS Container Breaker: Prevent 1px situation Where Container Doesn Collapse Correctly

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -109,7 +109,7 @@ class SiteOrigin_Panels_Renderer {
 
 			// If the CSS Container Breaker is enabled, and this row is using it,
 			// we need to remove the cell widths on mobile.
-			$css_container_cutoff = $this->container['css_override'] && isset( $row['style']['row_stretch'] ) && $row['style']['row_stretch'] == 'full' ? ":$panels_mobile_width" : 1920;
+			$css_container_cutoff = $this->container['css_override'] && isset( $row['style']['row_stretch'] ) && $row['style']['row_stretch'] == 'full' ? ':' . ( $panels_mobile_width + 1 ) : 1920;
 
 			if (
 				$this->container['css_override'] &&


### PR DESCRIPTION
This PR fixes a situation where a full width row with multiple columns won't collapse correctly when the browser resolution is exactly at the Mobile Width.

To test this PR:
- Activate Corp and add https://github.com/siteorigin/siteorigin-panels/pull/929.
- Create a new page and add a two-column row with an Archives widget in each column.
- Save, and view the page at the exact Mobile Width.
- Note that the space for the second column is still present but it disappears when you increase/decrease by 1px.
- Activate this PR and the columns will collapse as expected.