### PR TITLE
Darken Default Cell Background

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -354,7 +354,7 @@
 					}
 
 					.cell-wrapper{
-						background: #e4eff4;
+						background: #cde2ec;
 						padding: 7px 7px 1px 7px;
 						height: 100%;
 						min-height: 63px;


### PR DESCRIPTION
This PR changes the default cell background from `#e4eff4` vs `#cde2ec`. This is mainly used when no other cell backgrounds are available and as a default.

A build is required to test this PR.