### PR TITLE
Page Builder: Resolve Rare Empty Widgets Warning

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -239,7 +239,7 @@ class SiteOrigin_Panels_Admin {
 		$panels_data = json_decode( wp_unslash( $_POST['panels_data'] ), true );
 
 		$panels_data['widgets'] = $this->process_raw_widgets(
-			$panels_data['widgets'],
+			! empty( $panels_data['widgets'] ) ? $panels_data['widgets'] : array(),
 			! empty( $old_panels_data['widgets'] ) ? $old_panels_data['widgets'] : false,
 			false
 		);


### PR DESCRIPTION
This PR resolves a rare warning that can occur when saving the layout when saving.

`( ! ) Warning: Undefined array key "widgets" in /Volumes/Projects/Sites/**.**/app/public/wp-content/plugins/siteorigin-panels/inc/admin.php on line 242`

This warning is very hard to replicate as it relies on you saving at exactly the right point in time where `panelsData` is set but an empty array for widgets hasn't been created. The user who reported this said it happened twice during 55 different pages being created. So this is to say, testing this is really tricky. 

- Create a new Classic Editor powered page.
- Disable Page Builder.
- Set a Page Title.
- Save.
- Low chance of error.