### PR TITLE
Styles: Remove Padding Description

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -169,7 +169,6 @@ class SiteOrigin_Panels_Styles {
 			'name'        => __( 'Padding', 'siteorigin-panels' ),
 			'type'        => 'measurement',
 			'group'       => 'layout',
-			'description' => sprintf( __( 'Padding around the entire %s.', 'siteorigin-panels' ), strtolower( $label ) ),
 			'priority'    => 7,
 			'multiple'    => true,
 		);


### PR DESCRIPTION
It's redundant due to the multi-measurement field.