### PR TITLE
WPML: Refrine Sidebar Emulator Language Path Removal

### DIFF
--- a/inc/sidebars-emulator.php
+++ b/inc/sidebars-emulator.php
@@ -73,9 +73,10 @@ class SiteOrigin_Panels_Sidebars_Emulator {
 		if ( ! empty( $current_url['path'] ) ) {
 
 			// Check if WPML is running.
-			if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
+			$wpml_language = apply_filters( 'wpml_current_language', NULL );
+			if ( ! empty( $wpml_language ) ) {
 				// Remove the current language code from path to avoid 404.
-				$current_url['path'] = ltrim( $current_url['path'], '/' . ICL_LANGUAGE_CODE . '/' );
+				$current_url['path'] = preg_replace( "/^\/$wpml_language\//", '/', $current_url['path'], 1 );
 			}
 
 			$page = get_page_by_path( $current_url['path'], OBJECT, siteorigin_panels_setting( 'post-types' ) );


### PR DESCRIPTION
This PR changes the WPML Language detection to the now-standard filter and it prevents a situation where if a page has a language code in the URL at the start of it it can sometimes incorrectly result in it being removed.

To test this PR please ensure [this issue](https://wpml.org/errata/page-builder-by-siteorigin-pagination-does-not-work-in-the-blog-page/) doesn't occur (related PR https://github.com/siteorigin/siteorigin-panels/pull/836).