### PR TITLE
Legacy Renderer: Resolve Link Color Notice

### DIFF
--- a/inc/renderer-legacy.php
+++ b/inc/renderer-legacy.php
@@ -133,9 +133,17 @@ class SiteOrigin_Panels_Renderer_Legacy extends SiteOrigin_Panels_Renderer {
 
 		foreach ( $panels_data['widgets'] as $widget_id => $widget ) {
 			if ( ! empty( $widget['panels_info']['style']['link_color'] ) ) {
-				$css->add_widget_css( $post_id, $widget['panels_info']['grid'], $widget['panels_info']['cell'], $widget['panels_info']['cell_index'], ' a', array(
-					'color' => $widget['panels_info']['style']['link_color']
-				) );
+				var_dump( $widget['panels_info'] );
+				$css->add_widget_css(
+					$post_id,
+					$widget['panels_info']['grid'],
+					$widget['panels_info']['cell'],
+					$widget['panels_info']['id'],
+					' a',
+					array(
+						'color' => $widget['panels_info']['style']['link_color']
+					)
+				);
 			}
 		}
 


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/php-notices-151/)

To trigger this error, enable the Legacy Renderer (Settings > Page Builder, open **Layouts** tab and set **Use Legacy Layout Engine** to **Always**) and add an Archives widget. Open the widget and set a Link Color via the widget styles.