### PR TITLE
Gravity Forms Compat: Add Additional Check to Prevent Unrelated Notice

### DIFF
--- a/compat/gravity-forms.php
+++ b/compat/gravity-forms.php
@@ -9,7 +9,11 @@
  * @return $instance
  */
 function siteorigin_gravity_forms_override_disable_print_scripts( $instance, $the_widget, $widget_class ) {
-	if ( $the_widget->id_base == 'gform_widget' ) {
+	if (
+		! empty( $the_widget ) &&
+		is_object( $the_widget ) &&
+		$the_widget->id_base == 'gform_widget'
+	) {
 		$instance['disable_scripts'] = true;
 
 		// Disable print scripts for older versions of Gravity Forms.


### PR DESCRIPTION
This PR will resolve the below error message caused by partially setup widgets:

`Notice: Trying to get property 'id_base' of non-object in /public_html/wp-content/plugins/siteorigin-panels/compat/gravity-forms.php on line 12`

This PR can be tested by viewing a widget with additional settings added by Gravity Forms.