### PR TITLE
Vantage Compat: Prevent TypeError If there are empty rows.

### DIFF
--- a/compat/vantage.php
+++ b/compat/vantage.php
@@ -11,6 +11,10 @@ add_filter( 'siteorigin_panels_row_style_attributes', 'siteorigin_panels_vantage
 // Ensure all full width stretched rows have padding.
 // This will prevent a situation where the content is squished.
 function siteorigin_panels_vantage_full_width_stretch( $data, $post_id ) {
+	if ( empty( $data['grids'] ) ) {
+		return $data;
+	}
+
 	foreach( $data['grids'] as $grid_id => $grid ) {
 		if (
 			! empty( $grid['style']['row_stretch'] ) &&


### PR DESCRIPTION
`PHP Fatal error: Uncaught TypeError: Cannot access offset of type string on string in plugins/siteorigin-panels/compat/vantage.php:14`