### PR TITLE
Row Color Adjustments

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -251,8 +251,8 @@
 						clear: both;
 						display: flex;
 						flex-wrap: wrap;
-						gap: 2px;
-						justify-content: center;
+						gap: 4px;
+						justify-content: space-evenly;
 						padding: 5px;
 
 						.so-row-color {

--- a/css/admin.less
+++ b/css/admin.less
@@ -250,8 +250,9 @@
 					ul li.so-row-colors-container {
 						clear: both;
 						display: flex;
-						justify-content: space-around;
-
+						flex-wrap: wrap;
+						gap: 2px;
+						justify-content: center;
 						padding: 5px;
 
 						.so-row-color {

--- a/css/admin.less
+++ b/css/admin.less
@@ -362,6 +362,10 @@
 						.transition(0.25s, background, ease-in-out);
 					}
 
+					&.cell-selected .cell-wrapper {
+						background: #a4cadd;
+
+					}
 					.so-live-editor-builder &.so-show-icon .widgets-container .so-widget:hover,
 					&.so-show-icon.so-small-actions .widgets-container .so-widget:hover {
 						.so-widget-wrapper {
@@ -630,6 +634,10 @@
 						height: 100%;
 
 						.transition(0.25s, background, ease-in-out);
+
+						&:hover {
+							background: #dcebf2;
+						}
 					}
 
 					&:first-child {


### PR DESCRIPTION
This PR will allow row colors to wrap and centers them.
![Screenshot 2022-11-09 at 16-06-33 Edit Page ‹ SO — WordPress](https://user-images.githubusercontent.com/17275120/200862141-d65174e6-cd4b-41bb-967e-6d6add59406a.png)

It also sets the default active color for rows and hover color for cell dividers.

This PR will require a build.