### PR TITLE
Styles: Trigger Background Visibility Checks After Clicking Remove

### DIFF
--- a/js/siteorigin-panels/view/styles.js
+++ b/js/siteorigin-panels/view/styles.js
@@ -359,6 +359,7 @@ module.exports = Backbone.View.extend( {
 			}
 			soBackgroundImageVisibility();
 			$background_image.find( '[name="style[background_image_attachment]"], [name="style[background_image_attachment_fallback]"]' ).on( 'change', soBackgroundImageVisibility );
+			$background_image.find( '.remove-image' ).on( 'click', soBackgroundImageVisibility );
 		}
 
 		// Conditionally show Border related settings.


### PR DESCRIPTION
This PR will trigger the Background Image conditional JS checks when you click Remove. Prior to this only adding and altering the external URL field would trigger it.

![2022-12-12_03-30-36-1738](https://user-images.githubusercontent.com/17275120/206909615-c6909bd5-3b53-49ec-a76d-e6fbd5986d88.jpg)