### PR TITLE
Resolve SiteOrigin Installer Saving Issue

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -738,7 +738,7 @@ class SiteOrigin_Panels_Settings {
 		$values[ 'mobile-width' ] = max( $values[ 'mobile-width' ], 320 );
 
 		if ( isset( $values['installer'] ) ) {
-			update_option( 'siteorigin_installer', rest_sanitize_boolean( $values['installer'] ) );
+			update_option( 'siteorigin_installer', (string) rest_sanitize_boolean( $values['installer'] ) );
 			unset( $values['installer'] );
 		}
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/1076

This will resolve an issue that can occur with the installer setting not saving on certain versions of PHP.