### PR TITLE
Row Layouts: Resolve Sizing Issues

### DIFF
--- a/js/styling.js
+++ b/js/styling.js
@@ -22,9 +22,15 @@ jQuery( function ( $ ) {
 			$$.css( {
 				'margin-left': 0,
 				'margin-right': 0,
-				'padding-left': defaultSidePadding,
-				'padding-right': defaultSidePadding
 			} );
+
+			// Reset row padding to prevent potential offset.
+			if ( stretchType !== 'full-stretched-padded' ) {
+				$$.css( {
+					'padding-left': defaultSidePadding,
+					'padding-right': defaultSidePadding
+				} );
+			}
 
 			var leftSpace = $$.offset().left - fullContainer.offset().left,
 				rightSpace = fullContainer.outerWidth() - leftSpace - $$.parent().outerWidth();
@@ -32,9 +38,15 @@ jQuery( function ( $ ) {
 			$$.css( {
 				'margin-left': - leftSpace + 'px',
 				'margin-right': - rightSpace + 'px',
-				'padding-left': stretchType === 'full' ? leftSpace + 'px' : defaultSidePadding,
-				'padding-right': stretchType === 'full' ? rightSpace + 'px': defaultSidePadding
 			} );
+
+			// If Row Layout is Full Width, apply content container.
+			if ( stretchType === 'full' ) {
+				$$.css( {
+					'padding-left': leftSpace + 'px',
+					'padding-right': rightSpace + 'px'
+				} );
+			}
 
 			var cells = $$.find( '> .panel-grid-cell' );
 


### PR DESCRIPTION
This PR contains two core changes:

[Row Layouts: Trigger Resize On Load](https://github.com/siteorigin/siteorigin-panels/commit/72758dffdae0c197fa9a7355ac07367b7951c6ba) which should avoid a situation where the `body` width is incorrect on load.

[Row Layouts: Only Remove Padding As Needed](https://github.com/siteorigin/siteorigin-panels/commit/cf0b056895aae50ccac453118d6bb85b7a8e2094) which will prevent a situation where the Full Width Stretched Padded Layout can end up without padding.