### PR TITLE
Pass post id to server when rendering widget form

### DIFF
--- a/js/siteorigin-panels/dialog/widget.js
+++ b/js/siteorigin-panels/dialog/widget.js
@@ -189,7 +189,8 @@ module.exports = panels.view.dialog.extend( {
 			'action': 'so_panels_widget_form',
 			'widget': this.model.get( 'class' ),
 			'instance': JSON.stringify( this.model.get( 'values' ) ),
-			'raw': this.model.get( 'raw' )
+			'raw': this.model.get( 'raw' ),
+			'postId': this.builder.config.postId
 		};
 
 		var $soContent = this.$( '.so-content' );


### PR DESCRIPTION
This PR will pass the post id to the server when rendering the widget form. This will allow post/page specific adjustments based on the current page. You can test this PR by opening `so-widgets-bundles/widgets/editor/editor.php` and find:

`function get_widget_form() {`

Add After:
`var_dump( $_POST['postId'] );`


This PR changes a core PB JS file so a build is required.