### PR TITLE
Layouts Directory: Allow Layout To Have "0" As Name

### DIFF
--- a/inc/admin-layouts.php
+++ b/inc/admin-layouts.php
@@ -337,7 +337,8 @@ class SiteOrigin_Panels_Admin_Layouts {
 		if ( empty( $_REQUEST['type'] ) ) {
 			wp_die();
 		}
-		if ( empty( $_REQUEST['lid'] ) ) {
+
+		if ( ! isset( $_REQUEST['lid'] ) || ! is_numeric( $_REQUEST['lid'] ) ) {
 			wp_die();
 		}
 		if ( empty( $_REQUEST['_panelsnonce'] ) || ! wp_verify_nonce( $_REQUEST['_panelsnonce'], 'panels_action' ) ) {
@@ -350,9 +351,8 @@ class SiteOrigin_Panels_Admin_Layouts {
 		
 		if ( $_REQUEST['type'] == 'prebuilt' ) {
 			$layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
-			$lid = ! empty( $_REQUEST['lid'] ) ? $_REQUEST['lid'] : false;
-			
-			if ( empty( $lid ) || empty( $layouts[ $lid ] ) ) {
+
+			if ( ! is_numeric( $lid ) || empty( $layouts[ $lid ] ) ) {
 				wp_send_json_error( array(
 					'error'   => true,
 					'message' => __( 'Missing layout ID or no such layout exists', 'siteorigin-panels' ),
@@ -374,7 +374,7 @@ class SiteOrigin_Panels_Admin_Layouts {
 			}
 			
 			// A theme or plugin could use this to change the data in the layout
-			$panels_data = apply_filters( 'siteorigin_panels_prebuilt_layout', $layout, $lid );
+			$panels_data = apply_filters( 'siteorigin_panels_prebuilt_layout', $layout, $_REQUEST['lid'] );
 			
 			// Remove all the layout specific attributes
 			if ( isset( $panels_data['name'] ) ) unset( $panels_data['name'] );

--- a/inc/admin-layouts.php
+++ b/inc/admin-layouts.php
@@ -338,7 +338,8 @@ class SiteOrigin_Panels_Admin_Layouts {
 			wp_die();
 		}
 
-		if ( ! isset( $_REQUEST['lid'] ) || ! is_numeric( $_REQUEST['lid'] ) ) {
+
+		if ( ! isset( $_REQUEST['lid'] ) ) {
 			wp_die();
 		}
 		if ( empty( $_REQUEST['_panelsnonce'] ) || ! wp_verify_nonce( $_REQUEST['_panelsnonce'], 'panels_action' ) ) {

--- a/inc/admin-layouts.php
+++ b/inc/admin-layouts.php
@@ -338,10 +338,10 @@ class SiteOrigin_Panels_Admin_Layouts {
 			wp_die();
 		}
 
-
 		if ( ! isset( $_REQUEST['lid'] ) ) {
 			wp_die();
 		}
+
 		if ( empty( $_REQUEST['_panelsnonce'] ) || ! wp_verify_nonce( $_REQUEST['_panelsnonce'], 'panels_action' ) ) {
 			wp_die();
 		}


### PR DESCRIPTION
[Reported here](https://siteorigin.com/thread/sorting-prebuilt-layouts-results-into-js-error-when-importing-the-1st-shown/).

You can test this PR by using [this test plugin](https://github.com/siteorigin/siteorigin-panels/files/10295715/so-layout-test.zip). Install the plugin, try to import the layout with called 0 and it'll fail. Switch to this PR, load the browser tab and try again and it'll succeed.