### PR TITLE
Prevent Layout Builder TypeError

### DIFF
--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -413,7 +413,6 @@ module.exports = Backbone.View.extend( {
 		}
 
 		// Create the sortable element for rows.
-		var wpVersion = $( 'body' ).attr( 'class' ).match( /version-([0-9-]+)/ )[0].replace( /\D/g,'' );
 		this.rowsSortable = this.$( '.so-rows-container:not(.sow-row-color)' ).sortable( {
 			appendTo: container,
 			items: '.so-row-container',


### PR DESCRIPTION
This PR resolves the following error:

`Uncaught TypeError: l(...).attr(...).match(...) is null`
![2022-08-11_02-57-12-1684](https://user-images.githubusercontent.com/17275120/183971558-d142c450-3ed3-4c06-a3e5-c45f39542c89.jpg)

To replicate it, add a Layout Builder to a widget area via **Appearance > Widgets**. Navigate to **Appearance > Customize**, **Widgets** and open the Layout Builder. You'll get this TypeError in the console.