### PR TITLE
`full_width_stretched_legacy_padding`: Ensure Padding Exists Before Migrating

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -881,7 +881,8 @@ class SiteOrigin_Panels_Styles {
 	public static function full_width_stretched_legacy_padding( & $style, $field ) {
 		if (
 			! empty( $style['row_stretch'] ) &&
-			$style['row_stretch'] == 'full-stretched'
+			$style['row_stretch'] == 'full-stretched' &&
+			! empty( $style[ $field ] )
 		) {
 			$padding = explode( ' ', $style[ $field ] );
 			$unit = preg_replace( '/[0-9]+/', '', $padding[0] );


### PR DESCRIPTION
This has largely been accounted for already, but there is a chance for this to come up.

```
PHP Warning:  Undefined array key "mobile_padding" in  wp-content\plugins\siteorigin-panels\inc\styles.php on line 886

PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in wp-content\plugins\siteorigin-panels\inc\styles.php on line 886

PHP Warning:  Undefined array key "tablet_padding" in wp-content\plugins\siteorigin-panels\inc\styles.php on line 886

PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in wp-content\plugins\siteorigin-panels\inc\styles.php on line 886

```