### PR TITLE
CSS Output Location: Add Block Editor Support

### DIFF
--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -31,9 +31,7 @@ class SiteOrigin_Panels_Renderer {
 				$css_output_set = true;
 			}
 
-			// The CSS can only be output in the header if the page is powered by the Classic Editor.
-			// $post_id won't be a number if the current page is powered by the Block Editor.
-			if ( ! $css_output_set && $output_css == 'header' && is_numeric( $post_id ) ) {
+			if ( ! $css_output_set && $output_css == 'header' ) {
 				add_action( 'wp_head', array( $this, 'print_inline_css' ), 12 );
 				$css_output_set = true;
 			}

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -533,7 +533,6 @@ class SiteOrigin_Panels_Settings {
 				'footer' => __( 'Footer', 'siteorigin-panels' ),
 			),
 			'label'       => __( 'Page Builder Layout CSS Output Location', 'siteorigin-panels' ),
-			'description' => __( 'This setting is only applicable in the Classic Editor.', 'siteorigin-panels' ),
 		);
 
 		$fields['layout']['fields']['inline-styles'] = array(


### PR DESCRIPTION
This PR will allow for the `Page Builder Layout CSS Output Location` setting to be compatible with the SO Layout Block, and correctly output its CSS in the header it's set to.