### PR TITLE
Add Custom Style Field Type Support

### DIFF
--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -389,6 +389,20 @@ class SiteOrigin_Panels_Styles_Admin {
 
 				<?php
 				break;
+			default:
+				// No standard style fields used. See if there's a custom one set.
+				$custom_style_field = apply_filters( 'siteorigin_panels_style_field_'. $field['type'],
+					$field,
+					$field_name,
+					$current,
+					$field_id
+				);
+
+				if ( ! empty( $custom_style_field ) ) {
+					echo $custom_style_field;
+				}
+
+				break;
 		}
 
 		echo '</div>';
@@ -539,8 +553,23 @@ class SiteOrigin_Panels_Styles_Admin {
 						$return = $return + $this->sanitize_style_fields( $k, $styles, $field['fields'] );
 					}
 				default:
-					// Just pass the value through.
-					$return[ $k ] = $styles[ $k ];
+					// No standard style fields used. See if there's a custom one set.
+					$custom_style_sanitized_data = apply_filters(
+						'siteorigin_panels_style_field_sanitize_'. $field['type'],
+						$styles[ $k ],
+						$k,
+						$field,
+						$styles,
+						$sub_field
+					);
+
+					if ( ! empty( $custom_style_sanitized_data ) ) {
+						$return[ $k ] = $custom_style_sanitized_data;
+					} else {
+						// Just pass the value through.
+						$return[ $k ] = $styles[ $k ];
+					}
+
 					break;
 
 			}


### PR DESCRIPTION
This PR allows developers to add custom Style field types via two filters. `siteorigin_panels_style_field_` and `siteorigin_panels_style_field_sanitize_`. Both of these fields require the field type to be appended to the filter name. For example, if your custom style field type was called example, these fields would look like this:

- `siteorigin_panels_style_field_example`
- `siteorigin_panels_style_field_sanitize_example`

Here's a test snippet that:

- Adds a field to the Design setting group called `Test Custom Field`.
- If a number is input, it'll double it.

This is a very rough example of these filters rather than an actual useful example.

```
<?php
add_filter( 'siteorigin_panels_general_style_fields', function( $fields, $post_id, $args ) ) {
	$fields['test_custom_field'] = array(
		'name' => __( 'Test Custom Field', 'siteorigin-premium' ),
		'type' => 'test_field',
		'group' => 'design',
		'priority' => 9,
	);

	return $fields;
}, 10, 3 );

add_filter( 'siteorigin_panels_style_field_test_field', function( $field, $field_name, $current, $field_id ) {
	?>
	<input
		type="number"
		name="<?php echo esc_attr( $field_name ); ?>"
		value="<?php echo esc_attr( $current ); ?>"
		class="widefat"
	/>

	<br>
	<smal>
		(test field)
	</smal>
	<?php
}, 10, 4 );

add_filter( 'siteorigin_panels_style_field_sanitize_test_field', function( $field_data, $field_key, $field, $styles, $sub_field ) {
	if ( is_numeric( $field_data ) ) {
		// Double input field as a basic example.
		$field_data *= 2;
	}

	return $field_data;
}, 10, 5 );

```