### PR TITLE
SO Layouts Block: Export Filename Fix

### DIFF
--- a/js/siteorigin-panels/dialog/prebuilt.js
+++ b/js/siteorigin-panels/dialog/prebuilt.js
@@ -180,8 +180,8 @@ module.exports = panels.view.dialog.extend( {
 			var $$ = $( this );
 			var panelsData = thisView.builder.model.getPanelsData();
 			var postName = $( 'input[name="post_title"], .editor-post-title__input' ).val();
-			if ( ! postName ) {
-				postName = $('input[name="post_ID"]').val();
+			if ( postName !== '' && $( 'body' ).hasClass( 'block-editor-page' ) ) {
+				postName = $( '.wp-block-post-title' ).text();
 			} else if ( $( '.block-editor-page' ).length ) {
 				var currentBlockPosition = thisView.getCurrentBlockPosition();
 				if ( currentBlockPosition >= 0 ) {
@@ -189,7 +189,7 @@ module.exports = panels.view.dialog.extend( {
 				}
 
 			}
-			panelsData.name = postName;
+			panelsData.name = postName !== '' ? postName : $( 'input[name="post_ID"]' ).val();
 			$$.find( 'input[name="panels_export_data"]' ).val( JSON.stringify( panelsData ) );
 		} );
 

--- a/js/siteorigin-panels/dialog/prebuilt.js
+++ b/js/siteorigin-panels/dialog/prebuilt.js
@@ -180,16 +180,18 @@ module.exports = panels.view.dialog.extend( {
 			var $$ = $( this );
 			var panelsData = thisView.builder.model.getPanelsData();
 			var postName = $( 'input[name="post_title"], .editor-post-title__input' ).val();
-			if ( postName !== '' && $( 'body' ).hasClass( 'block-editor-page' ) ) {
+			if ( ( ! postName || postName === '' ) && $( '.block-editor-page' ).length ) {
 				postName = $( '.wp-block-post-title' ).text();
-			} else if ( $( '.block-editor-page' ).length ) {
-				var currentBlockPosition = thisView.getCurrentBlockPosition();
-				if ( currentBlockPosition >= 0 ) {
-					postName += '-' + currentBlockPosition; 
-				}
-
 			}
 			panelsData.name = postName !== '' ? postName : $( 'input[name="post_ID"]' ).val();
+
+			// Append block position id to filename.
+			if ( $( '.block-editor-page' ).length ) {
+				var currentBlockPosition = thisView.getCurrentBlockPosition();
+				if ( currentBlockPosition >= 0 ) {
+					panelsData.name += '-' + currentBlockPosition; 
+				}
+			}
 			$$.find( 'input[name="panels_export_data"]' ).val( JSON.stringify( panelsData ) );
 		} );
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/979

In a recent WordPress update, the title field was changed from an input to a div so the previous method of getting the post title no longer works. This PR accounts for the new field while also retaining the older Block Editor field and Classic Editor field