### PR TITLE
Border Radius: Add `so-rounded` Context Class When Applied

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -639,6 +639,10 @@ class SiteOrigin_Panels_Styles {
 			}
 		}
 
+		if ( ! empty( $style['border_radius'] ) ) {
+			$attributes['class'][] = 'so-rounded';
+		}
+
 		if ( ! empty( $style['id'] ) ) {
 			$attributes['id'] = sanitize_html_class( $style['id'] );
 		}


### PR DESCRIPTION
This will allow additional styling to be applied to the row/cell/widget. This is useful when applying targeted styling to specific widgets. For example, this will allow the Border Radius to be applied to the SiteOrigin Image widget (if applicable).


```
.widget_sow-image .so-rounded {
	overflow: hidden;
}
```