### PR TITLE
Round Cell Size Input

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1798,9 +1798,10 @@
 						}
 
 						.preview-cell-weight-input {
+							.box-shadow( none );
 							background: #f6f6f6;
+							border-radius: 4px;
 							border: 1px solid #d0d0d0;
-							.box-shadow(none);
 						}
 					}
 


### PR DESCRIPTION
This PR will round the Cell Size input field to 4px. This is In line with [the new direction button](https://github.com/siteorigin/siteorigin-panels/pull/1116) and the existing Column Count setting.

