### PR TITLE
Color Style Field: Adjust Spacing to Help With Field Consistency

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -2201,13 +2201,13 @@
 						font-size: 12px;
 					}
 
-					.so-wp-color-field {
-						margin-left: 6px;
-					}
-
 					.wp-color-result,
 					.so-wp-color-field {
-						margin-bottom: 10px;
+						margin-bottom: 4px;
+					}
+
+					.iris-picker {
+						margin-top: 0;
 					}
 				}
 
@@ -2317,13 +2317,20 @@
 				max-width: 100%;
 			}
 
-			.wp-picker-clear {
-				margin-left: 6px;
-				min-height: 30px;
-			}
+			.wp-picker-container {
 
-			.wp-color-result {
-				margin: 0;
+				input {
+					height: 30px;
+				}
+
+				.wp-picker-clear {
+					margin-left: 6px;
+					min-height: 30px;
+				}
+
+				.wp-color-result {
+					margin: 0;
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR adjust the Color Style field to have more consistent spacing with other fields. A build is required to test this PR.

Before:
![screenshot_2023-10-30_at_20_36_56](https://github.com/siteorigin/siteorigin-panels/assets/17275120/09d88303-a065-4fb0-8833-9399bf711ae9)


After:
![Screenshot 2023-11-01 at 01-18-58 Edit Page “Full Width Stretched Padded Layout Test” ‹ SO — WordPress](https://github.com/siteorigin/siteorigin-panels/assets/17275120/9a7fa548-0e4d-4cea-9891-585706353978)
