### PR TITLE
Inline Styles: Resolve Unexpected Widget Margin If Custom Margin Set

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -701,7 +701,7 @@ class SiteOrigin_Panels_Renderer {
 			$after_title = '</h3>';
 		}
 
-		// Attributes of the widget wrapper
+		// Attributes of the widget wrapper.
 		$attributes = array(
 			'id'         => $id,
 			'class'      => implode( ' ', $classes ),
@@ -709,7 +709,14 @@ class SiteOrigin_Panels_Renderer {
 		);
 
 		if ( siteorigin_panels_setting( 'inline-styles' ) && ! $is_last ) {
-			$widget_bottom_margin = apply_filters( 'siteorigin_panels_css_cell_margin_bottom', siteorigin_panels_setting('margin-bottom') . 'px', false, false, array(), $post_id );
+			$widget_bottom_margin = apply_filters(
+				'siteorigin_panels_css_cell_margin_bottom',
+				( empty( $widget_info['style']['margin'] ) ? siteorigin_panels_setting('margin-bottom') : 0 ) . 'px',
+				false,
+				false,
+				array(),
+				$post_id
+			);
 			if ( ! empty( $widget_bottom_margin ) ) {
 				$attributes['style'] = 'margin-bottom: ' . $widget_bottom_margin;
 			}


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/1079

To test this PR please import the Link Bio layout and then save. View the page and then view the page again with Inline Styles enabled/disabled. You'll notice the spacing after the image is different when Inline Styles is active. This PR fixes this unexpected additional spacing.