### PR TITLE
Layouts Block: Prevent Double Page Builder when in Dev Mode

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -91,8 +91,8 @@ function (_wp$element$Component) {
         previewInitialized: !editMode,
         pendingPreviewRequest: false,
         panelsInitialized: false
-      }; // Depending on when this function is called, we need to update the state
-      // differently.
+      }; // Depending on when this function is called, we need to update the
+      // state differently.
 
       if (newState) {
         this.state = _objectSpread({}, this.initialState);

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -24,8 +24,8 @@ class SiteOriginPanelsLayoutBlock extends wp.element.Component {
 			panelsInitialized: false,
 		};
 
-		// Depending on when this function is called, we need to update the state
-		// differently.
+		// Depending on when this function is called, we need to update the
+		// state differently.
 		if ( newState ) {
 			this.state = { ...this.initialState };
 		} else {
@@ -35,7 +35,6 @@ class SiteOriginPanelsLayoutBlock extends wp.element.Component {
 
 	componentDidMount() {
 		this.isStillMounted = true;
-
 		if ( ! this.state.panelsInitialized ) {
 			this.setupPanels();
 		}
@@ -109,9 +108,9 @@ class SiteOriginPanelsLayoutBlock extends wp.element.Component {
 
 		var config = {
 			editorType: 'standalone',
-	        loadLiveEditor: false,
-	        postId: window.soPanelsBlockEditorAdmin.postId,
-	        editorPreview: window.soPanelsBlockEditorAdmin.liveEditor,
+			loadLiveEditor: false,
+			postId: window.soPanelsBlockEditorAdmin.postId,
+			editorPreview: window.soPanelsBlockEditorAdmin.liveEditor,
 		};
 
 		var builderModel = new panels.model.builder();
@@ -193,8 +192,8 @@ class SiteOriginPanelsLayoutBlock extends wp.element.Component {
 
 		this.builderView.on( 'content_change', () => {
 			const newPanelsData = this.builderView.getData();
-			this.panelsDataChanged = ! SiteOriginIsPanelsEqual( panelsData, newPanelsData );
 
+			this.panelsDataChanged = ! SiteOriginIsPanelsEqual( panelsData, newPanelsData );
 			if ( this.panelsDataChanged ) {
 				if (
 					this.props.onContentChange &&


### PR DESCRIPTION
This PR prevents a single Layouts Block from rendering PB twice, preventing changes in "dev mode". This PR improves Layout Block unmounting so it also has positive knock-on effects outside of dev mode.

Dev mode requires at least the following added to wp-config.php:

`define( 'WP_DEBUG', true );`

It may also require one of, or both of, the following (I get inconsistent results):


```
define( 'WP_ENVIRONMENT_TYPE', 'local' );
define( 'SCRIPT_DEBUG', true );
```


![double](https://github.com/user-attachments/assets/80c49525-7cd9-433f-a929-bcf6277c98b8)
