### PR TITLE
Prevent Row Color Spacing If No Row Colors

### DIFF
--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -101,19 +101,23 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 						<li><a class="so-row-settings"><?php _e('Edit Row', 'siteorigin-panels') ?></a></li>
 						<li><a class="so-row-duplicate"><?php _e('Duplicate Row', 'siteorigin-panels') ?></a></li>
 						<li><a class="so-row-delete so-needs-confirm" data-confirm="<?php esc_attr_e('Are you sure?', 'siteorigin-panels') ?>"><?php _e('Delete Row', 'siteorigin-panels') ?></a></li>
-						<li class="so-row-colors-container">
-							<?php
-							$row_colors = SiteOrigin_Panels_Admin::get_row_colors();
-							foreach ( $row_colors as $id => $color ) {
-								$name = ! empty( $color['name'] ) ? sanitize_title( $color['name'] ) : $id;
-								?>
-								<div data-color-label="<?php echo esc_attr( $name ); ?>"
-									class="<?php echo esc_attr( 'so-row-color so-row-color-' . $name ); ?>{{% if( rowColorLabel == '<?php echo esc_attr( $name ); ?>' ) print(' so-row-color-selected'); %}}"
-									></div>
+						<?php
+						$row_colors = SiteOrigin_Panels_Admin::get_row_colors();
+						if ( ! empty( $row_colors ) ) :
+						?>
+							<li class="so-row-colors-container">
 								<?php
-							}
-							?>
-						</li>
+								foreach ( $row_colors as $id => $color ) {
+									$name = ! empty( $color['name'] ) ? sanitize_title( $color['name'] ) : $id;
+									?>
+									<div data-color-label="<?php echo esc_attr( $name ); ?>"
+										class="<?php echo esc_attr( 'so-row-color so-row-color-' . $name ); ?>{{% if( rowColorLabel == '<?php echo esc_attr( $name ); ?>' ) print(' so-row-color-selected'); %}}"
+										></div>
+									<?php
+								}
+								?>
+							</li>
+						<?php endif; ?>
 					</ul>
 					<div class="so-pointer"></div>
 				</div>


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/1010

This PR prevents the Row Colors container from being added if there aren't any row colors.

Before this PR:
![2022-10-26_03-48-57-1720](https://user-images.githubusercontent.com/17275120/197807268-7456561b-66d3-41a8-95ff-854f29a80673.jpg)

After this PR:
![2022-10-26_03-47-17-1719](https://user-images.githubusercontent.com/17275120/197807283-bef11439-4fa1-4470-8a75-dded86d93a28.jpg)

A simple way to test this is to simply comment out line 105.
`// $row_colors = SiteOrigin_Panels_Admin::get_row_colors();`
