### PR TITLE
Overlay Check: Prevent Potential Warning

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -71,6 +71,7 @@ class SiteOrigin_Panels_Styles {
 					! empty( $context['style']['background_image_attachment'] ) ||
 					! empty( $context['style']['background_image_attachment_fallback'] )
 				) &&
+				! empty( $context['style']['background_display'] ) &&
 				! self::is_background_parallax( $context['style']['background_display'] ) &&
 				(
 					isset( $context['style']['background_image_opacity'] ) &&


### PR DESCRIPTION
Resolves the following potential warning:

`Warning: Undefined array key "background_display" in wp-content/plugins/siteorigin-panels/inc/styles.php on line 73`