### PR TITLE
Inline Styles: Restore Tablet and Mobile Padding

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -815,7 +815,7 @@ class SiteOrigin_Panels_Styles {
 	 */
 	public static function general_style_tablet_css( $css, $style ) {
 		if ( ! empty( $style['tablet_padding'] ) ) {
-			$css['padding'] = $style['tablet_padding'] . siteorigin_panels_setting( 'inline-styles' ) ? ' !important' : '';
+			$css['padding'] = $style['tablet_padding'] . ( siteorigin_panels_setting( 'inline-styles' ) ? ' !important' : '' );
 		}
 
 		if (
@@ -836,7 +836,7 @@ class SiteOrigin_Panels_Styles {
 	 */
 	public static function general_style_mobile_css( $css, $style ) {
 		if ( ! empty( $style['mobile_padding'] ) ) {
-			$css['padding'] = $style['mobile_padding'] . siteorigin_panels_setting( 'inline-styles' ) ? ' !important' : '';
+			$css['padding'] = $style['mobile_padding'] . ( siteorigin_panels_setting( 'inline-styles' ) ? ' !important' : '' );
 		}
 
 		if ( ! empty( $style['background_display'] ) &&


### PR DESCRIPTION
This PR will resolve an issue introduced in 2.22.0 that resulted in mobile and tablet padding not always applying. Related to the following:

> Styles: Prevented !important from being added to tablet and mobile padding.