### PR TITLE
Rename Full Width Stretched Padded Setting

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -408,7 +408,7 @@ class SiteOrigin_Panels_Styles {
 				''               => __( 'Standard', 'siteorigin-panels' ),
 				'full'           => __( 'Full Width', 'siteorigin-panels' ),
 				'full-stretched' => __( 'Full Width Stretched', 'siteorigin-panels' ),
-				'full-stretched-padded' => __( 'Full Width Stretched Padded', 'siteorigin-panels' ),
+				'full-stretched-padded' => __( 'Full Width Stretched With Padding Support', 'siteorigin-panels' ),
 			),
 			'priority' => 10,
 		);


### PR DESCRIPTION
It wasn't very clear what this setting does so this PR will rename it to "Full Width Stretched With Padding Support". This should make it clear that it supports padding while the base Full Width Stretched layout doesn't.