### PR TITLE
Resolve `Array to String` conversion warning

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -370,7 +370,7 @@ class SiteOrigin_Panels_Admin {
 			) );
 			$tabs = array_map( function ( $tab ) {
 				$tab['title'] = esc_html( $tab['title'] );
-				$tab['filter']['groups'] = esc_html( $tab['filter']['groups'] );
+				$tab['filter']['groups'] = self::escape_text_recursive( $tab['filter']['groups'] );
 				return $tab;
 			}, $tabs );
 
@@ -1927,5 +1927,19 @@ class SiteOrigin_Panels_Admin {
 		}
 
 		return $post_states;
+	}
+
+	/**
+	 * Recursively escapes text to prevent HTML entities from being rendered.
+	 *
+	 * @param mixed $text The text to be escaped.
+	 * @return mixed The escaped text or array.
+	 */
+	private function escape_text_recursive( $text ) {
+		if ( is_array( $text ) ) {
+			return array_map( array( $this, 'escape_text_recursive' ), $text );
+		} else {
+			return esc_html( $text );
+		}
 	}
 }


### PR DESCRIPTION
This PR fixes an issue introduced in [this unrelated PR](https://github.com/siteorigin/siteorigin-panels/pull/1204). To test it, open any Page Builder powered page in the editor. If the below error isn't present in the debug.log this PR resolved it.

`[05-May-2024 13:49:29 UTC] PHP Warning:  Array to string conversion in C:\laragon\www\so\wp-includes\formatting.php on line 1108`
