### PR TITLE
Row Cell Ratio: Improve Handling of Greater Number of Sizes

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1637,27 +1637,37 @@
 				}
 
 				.row-cell-column {
-					flex: 1;
+					flex: 2;
 				}
 
 				.cell-resize-container {
 					align-items: center;
 					display: flex;
+					flex: 4;
+					justify-content: end;
 
-					@media (max-width: 700px) {
-						justify-content: center;
-						margin-top: 5px;
+					.cell-resize-label {
+						margin: 0;
+						min-width: 93px;
+						padding: 0;
 					}
 
 					.cell-resize {
+						align-content: center;
+						align-items: end;
 						display: flex;
+						flex-wrap: wrap;
+						gap: 10px;
+						justify-content: end;
+						padding-left: 4px;
 
 						&-sizing {
 							background: #e4eff4;
 							border: 1px solid #8c8f94;
-							display: flex !important;
+							display: inline-flex !important;
 							height: 24px;
-							width: 190px !important;
+							margin: 0;
+							width: 168px !important;
 
 							&.so-active-ratio,
 							&:not(.so-active-ratio):hover {
@@ -1672,16 +1682,31 @@
 							& > span {
 								align-self: center;
 								border-right: 1px solid #bcccd2;
-								display: inline-block  !important;
-								font-size: 10px;
+								display: inline-block !important;
+								font-size: 12px;
 								margin: 0  !important;
+								min-width: 26px;
 								padding: 0 !important;
 								text-align: center;
+								min-width: 25px;
 
 								&:last-of-type {
 									border-right: none;
 								}
 							}
+						}
+					}
+
+					@media (max-width: 1024px) {
+						flex-direction: column;
+
+						.cell-resize {
+							padding-left: 0;
+							justify-content: start;
+						}
+
+						.cell-resize-sizing {
+							width: 47%;
 						}
 					}
 				}

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -333,7 +333,9 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 				</div>
 
 				<div class="cell-resize-container">
-					<?php echo __( 'Resize Columns: ', 'siteorigin-panels' ); ?>
+					<span class="cell-resize-label">
+						<?php echo __( 'Resize Columns: ', 'siteorigin-panels' ); ?>
+					</span>
 					<div class="cell-resize" data-resize="<?php echo esc_js( json_encode( $column_sizes ) ); ?>"></div>
 				</div>
 			</div>


### PR DESCRIPTION
This will improve the overall design of Row Cell Ratios to ensure the cell preview columns cannot overflow/overlap while also increasing the font size of the preview text to improve readability. This PR also improves the handling of more than three sizes.

Before:
![before](https://github.com/siteorigin/siteorigin-panels/assets/17275120/3f99ecaf-1014-4315-b0cc-bcefe53c23ac)

After:
![after](https://github.com/siteorigin/siteorigin-panels/assets/17275120/798186fd-ad52-4969-8d65-d28bcf78a30a)

Before with 6 Sizes:
![before-6](https://github.com/siteorigin/siteorigin-panels/assets/17275120/f0779182-f020-467e-9bd7-482d5e8ccab6)

After with 6 sizes:
![after-6](https://github.com/siteorigin/siteorigin-panels/assets/17275120/82df8a17-4305-4d43-9862-39c36b975780)

