### PR TITLE
Renderer: If `$panels_data` Parameter is Set, Detect String and Attempt Decode

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -452,6 +452,9 @@ class SiteOrigin_Panels_Renderer {
 			if ( $panels_data === false ) {
 				return false;
 			}
+		} elseif ( is_string( $panels_data ) ) {
+			// If $panels_data is a string, it's likely json, try decoding it.
+			$panels_data = json_decode( $panels_data, true );
 		}
 
 		$panels_data = apply_filters( 'siteorigin_panels_data', $panels_data, $post_id );


### PR DESCRIPTION
This PR will account for a situation where the `$panels_data` is passed as a string containing JSON rather than an array.
To test this, please add a SiteOrigin Tabs widget and add a tab with Layout Builder setup present - add an archives widget. Save. Load the page in the Live Editor and make any changes to the page (you need to trigger the Live Editor to reload the preview). After the reload has occurred you'll notice the Tab contents didn't render. Switch to this branch and make another change in the Live Editor. The Tab contents will now display correctly.