### PR TITLE
Apply XML updates

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -435,4 +435,7 @@
       </fields-in-item>
     </widget>
   </siteorigin-widgets>
+  <custom-fields>
+    <custom-field action="ignore">panels_data</custom-field>
+  </custom-fields>
 </wpml-config>

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,11 +1,5 @@
 <wpml-config>
   <built-with-page-builder>/\[siteorigin_widget.*\]/</built-with-page-builder>
-  <admin-texts>
-    <key name="so_widget_settings[SiteOrigin_Widget_GoogleMap_Widget]">
-      <key name="map_consent_btn_text" />
-      <key name="map_consent_notice" />
-    </key>
-  </admin-texts>
   <gutenberg-blocks>
     <gutenberg-block type="siteorigin-panels/layout-block" translate="1">
       <key name="panelsData">
@@ -308,11 +302,6 @@
         <field type="Feature more URL" editor_type="LINK">more_url</field>
       </fields-in-item>
     </widget>
-    <widget name="SiteOrigin_Widget_GoogleMap_Widget">
-      <fields-in-item items_of="markers>marker_positions">
-        <field type="Map marker info" editor_type="VISUAL">info</field>
-      </fields-in-item>
-    </widget>
     <widget name="SiteOrigin_Widget_Headline_Widget">
       <fields>
         <field type="Headline text">headline>text</field>
@@ -443,11 +432,6 @@
       <fields-in-item items_of="columns>features">
         <field type="Feature text">text</field>
         <field type="Feature hover text">hover</field>
-      </fields-in-item>
-    </widget>
-    <widget name="SiteOrigin_Widget_GoogleMap_Widget">
-      <fields-in-item items_of="markers>marker_positions">
-        <field type="Map marker info" editor_type="VISUAL">info</field>
       </fields-in-item>
     </widget>
   </siteorigin-widgets>


### PR DESCRIPTION
The first commit is just a cleanup. This widget actually belongs to so-widgets-bundle so I have remove it from here.

The second commit instructs WPML to ignore the panels_data field because we are handling its translation separately with code.