### PR TITLE
Add `siteorigin_panels_add_preview_content`

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -206,7 +206,7 @@ class SiteOrigin_Panels_Admin {
 	function render_meta_boxes( $post ) {
 		$panels_data = $this->get_current_admin_panels_data();
 		$preview_url = SiteOrigin_Panels::preview_url();
-		$preview_content = siteorigin_panels_setting( 'copy-content' ) ? $this->generate_panels_preview( $post->ID, $panels_data ) : '';
+		$preview_content = apply_filters( 'siteorigin_panels_add_preview_content', true ) ? $this->generate_panels_preview( $post->ID, $panels_data ) : '';
 		$builder_id = uniqid();
 		$builder_type = apply_filters( 'siteorigin_panels_post_builder_type', 'editor_attached', $post, $panels_data );
 		$builder_supports = apply_filters( 'siteorigin_panels_builder_supports', array(), $post, $panels_data );

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -206,7 +206,7 @@ class SiteOrigin_Panels_Admin {
 	function render_meta_boxes( $post ) {
 		$panels_data = $this->get_current_admin_panels_data();
 		$preview_url = SiteOrigin_Panels::preview_url();
-		$preview_content = $this->generate_panels_preview( $post->ID, $panels_data );
+		$preview_content = siteorigin_panels_setting( 'copy-content' ) ? $this->generate_panels_preview( $post->ID, $panels_data ) : '';
 		$builder_id = uniqid();
 		$builder_type = apply_filters( 'siteorigin_panels_post_builder_type', 'editor_attached', $post, $panels_data );
 		$builder_supports = apply_filters( 'siteorigin_panels_builder_supports', array(), $post, $panels_data );

--- a/tpl/metabox-panels.php
+++ b/tpl/metabox-panels.php
@@ -1,7 +1,9 @@
 <div id="siteorigin-panels-metabox"
 	data-builder-type="<?php echo esc_attr( $builder_type ) ?>"
 	data-preview-url="<?php echo $preview_url; ?>"
-	data-preview-markup="<?php echo esc_attr( json_encode( $preview_content ) ); ?>"
+	<?php if ( ! empty( $preview_content ) ) { ?>
+		data-preview-markup="<?php echo esc_attr( json_encode( $preview_content ) ); ?>"
+	<?php } ?>
 	data-builder-supports="<?php echo esc_attr( json_encode( $builder_supports ) ) ?>"
 	<?php if ( ! empty( $_GET['so_live_editor'] ) ) : ?>
 	data-live-editor="1"


### PR DESCRIPTION
This PR adds a filter that allows users to prevent Page Builder from populating the preview content attribute with the metabox (Classic Editor). This is done for users who have especially large pages and would prefer not to generate a version of the page on page load, or if they don't need it.

Test filter:

`add_filter( 'siteorigin_panels_add_preview_content', '__return_false' );`

To verify it's working as expected, open a Classic Editor powered page with Page Builder enabled and search for: `#siteorigin-panels-metabox` the `data-preview-markup` attribute should be removed.
