### PR TITLE
Inline Styles: Pass `$panels_data` for Widget Bottom Margin

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -709,7 +709,7 @@ class SiteOrigin_Panels_Renderer {
 		);
 
 		if ( siteorigin_panels_setting( 'inline-styles' ) && ! $is_last ) {
-			$widget_bottom_margin = apply_filters( 'siteorigin_panels_css_cell_margin_bottom', siteorigin_panels_setting('margin-bottom') . 'px', false, false, $panels_data, $post_id );
+			$widget_bottom_margin = apply_filters( 'siteorigin_panels_css_cell_margin_bottom', siteorigin_panels_setting('margin-bottom') . 'px', false, false, array(), $post_id );
 			if ( ! empty( $widget_bottom_margin ) ) {
 				$attributes['style'] = 'margin-bottom: ' . $widget_bottom_margin;
 			}


### PR DESCRIPTION
`Warning: Undefined variable $panels_data in /home/forge/demo.siteorigin.com/public/wp-content/plugins/siteorigin-panels/inc/renderer.php on line 712`