### PR TITLE
Add Background to Layouts Block to prevent styling issues with darker themes

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -913,6 +913,10 @@
 		.so-builder-container {
 			background: #fff;
 
+			.so-row-container {
+				padding: 0 15px 20px;
+			}
+
 			a:not(.so-tool-button):not([class^="so-row-"]) {
 				color: #2271b1;
 


### PR DESCRIPTION
[Before](https://i.imgur.com/PbxSOz2.jpeg)

[After](https://i.imgur.com/ttaAn5z.jpeg)