### PR TITLE
Classic Editor: Prevent Potential Notice When Opening Saved Widget

### DIFF
--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -11,6 +11,7 @@ module.exports = Backbone.View.extend( {
 	dataField: false,
 	currentData: '',
 	contentPreview: '',
+	initialContentPreviewSetup: false,
 
 	attachedToEditor: false,
 	attachedVisible: false,
@@ -785,12 +786,17 @@ module.exports = Backbone.View.extend( {
 					},
 					function ( content ) {
 						// Post content doesn't need to be generated on load while contentPreview does.
-						if ( this.contentPreview && content.post_content !== '' ) {
+						if (
+							this.contentPreview &&
+							content.post_content !== '' &&
+							this.initialContentPreviewSetup
+						) {
 							this.updateEditorContent( content.post_content );
 						}
 
 						if ( content.preview !== '' ) {
 							this.contentPreview = content.preview;
+							this.initialContentPreviewSetup = true;
 						}
 					}.bind( this )
 				);


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/1022

This PR will prevent a situation where Page Builder will update its data input and that'll get picked up by WP. This can result in a "are you sure you want to navigate away" notice.

To test this PR please create a build. Add an Archives widget to a Classic Editor powered page and then save. Open the Archives widget and then navigate away. A prompt _may_ occur. If it doesn't, the issue didn't occur - it's really random. If it did occur, switch to the build of this PR and try to replicate it again. It shouldn't occur again.

If you're unable to replicate this prompt, navigate away and make a few row and widget edits, and then save. Confirm data is saving as expected.