### PR TITLE
Full Stretch Migration: Prevent Unit Potentially Being Lost

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -884,7 +884,7 @@ class SiteOrigin_Panels_Styles {
 			$style['row_stretch'] == 'full-stretched'
 		) {
 			$padding = explode( ' ', $style[ $field ] );
-			$unit = preg_replace( '/[^a-z]/i', '', $padding[0] );
+			$unit = preg_replace( '/[0-9]+/', '', $padding[0] );
 			$padding[1] = $padding[3] = "0$unit";
 			$style[ $field ] = implode( ' ', $padding );
 		}


### PR DESCRIPTION
During migration, the unit of measurement can be lost. This will prevent that.