### PR TITLE
Add a Blueprint for WP.org Live Preview

### DIFF
--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -1,0 +1,34 @@
+{
+	"features": {
+		"networking": true
+	},
+	"preferredVersions": {
+		"php": "latest",
+		"wp": "latest"
+	},
+	"steps": [
+		{
+			"step": "installTheme",
+			"themeData": {
+				"resource": "wordpress.org/themes",
+				"slug": "vantage"
+			},
+			"options": {
+				"activate": true,
+				"importStarterContent": true
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "siteorigin-panels"
+			},
+			"options": {
+				"activate": true
+			}
+		}
+	],
+	"login": true,
+	"landingPage": "/wp-admin/admin.php?page=siteorigin_panels"
+}


### PR DESCRIPTION
This PR adds a Blueprint file so that SiteOrigin's Page Builder plugin can have a Live Preview button in the WP.org plugin repo. The Live Preview will load your plugin in the WordPress Playground web app using the provided Blueprint.

According to [the WP.org docs](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/#enabling-plugin-previews):

> There are two things required for a plugin preview button to appear to all users:
> 1. A valid blueprint.json file must be provided in a blueprints sub-directory of the plugin’s assets folder.
> 2. The plugin preview must be set to “public” from the plugin’s Advanced view by a committer.

Once those conditions are met, a Live Preview button should appear next to the Download button in the WordPress.org plugin repo, like:

![image](https://github.com/user-attachments/assets/07d7d338-0faa-4c33-83de-5991ebc081df)

Try [this link](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/brandonpayton/siteorigin-panels/3b6135725fad21968918f5679ebefdf06a414d88/assets/blueprints/blueprint.json) for an example of the preview.

I work on the [WordPress Playground project](https://github.com/WordPress/wordpress-playground) and have started creating some PRs to propose Live Preview for various plugins. If you have any feedback related to Playground or Live Previews, I would love to hear it.