### PR TITLE
Avoid `GLOB_BRACE` For PHP 8 Compat.

### DIFF
--- a/inc/admin-layouts.php
+++ b/inc/admin-layouts.php
@@ -158,12 +158,27 @@ class SiteOrigin_Panels_Admin_Layouts {
 			return $fallback;
 		}
 	}
+
+	static private function get_files( $folder_path, $file_name ) {
+		$paths = array();
+		$types = array (
+			'jpg',
+			'jpeg',
+			'gif',
+			'png',
+		);
+		foreach ( $types as $ext ) {
+			$paths = array_merge( glob( $folder_path . "/$file_name.$ext" ), $paths );
+		}
+
+		return $paths;
+	}
 	
 	private function get_layout_file_screenshot( $panels_data, $folder_path, $file_name ) {
 		if ( ! empty( $panels_data['screenshot'] ) ) {
 			return $panels_data['screenshot'];
 		} else {
-			$paths = glob( $folder_path . "/$file_name.{jpg,jpeg,gif,png}", GLOB_BRACE );
+			$paths = self::get_files( $folder_path, $file_name );
 			// Highlander Condition. There can be only one.
 			$screenshot_path = empty( $paths ) ? '' : wp_normalize_path( $paths[0] );
 			$wp_content_dir = wp_normalize_path( WP_CONTENT_DIR );


### PR DESCRIPTION
This PR will replace the usage of `GLOB_BRACE` in favour of multiple globs. As we're only using `glob` once okay to use multiple globs like this.

To test this activate Corp and rename [this file](https://github.com/siteorigin/siteorigin-corp/blob/develop/inc/layouts/one-pager.jpg) locally to a .png (it's okay if this isn't technically valid). If the screenshot shows when looking at the bundled layouts, this PR worked as expected.