### PR TITLE
Widget Groups: Resolve TypeError

### DIFF
--- a/inc/admin-widget-dialog.php
+++ b/inc/admin-widget-dialog.php
@@ -201,6 +201,7 @@ class SiteOrigin_Panels_Admin_Widget_Dialog {
 		foreach ( $widgets as $widgetName => $widgetData ) {
 			if (
 				isset( $widgetData['groups'] ) &&
+				is_array( $widgetData['groups'] ) &&
 				in_array( 'recommended', $widgetData['groups'] )
 			) {
 				$recommendedWidgets[ $widgetName ] = $widgetData;


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/argument-2-haystack-must-be-of-type-array-string-given/)

`Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, string given in admin-widget-dialog.php:204`