### PR TITLE
ACF: Allow Fields That Store Arrays To Have `0` Index

### DIFF
--- a/compat/acf-widgets.php
+++ b/compat/acf-widgets.php
@@ -98,7 +98,13 @@ class SiteOrigin_Panels_Compat_ACF_Widgets {
 		if ( is_array( $fields ) ) {
 			foreach ( $fields as $field_id => $field ) {
 				// If it's a cloneindex, or empty, don't keep it.
-				if ( $field_id == 'acfcloneindex' || empty( $field ) ) {
+				if (
+					$field_id === 'acfcloneindex' ||
+					(
+						$field_id !== 0 &&
+						empty( $field )
+					)
+				) {
 					unset( $fields[ $field_id ] );
 					continue;
 				}


### PR DESCRIPTION
This PR is a follow-up to https://github.com/siteorigin/siteorigin-panels/pull/1075 but it affects all ACF fields that allow for array values without an array index. If ACF doesn't allow for an array index or the user doesn't set one), then ACF will use a numerical index and that could previously result in the value being skipped. Now that won't happen.