### PR TITLE
Add `siteorigin_panels_admin_row_colors`

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -174,46 +174,6 @@
 	.so-rows-container{
 		padding: 20px 15px 0 15px;
 
-		// See tpl/js-templates.php variable $row_color_count. It should match the number of colors defined here.
-		@row_colors: #CDE2EC, #F2C2BE, #D5CCDF, #CAE7CD, #E2DCB1;
-
-		.row-colors( @i: 1 ) when ( @i <= length( @row_colors ) ) {
-			@row_color: extract( @row_colors, @i );
-
-			// The color selectors
-			.so-row-color-@{i} {
-				&.so-row-color {
-					background-color: @row_color;
-					border: 1px solid darken( @row_color, 11% );
-
-					&.so-row-color-selected:before {
-						background: darken( @row_color, 10% );
-					}
-				}
-			}
-
-			// The actual container
-			.so-row-container.so-row-color-@{i} .so-cells .cell {
-				.cell-wrapper {
-					background-color: @row_color;
-				}
-
-				&.cell-selected .cell-wrapper {
-					background-color: darken( @row_color, 14% );
-				}
-
-				.resize-handle {
-					background-color: lighten( @row_color, 7% );
-
-					&:hover {
-						background-color: lighten( @row_color, 4% );
-					}
-				}
-			}
-
-			.row-colors( ( @i + 1 ) );
-		} .row-colors();
-
 		h3.so-row-label {
 			display: inline-block;
 			font-size: 1em;

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -609,6 +609,37 @@ class SiteOrigin_Panels_Admin {
 				SITEORIGIN_PANELS_VERSION
 			);
 			do_action( 'siteorigin_panel_enqueue_admin_styles' );
+
+			$row_colors = SiteOrigin_Panels_Admin::get_row_colors();
+			$row_colors_css = '';
+			foreach ( $row_colors as $name => $color ) {
+				$row_colors_css .= '
+					.siteorigin-panels-builder .so-rows-container .so-row-color-' . $name . '.so-row-color {
+						background-color: ' . $color['active'] . ';
+						border: 1px solid ' . $color['inactive'] . ';
+					}
+					.siteorigin-panels-builder .so-rows-container .so-row-color-' . $name . '.so-row-color.so-row-color-selected:before {
+					  background: ' . $color['active'] . ';
+					}
+
+					.siteorigin-panels-builder .so-rows-container .so-row-container.so-row-color-' . $name . ' .so-cells .cell .cell-wrapper {
+						background-color: ' . $color['inactive'] . ';
+					}
+					.siteorigin-panels-builder .so-rows-container .so-row-container.so-row-color-' . $name . ' .so-cells .cell.cell-selected .cell-wrapper {
+						background-color: ' . $color['active'] . ';
+					}
+
+					.siteorigin-panels-builder .so-rows-container .so-row-container.so-row-color-' . $name . ' .so-cells .cell .resize-handle {
+						background-color: ' . $color['cell_divider'] . ';
+					}
+					.siteorigin-panels-builder .so-rows-container .so-row-container.so-row-color-' . $name . ' .so-cells .cell .resize-handle:hover {
+						background-color: ' . $color['cell_hover'] . ';
+					}';
+			}
+
+			if ( ! empty( $row_colors_css ) ) {
+				wp_add_inline_style( 'so-panels-admin', $row_colors_css );
+			}
 		}
 	}
 
@@ -956,6 +987,54 @@ class SiteOrigin_Panels_Admin {
 	 */
 	function js_templates() {
 		include plugin_dir_path( __FILE__ ) . '../tpl/js-templates.php';
+	}
+
+	public static function get_row_colors() {
+		$row_colors = apply_filters( 'siteorigin_panels_admin_row_colors', array(
+			1 => array(
+				'inactive' => '#cde2ec',
+				'active' => '#a4cadd',
+				'cell_divider' => '#e7f1f6',
+				'cell_hover' => '#dcebf2',
+			),
+			2 => array(
+				'inactive' => '#f2c2be',
+				'active' => '#e9968f',
+				'cell_divider' => '#f8dedc',
+				'cell_hover' => '#f5d2cf',
+			),
+			3 => array(
+				'inactive' => '#d5ccdf',
+				'active' => '#b9aac9',
+				'cell_divider' => '#e7e2ed',
+				'cell_hover' => '#dfd9e7',
+			),
+			4 => array(
+				'inactive' => '#cae7cd',
+				'active' => '#a3d6a9',
+				'cell_divider' => '#e3f2e4',
+				'cell_hover' => '#d8edda',
+			),
+			5 => array(
+				'inactive' => '#e2dcb1',
+				'active' => '#d3ca88',
+				'cell_divider' => '#ece8cb',
+				'cell_hover' => '#e8e3c0',
+			),
+		) );
+
+		// Ensure all of the colors are valid.
+		foreach ( $row_colors as $name => $color ) {
+			if (
+				! empty( $color['inactive'] ) &&
+				! empty( $color['active'] ) &&
+				! empty( $color['cell_divider'] ) &&
+				! empty( $color['cell_hover'] )
+			) {
+				$valid_row_colors[ $name ] = array_map( 'sanitize_hex_color', $color );
+			}
+		}
+		return $valid_row_colors;
 	}
 
 	/**

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -107,7 +107,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 							foreach ( $row_colors as $name => $color) {
 								?>
 								<div data-color-label="<?php echo esc_attr( $name ); ?>"
-									class="<?php echo esc_attr( 'so-row-color so-row-color-' . $name ) ?>{{% if( rowColorLabel == '<?php echo esc_attr( $name ); ?>' ) print(' so-row-color-selected'); %}}"
+									class="<?php echo esc_attr( 'so-row-color so-row-color-' . $name ); ?>{{% if( rowColorLabel == '<?php echo esc_attr( $name ); ?>' ) print(' so-row-color-selected'); %}}"
 									></div>
 								<?php
 							}

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -103,15 +103,11 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 						<li><a class="so-row-delete so-needs-confirm" data-confirm="<?php esc_attr_e('Are you sure?', 'siteorigin-panels') ?>"><?php _e('Delete Row', 'siteorigin-panels') ?></a></li>
 						<li class="so-row-colors-container">
 							<?php
-							// See css/admin.less variable @row_colors. This should match the number of colors defined there.
-							$row_color_count = 5;
-
-							for ( $i = 1; $i <= $row_color_count; $i++ ) {
-								$classes = array( 'so-row-color', 'so-row-color-' . $i );
-
+							$row_colors = SiteOrigin_Panels_Admin::get_row_colors();
+							foreach ( $row_colors as $name => $color) {
 								?>
-								<div data-color-label="<?php echo esc_attr( $i ); ?>"
-									class="<?php echo esc_attr( implode( ' ', $classes ) ) ?>{{% if( rowColorLabel == '<?php echo esc_attr( $i ); ?>' ) print(' so-row-color-selected'); %}}"
+								<div data-color-label="<?php echo esc_attr( $name ); ?>"
+									class="<?php echo esc_attr( 'so-row-color so-row-color-' . $name ) ?>{{% if( rowColorLabel == '<?php echo esc_attr( $name ); ?>' ) print(' so-row-color-selected'); %}}"
 									></div>
 								<?php
 							}


### PR DESCRIPTION
Resolve #968 

This will allow re-ordering, custom row colours with names, and row colour removal.

Add custom colour:

```
add_filter( 'siteorigin_panels_admin_row_colors', function( $row_colors ) {
	$row_colors['custom'] = array(
		'inactive' => '#0f0',
		'active' => '#000',
		'cell_divider' => '#ff0',
		'cell_hover' => '#0ff',
	);
	
	return $row_colors;
} );
```

Remove lavender row colour:

```
add_filter( 'siteorigin_panels_admin_row_colors', function( $row_colors ) {
	unset( $row_colors[3] );
	
	return $row_colors;
} );
```

Reverse row colour ordering (won't change the default row color):

```
add_filter( 'siteorigin_panels_admin_row_colors', function( $row_colors ) {
	$row_colors = array_reverse( $row_colors, true );
	
	return $row_colors;
} );
```