### PR TITLE
WP 6.0 Compatibility Changes

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -542,6 +542,7 @@
 									}
 
 									a{
+										box-shadow: none;
 										color: #0073aa;
 										display: none;
 										margin-right: 3px;

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -408,7 +408,7 @@ module.exports = Backbone.View.extend( {
 		var builderID = builderView.$el.attr( 'id' );
 
 		// Create the sortable for the rows
-		var wpVersion = $( 'body' ).attr( 'class' ).match( /branch-([0-9-]+)/ )[0].replace( /\D/g,'' );
+		var wpVersion = $( 'body' ).attr( 'class' ).match( /version-([0-9-]+)/ )[0].replace( /\D/g,'' );
 		this.rowsSortable = this.$( '.so-rows-container:not(.sow-row-color)' ).sortable( {
 			appendTo: wpVersion >= 59 ? 'parent' : '#wpwrap',
 			items: '.so-row-container',


### PR DESCRIPTION
This PR removes an underline (actually a shadow) added to links in the Block Editor in WordPress 6.0.
![2022-05-22_03-21-50-1656](https://user-images.githubusercontent.com/17275120/169663943-b712a0f9-2729-4831-a04e-4d593c9b9db6.jpg)

It also changes [this compatibility fix](https://github.com/siteorigin/siteorigin-panels/pull/959) to use the version body class rather than the branch class. Version is more reliable as branch won't have the minor version if it doesn't have one. This results in the class version being seen as `6` rather than `60`. This PR will require a build to test.
![2022-05-22_03-34-25-1658](https://user-images.githubusercontent.com/17275120/169663944-b85f3fe9-a429-4355-88d7-de2910217900.jpg)
