### PR TITLE
Panels `close_dialog_validation`: Client Side Event to Allow for Widget Validation

### DIFF
--- a/js/siteorigin-panels/view/dialog.js
+++ b/js/siteorigin-panels/view/dialog.js
@@ -379,6 +379,29 @@ module.exports = Backbone.View.extend( {
 			silent: false
 		}, options );
 
+		// Allow for external field validation when attempting to close a widget.
+		if ( typeof this.widgetView == 'object' ) {
+			if ( typeof values.widgets == 'object' ) {
+				validSave = $( document ).triggerHandler(
+					'close_dialog_validation',
+					[
+						// Widget values.
+						values.widgets[ this.model.cid ],
+						// Widget Class
+						this.model.attributes.class,
+						// Model instance - used for finding field markup.
+						this.model.cid,
+						// Instance.
+						this
+					]
+				);
+			}
+
+			if ( typeof validSave == 'boolean' && ! validSave ) {
+				return false;
+			}
+		}
+
 		if ( ! options.silent ) {
 			this.trigger( 'close_dialog' );
 		}

--- a/js/siteorigin-panels/view/dialog.js
+++ b/js/siteorigin-panels/view/dialog.js
@@ -381,6 +381,7 @@ module.exports = Backbone.View.extend( {
 
 		// Allow for external field validation when attempting to close a widget.
 		if ( typeof this.widgetView == 'object' ) {
+			var values = this.getFormValues();
 			if ( typeof values.widgets == 'object' ) {
 				validSave = $( document ).triggerHandler(
 					'close_dialog_validation',


### PR DESCRIPTION
This PR resolves https://github.com/siteorigin/siteorigin-panels/issues/938. It's also the Page Builder's side of widget validation for the Widgets Bundle (which will interface with this and a similar event on its side). Please note that this PR modifies core PB JS files so a build is required.

Here's some test JavaScript you can try by adding them to the browser console.

This snippet is a simple way of testing validation success and failure. It causes a 50/50 chance of widget failing validation.
```
jQuery( document ).on('close_dialog_validation', function( e, values, widget, id, instance ) {
	return Math.random() >= 0.5;
} );
```


This snippet applies to the Archives widget and makes the title field required. It also shows an example of indicating an issue by adding a red border around the title field.
```
jQuery( document ).on('close_dialog_validation', function( e, values, widget, id, instance ) {
	var valid = true;

	if ( widget == 'WP_Widget_Archives' ) {
		if ( ! values.title.length ) {
			jQuery( '[name="widgets[' + id + '][title]"]' ).css( 'border', '2px solid #f00')
			valid = false;
		} else {
			jQuery( '[name="widgets[' + id + '][title]"]' ).css( 'border', '1px solid #8c8f94')
		}
	}
	return valid;
} );
```