### PR TITLE
Prevent Potential Error When Creating New Pages That Prevents PB From Showing

### DIFF
--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -81,7 +81,10 @@ module.exports = Backbone.View.extend( {
 		$panelsMetabox = $( '#siteorigin-panels-metabox' );
 		if ( $panelsMetabox.length ) {
 			var previewContent = $.parseHTML( $panelsMetabox.data( 'preview-markup' ) );
-			this.contentPreview = previewContent.length > 1 ? previewContent[1] : previewContent;
+
+			if ( previewContent !== null ) {
+				this.contentPreview = previewContent.length > 1 ? previewContent[1] : previewContent;
+			}
 		}
 
 		// Set the builder for each dialog and render it.


### PR DESCRIPTION
This PR prevents the following notice that prevents PB from showing when creating pages on certain websites:

`TypeError: null is not an object (evaluating 'i.length')`

I say certain websites because I haven't been able to replicate this issue locally and haven't received many reports so the specific circumstances for it to occur beyond a new page is unclear.