### PR TITLE
Trigger Row Column Resize Immediately After Change

### DIFF
--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -49,6 +49,7 @@ module.exports = panels.view.dialog.extend({
 
 		// Changing the row.
 		'click .row-set-form .so-row-field': 'changeCellTotal',
+		'change .row-set-form .so-row-field': 'changeCellTotal',
 		'click .cell-resize-sizing span': 'changeCellRatio',
 		'click .cell-resize-direction ': 'changeSizeDirection',
 
@@ -183,10 +184,6 @@ module.exports = panels.view.dialog.extend({
 			// Set the initial value of the
 			this.$( 'input[name="cells"].so-row-field' ).val( this.model.get( 'cells' ).length );
 		}
-
-		this.$( 'input.so-row-field' ).on( 'keyup', function() {
-			$(this).trigger('change');
-		});
 
 		return this;
 	},


### PR DESCRIPTION
This PR prevents a delay that previously occurred when manually increasing the number of columns a row has via keyboard input.

A build will be required to test this.