### PR TITLE
Compat: Prevent `load_textdomain_just_in_time`

### DIFF
--- a/inc/compatibility.php
+++ b/inc/compatibility.php
@@ -5,7 +5,7 @@
 class SiteOrigin_Panels_Compatibility {
 	public function __construct() {
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
-		add_action( 'plugins_loaded', array( $this, 'init' ), 100 );
+		add_action( 'init', array( $this, 'init' ), 100 );
 	}
 
 	public static function single() {


### PR DESCRIPTION
[Reported here](https://wordpress.org/support/topic/load_textdomain_just_in_time-errors/#post-18199992)