### PR TITLE
Styles Admin: Make Color Picker Field and Clear Button are on Dedicated Line

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -2484,6 +2484,18 @@
 					height: 30px;
 				}
 
+				.wp-picker-open + .wp-picker-input-wrap {
+					display: flex;
+
+					> label {
+						flex: 2;
+					}
+
+					.wp-color-picker {
+						width: 100%;
+					}
+				}
+
 				.wp-picker-clear {
 					margin-left: 6px;
 					min-height: 30px;


### PR DESCRIPTION
The colour picker will still unfortunately exceed the base sidebar width due to a color picker sizing limitaiton.