### PR TITLE
Legacy Layout: Add `siteorigin_panels_data` Filtering

### DIFF
--- a/inc/renderer-legacy.php
+++ b/inc/renderer-legacy.php
@@ -16,6 +16,7 @@ class SiteOrigin_Panels_Renderer_Legacy extends SiteOrigin_Panels_Renderer {
 		// Exit if we don't have panels data
 		if ( empty( $panels_data ) ) {
 			$panels_data = get_post_meta( $post_id, 'panels_data', true );
+			$panels_data = apply_filters( 'siteorigin_panels_data', $panels_data, $post_id );
 
 			if ( empty( $panels_data ) ) {
 				return '';


### PR DESCRIPTION
This PR will allow for filtering of `$panels_data` when `generate_css` is run. This will allow for the Vantage Compatability code to kick in.