### PR TITLE
Add `Block Editor Layout Block Quick Add Button` Setting

### DIFF
--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -68,7 +68,10 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 					'postId' => get_the_ID(),
 					'liveEditor' => SiteOrigin_Panels::preview_url(),
 					'defaultMode' => siteorigin_panels_setting( 'layout-block-default-mode' ),
-					'showAddButton' => apply_filters( 'siteorigin_layout_block_show_add_button', $is_panels_post_type ),
+					'showAddButton' => apply_filters(
+						'siteorigin_layout_block_show_add_button',
+						$is_panels_post_type && siteorigin_panels_setting( 'layout-block-quick-add' )
+					),
 				)
 			);
 			// This is only available in WP5.

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -154,6 +154,7 @@ class SiteOrigin_Panels_Settings {
 		$defaults['parallax-scale']                     = 1.2;
 		$defaults['sidebars-emulator']                  = true;
 		$defaults['layout-block-default-mode']          = 'preview';
+		$defaults['layout-block-quick-add']             = true;
 
 		// Widgets fields.
 		$defaults['title-html']           = '<h3 class="widget-title">{{title}}</h3>';
@@ -380,6 +381,12 @@ class SiteOrigin_Panels_Settings {
 				'preview' => __( 'Preview', 'siteorigin-panels' ),
 			),
 			'description' => __( 'Whether to display SiteOrigin Layout Blocks in edit mode or preview mode in the Block Editor.', 'siteorigin-panels' ),
+		);
+
+		$fields['general']['fields']['layout-block-quick-add'] = array(
+			'type'        => 'checkbox',
+			'label'       => __( 'Block Editor Layout Block Quick Add Button', 'siteorigin-panels' ),
+			'description' => __( 'Display the Add SiteOrigin Layout Block quick add button in the Block Editor.', 'siteorigin-panels' ),
 		);
 
 		// Widgets settings.


### PR DESCRIPTION
This PR will add a global setting that will allow users to disable the Quick Add Button in the Block Editor. It does this while retaining the existing functionality of the `siteorigin_layout_block_show_add_button` filter.