### PR TITLE
Resolve PB Column Resize Error

### DIFF
--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -672,6 +672,7 @@ module.exports = panels.view.dialog.extend({
 	},
 
 	changeCellTotal: function ( cellRatio = 0 ) {
+		var thisDialog = this;
 		 try {
 			var cellsCount = this.getCurrentCellCount();
 			this.drawCellResizers();
@@ -735,8 +736,6 @@ module.exports = panels.view.dialog.extend({
 			if ( cellCountChanged ) {
 				this.regenerateRowPreview();
 			} else {
-				var thisDialog = this;
-
 				// // Now lets animate the cells into their new widths
 				this.$( '.preview-cell' ).each( function( i, el ) {
 					var width = Math.round( thisDialog.row.cells.at( i ).get( 'weight' ) * 1000 ) / 10;


### PR DESCRIPTION
https://github.com/siteorigin/siteorigin-panels/pull/1114/ introduced an issue that could result in PB columns not changing when altering the column count for a row. This change has not been released so a release is not needed - this does however need to be merged before the next release.