### PR TITLE
Rename `Resize Columns` label to `Column Presets`

### DIFF
--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -338,7 +338,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 
 				<div class="cell-resize-container">
 					<span class="cell-resize-label">
-						<?php echo __( 'Resize Columns: ', 'siteorigin-panels' ); ?>
+						<?php echo __( 'Column Presets: ', 'siteorigin-panels' ); ?>
 					</span>
 					<div class="cell-resize" data-resize="<?php echo esc_js( json_encode( $column_sizes ) ); ?>"></div>
 				</div>


### PR DESCRIPTION
This setting will make it clearer that these are presets and not the only way to resize columns.