### PR TITLE
Exclude Certain WooCommerce Post Types From Page Builder Types List

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -754,6 +754,8 @@ class SiteOrigin_Panels_Settings {
 
 		// These are post types we know we don't want to show Page Builder on.
 		unset( $types['ml-slider'] );
+		unset( $types['shop_coupon'] );
+		unset( $types['shop_order'] );
 
 		foreach ( $types as $type_id => $type ) {
 			$type_object = get_post_type_object( $type_id );


### PR DESCRIPTION
These do not have a content section so page builder won't work wtih them.