### PR TITLE
Improve UI for border-radius field.

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -2163,7 +2163,21 @@
 				width: 72%;
 			}
 		}
-
+		.so-field-border_radius .style-field-measurement .measurement-value {
+			&.measurement-top {
+				box-shadow: inset 2px 2px 1px rgba(0, 115, 170, .35);
+			}
+			&.measurement-right {
+				box-shadow: inset -2px 2px 1px rgba(0, 115, 170, .35);
+			}
+			&.measurement-bottom {
+				box-shadow: inset -2px -2px 1px rgba(0, 115, 170, .35);
+			}
+			&.measurement-left {
+				box-shadow: inset 2px -2px 2px rgba(0, 115, 170, .35);
+			}			
+		}
+		
 		.style-field-image {
 
 			@image_field_height: 28px;


### PR DESCRIPTION
Improve UI for border-radius field.

Just a small update for border radius field. This helps users to identify the border which they are changing by redesigning the shadows used in the measurement field. The css only affects the border-radius field.

![image](https://github.com/siteorigin/siteorigin-panels/assets/10053621/4227e117-2977-4ea1-8a0d-10bcdce48812)
