### PR TITLE
Renderer: Prevent `$layout_data` Loading If Already Set PROPER

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -469,9 +469,11 @@ class SiteOrigin_Panels_Renderer {
 		if ( $is_preview ) {
 			$GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] = true;
 		}
-		
-		$layout_data = $this->get_panels_layout_data( $panels_data );
-		$layout_data = apply_filters( 'siteorigin_panels_layout_data', $layout_data, $post_id );
+
+		if ( empty( $layout_data ) ) {
+			$layout_data = $this->get_panels_layout_data( $panels_data );
+			$layout_data = apply_filters( 'siteorigin_panels_layout_data', $layout_data, $post_id );
+		}
 
 		ob_start();
 


### PR DESCRIPTION
This PR will allow for [$layout_data](https://github.com/siteorigin/siteorigin-panels/blame/develop/inc/renderer.php#L415) to be passed to render() and be used. Previously, it would always be overridden (which isn't correct). This is a developer centric change.