### PR TITLE
Layouts Block: Resolve Preview Updating Issue

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -247,10 +247,8 @@ function (_wp$element$Component) {
 
       if (!this.isStillMounted) {
         return;
-      } // If we don't have panelsData yet, fetch it from PB directly.
+      }
 
-
-      var panelsData = props.panelsData === null ? this.builderView.getData() : props.panelsData;
       this.setState({
         previewInitialized: false
       });
@@ -258,7 +256,7 @@ function (_wp$element$Component) {
         url: window.soPanelsBlockEditorAdmin.previewUrl,
         data: {
           action: 'so_panels_layout_block_preview',
-          panelsData: JSON.stringify(panelsData)
+          panelsData: JSON.stringify(this.builderView.getData())
         }
       }).then(function (preview) {
         if (!_this4.isStillMounted) {
@@ -392,7 +390,11 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
             panelsAttributes.contentPreview = content.preview;
           }
 
-          setAttributes(panelsAttributes);
+          setAttributes({
+            contentPreview: panelsAttributes.contentPreview,
+            panelsData: panelsAttributes.panelsData,
+            previewInitialized: false
+          });
 
           if (!isNewWPBlockEditor) {
             wp.data.dispatch('core/editor').unlockPostSaving();

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -189,9 +189,6 @@ class SiteOriginPanelsLayoutBlock extends wp.element.Component {
 			return;
 		}
 
-		// If we don't have panelsData yet, fetch it from PB directly.
-		var panelsData = props.panelsData === null ? this.builderView.getData() : props.panelsData;
-
 		this.setState( {
 			previewInitialized: false,
 		} );
@@ -200,7 +197,7 @@ class SiteOriginPanelsLayoutBlock extends wp.element.Component {
 			url: window.soPanelsBlockEditorAdmin.previewUrl,
 			data: {
 				action: 'so_panels_layout_block_preview',
-				panelsData: JSON.stringify( panelsData ),
+				panelsData: JSON.stringify( this.builderView.getData() ),
 			}
 		} )
 		.then( ( preview ) => {
@@ -354,7 +351,11 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 							panelsAttributes.contentPreview = content.preview;
 						}
 
-						setAttributes( panelsAttributes );
+						setAttributes( {
+							contentPreview: panelsAttributes.contentPreview,
+							panelsData: panelsAttributes.panelsData,
+							previewInitialized: false,
+						} );
 
 						if ( ! isNewWPBlockEditor ) {
 							wp.data.dispatch( 'core/editor' ).unlockPostSaving();


### PR DESCRIPTION
This PR resolves a previewing update issue with the Layouts Block. Basically, if you make a change, the change won't be visible until you make another one - and only the second to last change will be visible. This PR ensures the PR is always up to date.

This PR requires a build.
The JS file is the complied version of the jsx file. Formatting is not maintained.