### PR TITLE
Settings descriptions updates

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -124,7 +124,7 @@ class SiteOrigin_Panels_Styles {
 			'name'        => sprintf( __( '%s Class', 'siteorigin-panels' ), $label ),
 			'type'        => 'text',
 			'group'       => 'attributes',
-			'description' => __( 'A CSS class name.', 'siteorigin-panels' ),
+			'description' => sprintf(__( 'A custom class used for this %s.', 'siteorigin-panels' ), strtolower( $label ) ),
 			'priority'    => 5,
 		);
 

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -193,7 +193,6 @@ class SiteOrigin_Panels_Styles {
 			'name'        => __( 'Background Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
-			'description' => sprintf( __( 'Background color of the %s.', 'siteorigin-panels' ), strtolower( $label ) ),
 			'priority'    => 5,
 		);
 
@@ -201,7 +200,6 @@ class SiteOrigin_Panels_Styles {
 			'name'        => __( 'Background Image', 'siteorigin-panels' ),
 			'type'        => 'image',
 			'group'       => 'design',
-			'description' => sprintf( __( 'Background image of the %s.', 'siteorigin-panels' ), strtolower( $label ) ),
 			'priority'    => 6,
 		);
 
@@ -217,7 +215,6 @@ class SiteOrigin_Panels_Styles {
 				'fixed'             => __( 'Fixed', 'siteorigin-panels' ),
 				'parallax'          => __( 'Parallax', 'siteorigin-panels' ),
 			),
-			'description' => __( 'How the background image is displayed.', 'siteorigin-panels' ),
 			'priority'    => 7,
 		);
 
@@ -225,7 +222,6 @@ class SiteOrigin_Panels_Styles {
 			'name'        => __( 'Border Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
-			'description' => sprintf( __( 'Border color of the %s.', 'siteorigin-panels' ), strtolower( $label ) ),
 			'priority'    => 10,
 		);
 
@@ -379,7 +375,6 @@ class SiteOrigin_Panels_Styles {
 			'name'        => __( 'Font Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
-			'description' => __( 'Color of text inside this cell.', 'siteorigin-panels' ),
 			'priority'    => 15,
 		);
 
@@ -387,7 +382,6 @@ class SiteOrigin_Panels_Styles {
 			'name'        => __( 'Link Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
-			'description' => __( 'Color of links inside this cell.', 'siteorigin-panels' ),
 			'priority'    => 16,
 		);
 
@@ -395,7 +389,6 @@ class SiteOrigin_Panels_Styles {
 			'name'        => __( 'Link Hover Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
-			'description' => __( 'Color of links inside this widget when hovered.', 'siteorigin-panels' ),
 			'priority'    => 17,
 		);
 
@@ -427,7 +420,6 @@ class SiteOrigin_Panels_Styles {
 			'name'        => __( 'Font Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
-			'description' => __( 'Color of text inside this widget.', 'siteorigin-panels' ),
 			'priority'    => 15,
 		);
 
@@ -435,7 +427,6 @@ class SiteOrigin_Panels_Styles {
 			'name'        => __( 'Link Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
-			'description' => __( 'Color of links inside this widget.', 'siteorigin-panels' ),
 			'priority'    => 16,
 		);
 
@@ -443,7 +434,6 @@ class SiteOrigin_Panels_Styles {
 			'name'        => __( 'Link Hover Color', 'siteorigin-panels' ),
 			'type'        => 'color',
 			'group'       => 'design',
-			'description' => __( 'Color of links inside this widget when hovered.', 'siteorigin-panels' ),
 			'priority'    => 17,
 		);
 


### PR DESCRIPTION
@AlexGStapleton This PR makes a small update to the Attributes > Class setting description and removes several Design setting descriptions that are perhaps redundant. The extra space will hopefully make the section easier to navigate once we add the shadow and radius settings. I've moved this chat from Slack. Let me know if you're keen on these changes. No worries either way.