### PR TITLE
Only Apply !important To Inline Styles Padding

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -185,7 +185,7 @@ class SiteOrigin_Panels_Renderer {
 							$wi,
 							'',
 							array(
-								'margin' => $panels_mobile_widget_mobile_margin . ' !important',
+								'margin' => $panels_mobile_widget_mobile_margin . ( siteorigin_panels_setting( 'inline-styles' ) ? ' !important' : '' ),
 							),
 							$panels_mobile_width,
 							true

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -821,7 +821,7 @@ class SiteOrigin_Panels_Styles {
 	 */
 	public static function general_style_tablet_css( $css, $style ) {
 		if ( ! empty( $style['tablet_padding'] ) ) {
-			$css['padding'] = $style['tablet_padding'] . ' !important';
+			$css['padding'] = $style['tablet_padding'] . siteorigin_panels_setting( 'inline-styles' ) ? ' !important' : '';
 		}
 
 		if (
@@ -842,7 +842,7 @@ class SiteOrigin_Panels_Styles {
 	 */
 	public static function general_style_mobile_css( $css, $style ) {
 		if ( ! empty( $style['mobile_padding'] ) ) {
-			$css['padding'] = $style['mobile_padding'] . ' !important';
+			$css['padding'] = $style['mobile_padding'] . siteorigin_panels_setting( 'inline-styles' ) ? ' !important' : '';
 		}
 
 		if ( ! empty( $style['background_display'] ) &&


### PR DESCRIPTION
This will prevent a situation where applied padding can unintentionally have `!important` applied on tablets and mobiles.