### PR TITLE
Color Style Field: Prevent Gap In Button

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -2464,6 +2464,10 @@
 
 				.wp-color-result {
 					margin: 0;
+
+					.wp-color-result-text {
+						height: 28px;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
![gap](https://github.com/siteorigin/siteorigin-panels/assets/17275120/f8ae5363-dd8c-4405-a2e2-9f98378a9f02)

It's at the bottom of the button, just above the blue line.