### PR TITLE
Alter `siteorigin_panels_url` to Better Allow Different Directory Names

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -102,5 +102,5 @@ function siteorigin_panels_activate(){
  * @return string Base URL of the widget, with $path appended.
  */
 function siteorigin_panels_url( $path = '' ) {
-	return plugins_url( 'siteorigin-panels/' . $path );
+	return plugins_url( $path, SITEORIGIN_PANELS_BASE_FILE );
 }


### PR DESCRIPTION
This PR will better allow for a non-standard directory for Page Builder plugin files to be stored in. To test this PR, switch to this branch and then rename the `siteorigin-panels` plugin directory to something else. Confirm Page Builder works as expected.