### PR TITLE
Add Jetpack Copy Post Compatibility

### DIFF
--- a/compat/jetpack.php
+++ b/compat/jetpack.php
@@ -28,3 +28,17 @@ function siteorigin_panels_photon_exclude_parallax( $skip, $src, $tag ) {
 	}
 	return $skip;
 }
+
+/**
+ * When a post is copied using Jetpack, copy Page Builder data.
+ *
+ * @param WP_Post $source_post Post object that was copied.
+ * @param int     $target_post_id Target post ID.
+ */
+function siteorigin_panels_jetpack_copy_post( $source_post, $target_post_id ) {
+	$panels_data = get_post_meta( $source_post, 'panels_data', true );
+	if ( ! empty( $panels_data ) ) {
+		add_post_meta( $target_post_id, 'panels_data', $panels_data );
+	}
+}
+add_action( 'jetpack_copy_post', 'siteorigin_panels_jetpack_copy_post', 10, 2 );

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -234,7 +234,7 @@ class SiteOrigin_Panels {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/lazy-load-backgrounds.php';
 		}
 
-		if ( siteorigin_panels_setting( 'parallax-type' ) == 'modern' && class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
+		if ( class_exists( 'Jetpack' ) ) {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/jetpack.php';
 		}
 


### PR DESCRIPTION
This PR adds [Jetpack Copy Post](https://jetpack.com/support/copy-post/) compatibility by ensuring that Page Builder data is copied when Jetpack copies the page - which doesn't always happen.