### PR TITLE
Restore Layout Blocks SEO Editor Compat

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -40,7 +40,7 @@ var SiteOriginPanelsLayoutBlock = /*#__PURE__*/function (_wp$element$Component) 
     key: "componentDidMount",
     value: function componentDidMount() {
       this.isStillMounted = true;
-      if (this.state.editing) {
+      if (!this.state.panelsInitialized) {
         this.setupPanels();
       } else if (!this.state.editing && !this.previewInitialized) {
         clearTimeout(this.fetchPreviewTimer);
@@ -61,7 +61,7 @@ var SiteOriginPanelsLayoutBlock = /*#__PURE__*/function (_wp$element$Component) 
   }, {
     key: "componentDidUpdate",
     value: function componentDidUpdate(prevProps) {
-      if (this.state.editing && !this.state.panelsInitialized) {
+      if (!this.state.panelsInitialized) {
         this.setupPanels();
       } else if (this.state.loadingPreview) {
         if (!this.state.pendingPreviewRequest) {

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -22,7 +22,7 @@ class SiteOriginPanelsLayoutBlock extends wp.element.Component {
 	componentDidMount() {
 		this.isStillMounted = true;
 
-		if ( this.state.editing ) {
+		if ( ! this.state.panelsInitialized ) {
 			this.setupPanels();
 		} else if ( ! this.state.editing && ! this.previewInitialized ) {
 			clearTimeout( this.fetchPreviewTimer );
@@ -41,7 +41,7 @@ class SiteOriginPanelsLayoutBlock extends wp.element.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.state.editing && ! this.state.panelsInitialized ) {
+		if ( ! this.state.panelsInitialized ) {
 			this.setupPanels();
 		} else if ( this.state.loadingPreview ) {
         	if ( ! this.state.pendingPreviewRequest ) {

--- a/compat/seo.php
+++ b/compat/seo.php
@@ -7,6 +7,7 @@ function siteorigin_enqueue_seo_compat() {
 		defined( 'WPSEO_FILE' ) &&
 		(
 			// => 18
+			wp_script_is( 'yoast-seo-post-edit' ) ||
 			wp_script_is( 'yoast-seo-post-edit-classic' ) ||
 			// => 14.6 <= 17.9.
 			wp_script_is( 'yoast-seo-admin-global-script' ) ||


### PR DESCRIPTION
This change will ensure the Editor is always set up - and not after the user clicks the Block. This will allow SEO to be calculated on Block Editor load, and faster access to the Editor as needed.