### PR TITLE
Cell Size Input: Add Padding to Prevent Controls Touching Edge

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1823,7 +1823,7 @@
 							left: 50%;
 							line-height: 1.4em !important;
 							margin: -0.95em 0 0 -40px;
-							padding: 10px 0;
+							padding: 10px 5px;
 							position: absolute;
 							text-align: center;
 							top: 50%;


### PR DESCRIPTION
This PR adds some spacing to prevent the field controls from touching the edge of the field.

Before:
![before](https://github.com/siteorigin/siteorigin-panels/assets/17275120/009b0509-0958-4bca-9016-356228310016)

After:
![after](https://github.com/siteorigin/siteorigin-panels/assets/17275120/cfe3441e-92ca-4cd2-ba1f-b14bbfe87eed)
