### PR TITLE
Styles Filter Adjustments

### DIFF
--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -425,7 +425,8 @@ class SiteOrigin_Panels_Styles_Admin {
 					$field,
 					$field_name,
 					$current,
-					$field_id
+					$field_id,
+					$current_styles
 				);
 
 				if ( ! empty( $custom_style_field ) ) {


### PR DESCRIPTION
This PR does two things:

- Adds the Add siteorigin_panels_style_field_sanitize_all_FIELD_TYPE Filter.
This filter will allow developers to sanitize all styles after the base `siteorigin_panels_style_field_sanitize_FIELD_TYPE` has been run. It's useful for allowing things like the media field's fallback field.

- Passes `$current_styles` to `siteorigin_panels_style_field_FIELD_TYPE` filter. 
This will allow developers to adjust the value for this field based on other styles. For information on how this filter works in general, please refer to https://github.com/siteorigin/siteorigin-panels/pull/1027. While it doesn't use this new parameter it outlines the filter as a whole.