### PR TITLE
Resolve Row Reordering Not Updating Correctly

### DIFF
--- a/js/siteorigin-panels/view/row.js
+++ b/js/siteorigin-panels/view/row.js
@@ -47,7 +47,6 @@ module.exports = Backbone.View.extend( {
 	render: function () {
 		var rowColorLabel = this.model.has( 'color_label' ) ? this.model.get( 'color_label' ) : panelsOptions.row_color.default;
 		var rowLabel = this.model.has( 'label' ) ? this.model.get( 'label' ) : '';
-		this.$el.data( 'view', this );
 
 		// Migrate legacy row color labels.
 		if ( typeof rowColorLabel == 'number' && typeof panelsOptions.row_color.migrations[ rowColorLabel ] == 'string' ) {
@@ -61,6 +60,7 @@ module.exports = Backbone.View.extend( {
 			rowColorLabel: rowColorLabel,
 			rowLabel: rowLabel
 		} ) );
+		this.$el.data( 'view', this );
 
 		// Create views for the cells in this row
 		var thisView = this;


### PR DESCRIPTION
This PR will resolve an issue with rows being reordered without contents being changed. To replicate, open an existing multi-row page and re-order one of the rows. Save. The re-ordering won't be retained on save. Switch to this PR and make the same reorder attempt and it will be.