### PR TITLE
Panels: Change media Modal Title

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -368,6 +368,7 @@ class SiteOrigin_Panels_Admin {
 				'copy_content'              => siteorigin_panels_setting( 'copy-content' ),
 				'cache'                     => array(),
 				'instant_open'              => siteorigin_panels_setting( 'instant-open-widgets' ),
+				'add_media'                 => __( 'Choose Media', 'siteorigin-panels' ),
 				'default_columns'           => apply_filters( 'siteorigin_panels_default_row_columns', array(
 					array(
 						'weight' => 0.5,

--- a/js/siteorigin-panels/view/styles.js
+++ b/js/siteorigin-panels/view/styles.js
@@ -139,7 +139,7 @@ module.exports = Backbone.View.extend( {
 					// Create the media frame.
 					frame = wp.media( {
 						// Set the title of the modal.
-						title: 'choose',
+						title: panelsOptions.add_media,
 
 						// Tell the modal to show only images.
 						library: {


### PR DESCRIPTION
This PR changes the media modal (which is accessed via the Choose Media button in the Styles) title to Choose Media. It also allows for it to be translated.

![Screenshot 2022-10-09 at 15-02-36 Edit Page ‹ SO — WordPress](https://user-images.githubusercontent.com/17275120/194734118-e61db27d-fbb6-43c1-994d-dfa578826198.png)

Please note that this PR changes a core JS file so a build is required.
