### PR TITLE
Add Compatibility for `Custom Product Tabs for WooCommerce` Plugin

### DIFF
--- a/compat/yikes.php
+++ b/compat/yikes.php
@@ -1,0 +1,4 @@
+<?php
+// Yikes Product Tabs applies the content filter for tab contents.
+// This causes Page Builder to re-render the current page.
+add_filter( 'yikes_woo_use_the_content_filter', '__return_false', 11 );

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -230,6 +230,10 @@ class SiteOrigin_Panels {
 			require_once plugin_dir_path( __FILE__ ) . 'compat/gravity-forms.php';
 		}
 
+		if ( class_exists( 'YIKES_Custom_Product_Tabs' ) ) {
+			require_once plugin_dir_path( __FILE__ ) . 'compat/yikes.php';
+		}
+
 		$load_lazy_load_compat = false;
 		// LazyLoad by WP Rocket.
 		if ( defined( 'ROCKET_LL_VERSION' ) ) {


### PR DESCRIPTION
This PR adds for the [Custom Product Tabs for WooCommerce](https://wordpress.org/plugins/yikes-inc-easy-custom-woocommerce-product-tabs) plugin (100k). Before this PR, the custom tab will display a copy of the page when Page Builder is enabled.