### PR TITLE
Widget Title Fixes

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -492,9 +492,9 @@
 									font-size: 12px;
 									position: absolute;
 									top: 5px;
-									right: 7px;
+									right: 0;
 									cursor: pointer;
-									padding: 2px 2px 2px 15px;
+									padding: 2px 8px 2px 15px;
 									z-index: 10;
 
 									&:hover a {


### PR DESCRIPTION
This PR makes some adjustments to custom Widget titles. This PR requires a build.

To test this:
- Add an extremely long widget title, and you'll notice that the widget title can wrap resulting in it not being visible at all. (may require you to reopen modal).
- The long widget title can appear below actions when hovering on the widget.