### PR TITLE
Resolve Layout Builder Sizing Issue in Customizer

### DIFF
--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -406,11 +406,16 @@ module.exports = Backbone.View.extend( {
 
 		var builderView = this;
 		var builderID = builderView.$el.attr( 'id' );
+		var container = 'parent';
 
-		// Create the sortable for the rows
+		if ( ! $( 'body' ).hasClass( 'wp-customizer' ) && $( 'body' ).attr( 'class' ).match( /version-([0-9-]+)/ )[0].replace( /\D/g,'' ) < 59 ) {
+			wpVersion = '#wpwrap';
+		}
+
+		// Create the sortable element for rows.
 		var wpVersion = $( 'body' ).attr( 'class' ).match( /version-([0-9-]+)/ )[0].replace( /\D/g,'' );
 		this.rowsSortable = this.$( '.so-rows-container:not(.sow-row-color)' ).sortable( {
-			appendTo: wpVersion >= 59 ? 'parent' : '#wpwrap',
+			appendTo: container,
 			items: '.so-row-container',
 			handle: '.so-row-move',
 			// For the block editor, where it's possible to have multiple Page Builder blocks on a page.


### PR DESCRIPTION
This PR resolves a sizing issue in the Layout Builder while edited via the Customizer. To test this PR, please confirm cells size correctly in the following areas:

- Customizer.
- Appearance > Widgets
- Classic or Block Editor.

![2022-08-08_22-59-19-1683](https://user-images.githubusercontent.com/17275120/183424839-0a3f261a-0b43-46cc-9a4e-e8aa67f631a6.jpg)
