### PR TITLE
Restore New WP Widget Area SO Layouts Block Compatibility & Other Improvements

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -316,13 +316,13 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
         var isNewWPBlockEditor = jQuery('.widgets-php').length;
 
         if (!isNewWPBlockEditor) {
-          wp.data.dispatch('core/block-editor').lockPostSaving();
+          wp.data.dispatch('core/editor').lockPostSaving();
         }
 
         jQuery.post(panelsOptions.ajaxurl, {
           action: 'so_panels_builder_content_json',
           panels_data: JSON.stringify(newPanelsData),
-          post_id: !isNewWPBlockEditor ? wp.data.select("core/block-editor").getCurrentPostId() : ''
+          post_id: !isNewWPBlockEditor ? wp.data.select("core/editor").getCurrentPostId() : ''
         }, function (content) {
           var panelsAttributes = {};
 
@@ -337,7 +337,7 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
           setAttributes(panelsAttributes);
 
           if (!isNewWPBlockEditor) {
-            wp.data.dispatch('core/block-editor').unlockPostSaving();
+            wp.data.dispatch('core/editor').unlockPostSaving();
           }
         });
       } else {
@@ -373,8 +373,8 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
   if (window.soPanelsBlockEditorAdmin.showAddButton) {
     jQuery(function () {
       setTimeout(function () {
-        var editorDispatch = wp.data.dispatch('core/block-editor');
-        var editorSelect = wp.data.select('core/block-editor');
+        var editorDispatch = wp.data.dispatch('core/editor');
+        var editorSelect = wp.data.select('core/editor');
         var tmpl = jQuery('#siteorigin-panels-add-layout-block-button').html();
 
         if (jQuery('.block-editor-writing-flow > .block-editor-block-list__layout').length) {
@@ -404,7 +404,7 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
         });
 
         var hideButtonIfBlocks = function hideButtonIfBlocks() {
-          var isEmpty = wp.data.select('core/block-editor').isEditedPostEmpty();
+          var isEmpty = wp.data.select('core/editor').isEditedPostEmpty();
 
           if (isEmpty) {
             $addButton.show();

--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -316,13 +316,13 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
         var isNewWPBlockEditor = jQuery('.widgets-php').length;
 
         if (!isNewWPBlockEditor) {
-          wp.data.dispatch('core/editor').lockPostSaving();
+          wp.data.dispatch('core/block-editor').lockPostSaving();
         }
 
         jQuery.post(panelsOptions.ajaxurl, {
           action: 'so_panels_builder_content_json',
           panels_data: JSON.stringify(newPanelsData),
-          post_id: !isNewWPBlockEditor ? wp.data.select("core/editor").getCurrentPostId() : ''
+          post_id: !isNewWPBlockEditor ? wp.data.select("core/block-editor").getCurrentPostId() : ''
         }, function (content) {
           var panelsAttributes = {};
 
@@ -337,7 +337,7 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
           setAttributes(panelsAttributes);
 
           if (!isNewWPBlockEditor) {
-            wp.data.dispatch('core/editor').unlockPostSaving();
+            wp.data.dispatch('core/block-editor').unlockPostSaving();
           }
         });
       } else {
@@ -373,8 +373,8 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
   if (window.soPanelsBlockEditorAdmin.showAddButton) {
     jQuery(function () {
       setTimeout(function () {
-        var editorDispatch = wp.data.dispatch('core/editor');
-        var editorSelect = wp.data.select('core/editor');
+        var editorDispatch = wp.data.dispatch('core/block-editor');
+        var editorSelect = wp.data.select('core/block-editor');
         var tmpl = jQuery('#siteorigin-panels-add-layout-block-button').html();
 
         if (jQuery('.block-editor-writing-flow > .block-editor-block-list__layout').length) {
@@ -404,7 +404,7 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
         });
 
         var hideButtonIfBlocks = function hideButtonIfBlocks() {
-          var isEmpty = wp.data.select('core/editor').isEditedPostEmpty();
+          var isEmpty = wp.data.select('core/block-editor').isEditedPostEmpty();
 
           if (isEmpty) {
             $addButton.show();

--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -313,11 +313,16 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
     var onLayoutBlockContentChange = function onLayoutBlockContentChange(newPanelsData) {
       if (!lodash.isEmpty(newPanelsData.widgets)) {
         // Send panelsData to server for sanitization.
-        wp.data.dispatch('core/editor').lockPostSaving();
+        var isNewWPBlockEditor = jQuery('.widgets-php').length;
+
+        if (!isNewWPBlockEditor) {
+          wp.data.dispatch('core/editor').lockPostSaving();
+        }
+
         jQuery.post(panelsOptions.ajaxurl, {
           action: 'so_panels_builder_content_json',
           panels_data: JSON.stringify(newPanelsData),
-          post_id: wp.data.select("core/editor").getCurrentPostId()
+          post_id: !isNewWPBlockEditor ? wp.data.select("core/editor").getCurrentPostId() : ''
         }, function (content) {
           var panelsAttributes = {};
 
@@ -330,7 +335,10 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
           }
 
           setAttributes(panelsAttributes);
-          wp.data.dispatch('core/editor').unlockPostSaving();
+
+          if (!isNewWPBlockEditor) {
+            wp.data.dispatch('core/editor').unlockPostSaving();
+          }
         });
       } else {
         setAttributes({

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -258,13 +258,16 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 			
 			if ( ! lodash.isEmpty( newPanelsData.widgets ) ) {
 				// Send panelsData to server for sanitization.
-				wp.data.dispatch( 'core/editor' ).lockPostSaving();
+				var isNewWPBlockEditor = jQuery( '.widgets-php' ).length;
+				if ( ! isNewWPBlockEditor ) {
+					wp.data.dispatch( 'core/editor' ).lockPostSaving();
+				}
 				jQuery.post(
 					panelsOptions.ajaxurl,
 					{
 						action: 'so_panels_builder_content_json',
 						panels_data: JSON.stringify( newPanelsData ),
-						post_id: wp.data.select("core/editor").getCurrentPostId()
+						post_id: ! isNewWPBlockEditor ? wp.data.select("core/editor").getCurrentPostId() : ''
 			},
 					function ( content ) {
 						let panelsAttributes = {};
@@ -276,7 +279,10 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 						}
 						
 						setAttributes( panelsAttributes );
-						wp.data.dispatch( 'core/editor' ).unlockPostSaving(); 
+
+						if ( ! isNewWPBlockEditor ) {
+							wp.data.dispatch( 'core/editor' ).unlockPostSaving(); 
+						}
 					}
 				);
 			} else {

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -260,14 +260,14 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 				// Send panelsData to server for sanitization.
 				var isNewWPBlockEditor = jQuery( '.widgets-php' ).length;
 				if ( ! isNewWPBlockEditor ) {
-					wp.data.dispatch( 'core/block-editor' ).lockPostSaving();
+					wp.data.dispatch( 'core/editor' ).lockPostSaving();
 				}
 				jQuery.post(
 					panelsOptions.ajaxurl,
 					{
 						action: 'so_panels_builder_content_json',
 						panels_data: JSON.stringify( newPanelsData ),
-						post_id: ! isNewWPBlockEditor ? wp.data.select("core/block-editor").getCurrentPostId() : ''
+						post_id: ! isNewWPBlockEditor ? wp.data.select("core/editor").getCurrentPostId() : ''
 			},
 					function ( content ) {
 						let panelsAttributes = {};
@@ -281,7 +281,7 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 						setAttributes( panelsAttributes );
 
 						if ( ! isNewWPBlockEditor ) {
-							wp.data.dispatch( 'core/block-editor' ).unlockPostSaving(); 
+							wp.data.dispatch( 'core/editor' ).unlockPostSaving(); 
 						}
 					}
 				);
@@ -322,8 +322,8 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 	if ( window.soPanelsBlockEditorAdmin.showAddButton ) {
 		jQuery( () => {
 			setTimeout( () => {
-				const editorDispatch = wp.data.dispatch( 'core/block-editor' );
-				const editorSelect = wp.data.select( 'core/block-editor' );
+				const editorDispatch = wp.data.dispatch( 'core/editor' );
+				const editorSelect = wp.data.select( 'core/editor' );
 				var tmpl = jQuery( '#siteorigin-panels-add-layout-block-button' ).html();
 				if ( jQuery( '.block-editor-writing-flow > .block-editor-block-list__layout' ).length ) {
 					// > WP 5.7
@@ -348,7 +348,7 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 					}
 				} );
 				let hideButtonIfBlocks = () => {
-					const isEmpty = wp.data.select( 'core/block-editor' ).isEditedPostEmpty();
+					const isEmpty = wp.data.select( 'core/editor' ).isEditedPostEmpty();
 					if ( isEmpty ) {
 						$addButton.show();
 					} else {

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -260,14 +260,14 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 				// Send panelsData to server for sanitization.
 				var isNewWPBlockEditor = jQuery( '.widgets-php' ).length;
 				if ( ! isNewWPBlockEditor ) {
-					wp.data.dispatch( 'core/editor' ).lockPostSaving();
+					wp.data.dispatch( 'core/block-editor' ).lockPostSaving();
 				}
 				jQuery.post(
 					panelsOptions.ajaxurl,
 					{
 						action: 'so_panels_builder_content_json',
 						panels_data: JSON.stringify( newPanelsData ),
-						post_id: ! isNewWPBlockEditor ? wp.data.select("core/editor").getCurrentPostId() : ''
+						post_id: ! isNewWPBlockEditor ? wp.data.select("core/block-editor").getCurrentPostId() : ''
 			},
 					function ( content ) {
 						let panelsAttributes = {};
@@ -281,7 +281,7 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 						setAttributes( panelsAttributes );
 
 						if ( ! isNewWPBlockEditor ) {
-							wp.data.dispatch( 'core/editor' ).unlockPostSaving(); 
+							wp.data.dispatch( 'core/block-editor' ).unlockPostSaving(); 
 						}
 					}
 				);
@@ -322,8 +322,8 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 	if ( window.soPanelsBlockEditorAdmin.showAddButton ) {
 		jQuery( () => {
 			setTimeout( () => {
-				const editorDispatch = wp.data.dispatch( 'core/editor' );
-				const editorSelect = wp.data.select( 'core/editor' );
+				const editorDispatch = wp.data.dispatch( 'core/block-editor' );
+				const editorSelect = wp.data.select( 'core/block-editor' );
 				var tmpl = jQuery( '#siteorigin-panels-add-layout-block-button' ).html();
 				if ( jQuery( '.block-editor-writing-flow > .block-editor-block-list__layout' ).length ) {
 					// > WP 5.7
@@ -348,7 +348,7 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 					}
 				} );
 				let hideButtonIfBlocks = () => {
-					const isEmpty = wp.data.select( 'core/editor' ).isEditedPostEmpty();
+					const isEmpty = wp.data.select( 'core/block-editor' ).isEditedPostEmpty();
 					if ( isEmpty ) {
 						$addButton.show();
 					} else {

--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -52,7 +52,8 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 					'wp-element',
 					'wp-components',
 					'wp-compose',
-					'so-panels-admin'
+					'wp-data',
+					'so-panels-admin',
 				),
 				SITEORIGIN_PANELS_VERSION
 			);

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -672,7 +672,7 @@ module.exports = Backbone.View.extend( {
 		// Display the live editor button in the toolbar
 		if ( this.liveEditor.hasPreviewUrl() ) {
 			var addLEButton = false;
-			if ( ! panels.helpers.editor.isBlockEditor() ) {
+			if ( ! panels.helpers.editor.isBlockEditor() || $( '.widgets-php' ).length ) {
 				addLEButton = true;
 			} else if ( wp.data.select( 'core/editor' ).getEditedPostAttribute( 'status' ) != 'auto-draft' ) {
 				addLEButton = true;

--- a/js/siteorigin-panels/view/live-editor.js
+++ b/js/siteorigin-panels/view/live-editor.js
@@ -170,11 +170,7 @@ module.exports = Backbone.View.extend( {
 	closeAndSave: function(){
 		this.close( false );
 		// Finds the submit input for saving without publishing draft posts.
-		if ( $( '.block-editor-page' ).length ) {
-			$( '.editor-post-publish-button' )[0].click();
-		} else {
-			$( '#submitdiv input[type="submit"][name="save"]' )[0].click();
-		}
+		$( '#submitdiv input[type="submit"][name="save"], .editor-post-publish-button, .edit-widgets-header__actions .is-primary' )[0].click();
 	},
 
 	/**

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -24,7 +24,13 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 				<span class="so-button-text"><?php esc_html_e('Layouts', 'siteorigin-panels') ?></span>
 			</a>
 
-			<?php if( !empty($post) ) : ?>
+			<?php
+			if (
+				! empty( $post ) ||
+				( function_exists( 'get_current_screen' ) && get_current_screen()->base == 'widgets' &&  get_current_screen()->is_block_editor )
+
+			) :
+			?>
 
 				<a class="so-tool-button so-history" style="display: none" title="<?php esc_attr_e( 'Edit History', 'siteorigin-panels' ) ?>" tabindex="0">
 					<span class="so-panels-icon so-panels-icon-history"></span>


### PR DESCRIPTION
In a recent WP update:
- WP stopped outputting wp-data automatically.
- Removed the `core/editor` in certain contexts (mainly the new Widget Area).

This PR accounts for both of these and it adds Layout Editor and History support to the SiteOrigin Layouts Block in the new Widget area - it was a relatively simple change.

This PR modifies core JS files so a build will be required.