### PR TITLE
Prevent Overlay Covering Widget Contents

### DIFF
--- a/css/front-flex.less
+++ b/css/front-flex.less
@@ -60,10 +60,6 @@
 	z-index: 1;
 }
 
-.panel-has-overlay.so-panel .panel-background-overlay {
-	z-index: -1;
-}
-
 .panel-has-overlay.so-panel {
 	.panel-widget-style > * {
 		position: relative;


### PR DESCRIPTION
This PR will resolve an issue that can occur when adding an overlay to a widget where the overlay will cover the widget contents.