### PR TITLE
add_css: Stricker `px` exclusion

### DIFF
--- a/inc/css-builder.php
+++ b/inc/css-builder.php
@@ -30,7 +30,7 @@ class SiteOrigin_Panels_Css_Builder {
 					if ( ! strlen( (string) $v[ $i ] ) ) continue;
 					$attribute_string[] = wp_strip_all_tags( $k ) . ':' . wp_strip_all_tags( $v[ $i ] );
 				}
-			} elseif ( ! strlen( (string) $v ) || $v == 'px' ) {
+			} elseif ( ! strlen( (string) $v ) || $v === 'px' ) {
 				continue;
 			} else {
 				$attribute_string[] = wp_strip_all_tags( $k ) . ':' . wp_strip_all_tags( $v );


### PR DESCRIPTION
This PR will resolve an issue where a property said to `0` can be incorrectly trip the check added in https://github.com/siteorigin/siteorigin-panels/pull/974.