### PR TITLE
Prevent Potential Panels Preview PHP 8.3 TypeError

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1093,7 +1093,7 @@ class SiteOrigin_Panels_Admin {
 	function generate_panels_preview( $post_id, $panels_data ) {
 		$GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] = true;
 		$return = SiteOrigin_Panels::renderer()->render( (int) $post_id, false, $panels_data );
-		if ( function_exists( 'wp_targeted_link_rel' ) ) {
+		if ( function_exists( 'wp_targeted_link_rel' ) && is_array( $return ) ) {
 			$return = wp_targeted_link_rel( $return );
 		}
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] );


### PR DESCRIPTION
This PR prevents the following potential PHP 8.3 TypeError when previewing layouts that aren't able to render. To test this PR, simply confirm that the data is correctly detected on load by an SEO plugin or the SiteOrigin Layouts block displays correctly on load.

` Fatal error: Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given in /public_html/wp-includes/formatting.php:3238 Stack trace: #0 /public_html/wp-content/plugins/siteorigin-panels/inc/admin.php(1097): wp_targeted_link_rel('') #1 /public_html/wp-content/plugins/siteorigin-panels/inc/admin.php(209): SiteOrigin_Panels_Admin->generate_panels_preview(6514, Array) #2 /public_html/wp-admin/includes/template.php(1401): SiteOrigin_Panels_Admin->render_meta_boxes(Object(WP_Post), Array) #3 /public_html/wp-admin/edit-form-advanced.php(711): do_meta_boxes(Object(WP_Screen), 'advanced', Object(WP_Post)) #4 /public_html/wp-admin/post.php(206): require('/home/customer/...') #5 {main} thrown in /public_html/wp-includes/formatting.php on line 3238`