### PR TITLE
Fix Untranslatable Text

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -226,10 +226,16 @@ class SiteOrigin_Panels_Settings {
 	 * Add the Page Builder settings page
 	 */
 	public function add_settings_page() {
-		$page = add_options_page( esc_html( 'SiteOrigin Page Builder', 'siteorigin-panels' ), esc_html( 'Page Builder', 'siteorigin-panels' ), 'manage_options', 'siteorigin_panels', array(
-			$this,
-			'display_settings_page',
-		) );
+		$page = add_options_page(
+			esc_html__( 'SiteOrigin Page Builder', 'siteorigin-panels' ),
+			esc_html__( 'Page Builder', 'siteorigin-panels' ),
+			'manage_options',
+			'siteorigin_panels',
+			array(
+				$this,
+				'display_settings_page',
+			)
+		);
 		add_action( 'load-' . $page, array( $this, 'add_help_tab' ) );
 		add_action( 'load-' . $page, array( $this, 'save_settings' ) );
 	}
@@ -253,7 +259,7 @@ class SiteOrigin_Panels_Settings {
 
 		$screen->add_help_tab( array(
 			'id'      => 'panels-help-tab',
-			'title'   => esc_html( 'Page Builder Settings', 'siteorigin-panels' ),
+			'title'   => esc_html__( 'Page Builder Settings', 'siteorigin-panels' ),
 			'content' => $content,
 		) );
 	}

--- a/settings/tpl/help.php
+++ b/settings/tpl/help.php
@@ -3,7 +3,7 @@
 	echo preg_replace(
 		'/1\{ *(.*?) *\}/',
 		'<a href="https://siteorigin.com/page-builder/settings/" target="_blank" rel="noopener noreferrer">$1</a>',
-		esc_html( 'Please read the 1{settings guide} of the Page Builder documentation for help.', 'siteorigin-panels' )
+		esc_html__( 'Please read the 1{settings guide} of the Page Builder documentation for help.', 'siteorigin-panels' )
 	);
 	?>
 </p>

--- a/tpl/admin-home-page.php
+++ b/tpl/admin-home-page.php
@@ -39,7 +39,7 @@ $builder_supports = apply_filters( 'siteorigin_panels_builder_supports', array()
 					echo preg_replace(
 						'/1\{ *(.*?) *\}/',
 						'<a href="' . esc_url( get_the_permalink( $post ) ) . '">$1</a>',
-						esc_html( 'Home page updated. 1{View page}.', 'siteorigin-panels' )
+						esc_html__( 'Home page updated. 1{View page}.', 'siteorigin-panels' )
 					);
 					?>
 				</p>


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/these-strings-use-the-esc_html-function-and-are-not-translated-14/)