### PR TITLE
Block Editor: Don't Set Up Fallback Shortcode in Block Editor

### DIFF
--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -123,9 +123,9 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 		};
 		add_filter( 'siteorigin_panels_layout_classes', $add_custom_class_name );
 		$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+		SiteOrigin_Panels_Post_Content_Filters::add_filters( true );
 		$rendered_layout = SiteOrigin_Panels::renderer()->render( $builder_id, true, $panels_data );
-		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters( true );
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 		remove_filter( 'siteorigin_panels_layout_classes', $add_custom_class_name );
 

--- a/inc/post-content-filters.php
+++ b/inc/post-content-filters.php
@@ -9,18 +9,24 @@ class SiteOrigin_Panels_Post_Content_Filters {
 	/**
 	 * Add filters that include data-* attributes on Page Builder divs
 	 */
-	public static function add_filters() {
+	public static function add_filters( $is_block_editor = false ) {
 		add_filter( 'siteorigin_panels_row_attributes', 'SiteOrigin_Panels_Post_Content_Filters::row_attributes', 99, 2 );
 		add_filter( 'siteorigin_panels_cell_attributes', 'SiteOrigin_Panels_Post_Content_Filters::cell_attributes', 99, 2 );
 		add_filter( 'siteorigin_panels_widget_attributes', 'SiteOrigin_Panels_Post_Content_Filters::widget_attributes', 99, 2 );
-		SiteOrigin_Panels_Widget_Shortcode::add_filters();
+
+		if ( ! $is_block_editor ) {
+			SiteOrigin_Panels_Widget_Shortcode::add_filters();
+		}
 	}
 
-	public static function remove_filters() {
+	public static function remove_filters( $is_block_editor = false ) {
 		remove_filter( 'siteorigin_panels_row_attributes', 'SiteOrigin_Panels_Post_Content_Filters::row_attributes', 99, 2 );
 		remove_filter( 'siteorigin_panels_cell_attributes', 'SiteOrigin_Panels_Post_Content_Filters::cell_attributes', 99, 2 );
 		remove_filter( 'siteorigin_panels_widget_attributes', 'SiteOrigin_Panels_Post_Content_Filters::widget_attributes', 99, 2 );
-		SiteOrigin_Panels_Widget_Shortcode::remove_filters();
+
+		if ( ! $is_block_editor ) {
+			SiteOrigin_Panels_Widget_Shortcode::remove_filters();
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces a change that prevents PB from generating the fallback shortcodes when the Block Editor powers the page. This will prevent a TypeError if shortcodes are added to PB that have type issues. Preventing the fallback shortcodes from being generated in the Block Editor won't result in a noticeable difference to users.