### PR TITLE
Styles: Remove Color Picker WP Spacing

### DIFF
--- a/compat/acf-widgets.php
+++ b/compat/acf-widgets.php
@@ -98,7 +98,7 @@ class SiteOrigin_Panels_Compat_ACF_Widgets {
 		if ( is_array( $fields ) ) {
 			foreach ( $fields as $field_id => $field ) {
 				// If it's a cloneindex, or empty, don't keep it.
-				if ( $field_id === 'acfcloneindex' || empty( $field ) ) {
+				if ( $field_id == 'acfcloneindex' || empty( $field ) ) {
 					unset( $fields[ $field_id ] );
 					continue;
 				}


### PR DESCRIPTION
This PR will remove 6px of extra spacing added to each color picker by WP. This will allow the spacing between settings to be more uniform.

This PR requires a build.