### PR TITLE
Layout Directory: Check for WP Error Before Processing Request

### DIFF
--- a/inc/admin-layouts.php
+++ b/inc/admin-layouts.php
@@ -265,7 +265,8 @@ class SiteOrigin_Panels_Admin_Layouts {
 
 			if (
 				! is_wp_error( $response ) &&
-				is_array( $response ) && $response['response']['code'] == 200
+				is_array( $response ) &&
+				$response['response']['code'] == 200
 			) {
 				$results = json_decode( $response['body'], true );
 


### PR DESCRIPTION
Resolves a potential fatal error:

`[17-Sep-2023 14:27:28 UTC] PHP Fatal error:  Uncaught Error: Cannot use object of type WP_Error as array in \wp-content\plugins\siteorigin-panels\inc\admin-layouts.php:267`