### PR TITLE
Layout Builder Modal: Default to Cog Icon

### DIFF
--- a/js/siteorigin-panels/view/dialog.js
+++ b/js/siteorigin-panels/view/dialog.js
@@ -9,7 +9,7 @@ module.exports = Backbone.View.extend( {
 	builder: false,
 	className: 'so-panels-dialog-wrapper',
 	dialogClass: '',
-	dialogIcon: '',
+	dialogIcon: 'add-widget',
 	parentDialog: false,
 	dialogOpen: false,
 	editableLabel: false,


### PR DESCRIPTION
If a modal doesn't have an icon, there will be a gap present. This PR sets PB to default to having a cog icon rather than a gap.