### PR TITLE
ACF Check: Add Support For Multiple Options

### DIFF
--- a/compat/acf-widgets.php
+++ b/compat/acf-widgets.php
@@ -72,7 +72,10 @@ class SiteOrigin_Panels_Compat_ACF_Widgets {
 
 		if ( ! empty( $fields ) ) {
 			foreach ( $fields->data as $field ) {
-				if ( $widget_field['type'] != 'repeater' ) {
+				if (
+					$widget_field['type'] != 'repeater' ||
+					$widget_field['type'] != 'checkbox'
+				) {
 					if (
 						$field['key'] == $widget_field['key'] &&
 						! empty( $instance->data[ $field['key'] ] )

--- a/js/siteorigin-panels/view/dialog.js
+++ b/js/siteorigin-panels/view/dialog.js
@@ -539,7 +539,10 @@ module.exports = Backbone.View.extend( {
 				}
 
 				// Is this field an ACF Repeater?
-				if ( $$.parents( '.acf-repeater' ).length ) {
+				if (
+					$$.parents( '.acf-repeater' ).length ||
+					$$.parents( '.acf-field-checkbox' ).length
+				) {
 					// If field is empty, skip it - this is to avoid indexes which are admin only.
 					if ( fieldValue == '' ) {
 						return;


### PR DESCRIPTION
To test this PR add a checkbox field to any widget using ACF and add multiple options. Prior to this PR, you would end up with the widgets data not saving while after this PR it will.