### PR TITLE
Restore WP Events Manager Compatibility

### DIFF
--- a/inc/compatibility.php
+++ b/inc/compatibility.php
@@ -95,7 +95,7 @@ class SiteOrigin_Panels_Compatibility {
 
 		// Compatibility with WP Event Manager.
 		if ( class_exists( 'WP_Event_Manager' ) ) {
-			add_filter( 'display_event_description', array( $this, 'generate_post_content' ), 11 );
+			add_filter( 'display_event_description', array( SiteOrigin_Panels::single(), 'generate_post_content' ), 11 );
 		}
 
 		// Compatibility with Vantage.


### PR DESCRIPTION
`PHP Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'SiteOrigin_Panels_Compatibility' does not have a method 'generate_post_content' in /wp-includes/class-wp-hook.php on line 324`