### PR TITLE
Classic: Further SEO Compatibility Changes On Load

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -203,11 +203,7 @@ class SiteOrigin_Panels_Admin {
 		$preview_url = SiteOrigin_Panels::preview_url();
 		
 		if ( apply_filters( 'siteorigin_panels_add_preview_content', true ) ) {
-			SiteOrigin_Panels_Post_Content_Filters::add_filters();
-			$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-			$preview_content = SiteOrigin_Panels::renderer()->render( (int) $post->ID, false, wp_unslash( $panels_data ) );
-			SiteOrigin_Panels_Post_Content_Filters::remove_filters();
-			unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
+			$preview_content = apply_filters( 'siteorigin_panels_add_preview_content', true ) ? $this->generate_panels_preview( $post->ID, $panels_data ) : '';
 		}
 
 		$builder_id = uniqid();

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -78,13 +78,9 @@ module.exports = Backbone.View.extend( {
 
 		
 		// Check if we have preview markup available.
-		$panelsMetabox = $( '#siteorigin-panels-metabox' );
-		if ( $panelsMetabox.length ) {
-			var previewContent = $.parseHTML( $panelsMetabox.data( 'preview-markup' ) );
-
-			if ( previewContent !== null ) {
-				this.contentPreview = previewContent.length > 1 ? previewContent[1] : previewContent;
-			}
+		$previewContent = $( '.siteorigin-panels-preview-content' );
+		if ( $previewContent.length ) {
+			this.contentPreview = $previewContent.val();
 		}
 
 		// Set the builder for each dialog and render it.

--- a/tpl/metabox-panels.php
+++ b/tpl/metabox-panels.php
@@ -2,9 +2,6 @@
 	data-builder-type="<?php echo esc_attr( $builder_type ); ?>"
 	data-preview-url="<?php echo $preview_url; ?>"
 	data-builder-supports="<?php echo esc_attr( json_encode( $builder_supports ) ); ?>"
-	<?php if ( ! empty( $preview_content ) ) { ?>
-		data-preview-markup="<?php echo esc_attr( json_encode( wp_unslash( $preview_content ) ) ); ?>"
-	<?php } ?>
 	<?php if ( ! empty( $_GET['so_live_editor'] ) ) { ?>
 		data-live-editor="1"
 		data-live-editor-close="<?php echo siteorigin_panels_setting( 'live-editor-quick-link' ); ?>"
@@ -23,3 +20,7 @@
 
 	<?php do_action( 'siteorigin_panels_metabox_end' ); ?>
 </div>
+
+<?php if ( ! empty( $preview_content ) ) { ?>
+	<textarea class="siteorigin-panels-preview-content" style="display: none;"><?php echo esc_textarea( $preview_content ); ?></textarea>
+<?php } ?>


### PR DESCRIPTION
This proves to be more reliable with Rank Math. Moving the preview content isn't a ideal, but it results prevents a potential situation where HTML will be passed to Rank Math (something it cannot process so it'll error) instead of a string.

To test this PR, please open the Classic Editor with Rank Math installed and a layout with some text present:

- Reload 5 times and ensure the score updates after Page Builder finishes loading. (there was previously a chance it could fail on load).
- The score remains the same after making a change and then reverting the change.