### PR TITLE
Row Color: Add Migration For Legacy and Filter to Change Default

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -525,7 +525,16 @@ class SiteOrigin_Panels_Admin {
 				'siteoriginWidgetRegex'     => str_replace( '*+', '*', get_shortcode_regex( array( 'siteorigin_widget' ) ) ),
 				'forms'                   => array(
 					'loadingFailed' => __( 'Unknown error. Failed to load the form. Please check your internet connection, contact your web site administrator, or try again later.', 'siteorigin-panels' ),
-				)
+				),
+				'row_color' => array(
+					'migrations' => apply_filters( 'siteorigin_panels_admin_row_colors_migration', array(
+						1 => __( 'soft-blue', 'siteorigin-panels' ),
+						2 => __( 'soft-red', 'siteorigin-panels' ),
+						3 => __( 'grayish-violet', 'siteorigin-panels' ),
+						4 => __( 'lime-green', 'siteorigin-panels' ),
+						5 => __( 'desaturated-yellow', 'siteorigin-panels' ),
+					) ),
+				),
 			) );
 
 			$js_widgets = array();

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -534,7 +534,7 @@ class SiteOrigin_Panels_Admin {
 						4 => __( 'lime-green', 'siteorigin-panels' ),
 						5 => __( 'desaturated-yellow', 'siteorigin-panels' ),
 					) ),
-					'default' => apply_filters( 'siteorigin_panels_admin_row_colors_default', __( 'lime-green', 'siteorigin-panels' ) ),
+					'default' => apply_filters( 'siteorigin_panels_admin_row_colors_default', __( 'soft-blue', 'siteorigin-panels' ) ),
 				),
 			) );
 

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -534,6 +534,7 @@ class SiteOrigin_Panels_Admin {
 						4 => __( 'lime-green', 'siteorigin-panels' ),
 						5 => __( 'desaturated-yellow', 'siteorigin-panels' ),
 					) ),
+					'default' => apply_filters( 'siteorigin_panels_admin_row_colors_default', __( 'lime-green', 'siteorigin-panels' ) ),
 				),
 			) );
 

--- a/js/siteorigin-panels/view/row.js
+++ b/js/siteorigin-panels/view/row.js
@@ -47,14 +47,20 @@ module.exports = Backbone.View.extend( {
 	render: function () {
 		var rowColorLabel = this.model.has( 'color_label' ) ? this.model.get( 'color_label' ) : panelsOptions.row_color.default;
 		var rowLabel = this.model.has( 'label' ) ? this.model.get( 'label' ) : '';
-		this.setElement( this.template( { rowColorLabel: rowColorLabel, rowLabel: rowLabel } ) );
 		this.$el.data( 'view', this );
 
 		// Migrate legacy row color labels.
 		if ( typeof rowColorLabel == 'number' && typeof panelsOptions.row_color.migrations[ rowColorLabel ] == 'string' ) {
+			this.$el.removeClass( 'so-row-color-' + rowColorLabel );
 			rowColorLabel = panelsOptions.row_color.migrations[ rowColorLabel ];
+			this.$el.addClass( 'so-row-color-' + rowColorLabel );
 			this.model.set( 'color_label', rowColorLabel );
 		}
+
+		this.setElement( this.template( {
+			rowColorLabel: rowColorLabel,
+			rowLabel: rowLabel
+		} ) );
 
 		// Create views for the cells in this row
 		var thisView = this;

--- a/js/siteorigin-panels/view/row.js
+++ b/js/siteorigin-panels/view/row.js
@@ -45,7 +45,7 @@ module.exports = Backbone.View.extend( {
 	 * @returns {panels.view.row}
 	 */
 	render: function () {
-		var rowColorLabel = this.model.has( 'color_label' ) ? this.model.get( 'color_label' ) : 1;
+		var rowColorLabel = this.model.has( 'color_label' ) ? this.model.get( 'color_label' ) : panelsOptions.row_color.default;
 		var rowLabel = this.model.has( 'label' ) ? this.model.get( 'label' ) : '';
 		this.setElement( this.template( { rowColorLabel: rowColorLabel, rowLabel: rowLabel } ) );
 		this.$el.data( 'view', this );
@@ -327,7 +327,7 @@ module.exports = Backbone.View.extend( {
 		this.$( '.so-row-color' ).removeClass( 'so-row-color-selected' );
 		var clickedColorElem = $( event.target );
 		var newColorLabel = clickedColorElem.data( 'color-label' );
-		var oldColorLabel = this.model.has( 'color_label' ) ? this.model.get( 'color_label' ) : 1;
+		var oldColorLabel = this.model.has( 'color_label' ) ? this.model.get( 'color_label' ) : panelsOptions.row_color.default;
 		clickedColorElem.addClass( 'so-row-color-selected' );
 		this.$el.removeClass( 'so-row-color-' + oldColorLabel );
 		this.$el.addClass( 'so-row-color-' + newColorLabel );

--- a/js/siteorigin-panels/view/row.js
+++ b/js/siteorigin-panels/view/row.js
@@ -50,6 +50,12 @@ module.exports = Backbone.View.extend( {
 		this.setElement( this.template( { rowColorLabel: rowColorLabel, rowLabel: rowLabel } ) );
 		this.$el.data( 'view', this );
 
+		// Migrate legacy row color labels.
+		if ( typeof rowColorLabel == 'number' && typeof panelsOptions.row_color.migrations[ rowColorLabel ] == 'string' ) {
+			rowColorLabel = panelsOptions.row_color.migrations[ rowColorLabel ];
+			this.model.set( 'color_label', rowColorLabel );
+		}
+
 		// Create views for the cells in this row
 		var thisView = this;
 		this.model.get('cells').each( function ( cell ) {


### PR DESCRIPTION
This PR adds migration for legacy colors (legacy meaning number id to text id) and introduces the `siteorigin_panels_admin_row_colors_default` filter that allows you to change the row default colour.

[Test Layout for legacy migrations](https://drive.google.com/uc?id=1VIuywK0KqeqMbFwMsNkvrtnertCq5uEm). Before this branch, all row colors would display as the default row color. After this branch, they'll display correctly.

Test snippet:

add_filter( 'siteorigin_panels_admin_row_colors_default', function( $default ) {
return 'lime-green';
} );