### PR TITLE
Rank Math: Add Image Intergration With Sitemap

### DIFF
--- a/compat/rank-math.php
+++ b/compat/rank-math.php
@@ -1,0 +1,15 @@
+<?php
+function siteorigin_rank_math_sitemap( $content, $post_id ) {
+	$panels_data = get_post_meta( $post_id, 'panels_data', true );
+	if ( ! empty( $panels_data ) ) {
+		$GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] = true;
+		$content = SiteOrigin_Panels::renderer()->render( (int) $post_id, false, $panels_data );
+		if ( function_exists( 'wp_targeted_link_rel' ) && is_array( $return ) ) {
+			$content = wp_targeted_link_rel( $return );
+		}
+		unset( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] );
+	}
+
+	return $content;
+}
+add_filter( 'rank_math/sitemap/content_before_parse_html_images', 'siteorigin_rank_math_sitemap', 10, 2 );

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -210,6 +210,11 @@ class SiteOrigin_Panels {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/yoast.php';
 		}
 
+		// Compatibility with Rank Math.
+		if ( class_exists( 'RankMath' ) ) {
+			require_once plugin_dir_path( __FILE__ ) . 'compat/rank-math.php';
+		}
+
 		// Compatibility with AMP plugin.
 		if ( is_admin() && function_exists( 'amp_bootstrap_plugin' ) ) {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/amp.php';


### PR DESCRIPTION
Requires https://github.com/siteorigin/so-widgets-bundle/pull/1716

This PR adds image detection for the Rank Math sitemap. Rank Math caches its sitemap pretty heavily so the best way of testing this is to bypass it. This can be done with the following snippet:

`add_filter( 'rank_math/sitemap/enable_caching', '__return_false' );`