### PR TITLE
AIOSEO Compat: Load Widgets

### DIFF
--- a/compat/aioseo.php
+++ b/compat/aioseo.php
@@ -1,0 +1,12 @@
+<?php
+// AIOSEO compatibility. We need to add their widgets to a sidebar
+// to ensure they're useable in Page Builder.
+function siteorigin_panels_load_aioseo_widgets( $sidebars = array() ) {
+	$sidebars['aio_pb_compat'] = array(
+		'aioseo-breadcrumb-widget',
+		'aioseo-html-sitemap-widget',
+	);
+
+	return $sidebars;
+}
+add_filter( 'sidebars_widgets', 'siteorigin_panels_load_aioseo_widgets', 10, 1 );

--- a/inc/compatibility.php
+++ b/inc/compatibility.php
@@ -7,8 +7,9 @@ class SiteOrigin_Panels_Compatibility {
 
 	public function __construct() {
 		$this->compat_path = plugin_dir_path( SITEORIGIN_PANELS_BASE_FILE ) . 'compat/';
-		add_action( 'admin_init', array( $this, 'admin_init' ) );
-		add_action( 'init', array( $this, 'init' ), 100 );
+		add_action( 'admin_init', array( $this, 'admin_init' ), 10, 0 );
+		add_action( 'init', array( $this, 'init' ), 100, 0 );
+		add_action( 'widgets_init', array( $this, 'widgets_init' ), 1, 0 );
 	}
 
 	public static function single() {
@@ -114,6 +115,13 @@ class SiteOrigin_Panels_Compatibility {
 		// Compatibility with Popup Maker.
 		if ( class_exists( 'PUM_Site' )) {
 			require_once $this->compat_path . 'popup-maker.php';
+		}
+	}
+
+	public function widgets_init() {
+		// Compatibility for All in One SEO.
+		if ( function_exists( 'aioseo' ) ) {
+			require_once $this->compat_path . 'aioseo.php';
 		}
 	}
 }


### PR DESCRIPTION
To test this PR, install [AIOSEO](https://wordpress.org/plugins/all-in-one-seo-pack/) (3 million), and then open any Page Builder powered page. Try to insert an AIOSEO widget by searching for AIOSEO and you'll get no results. Switch to this branch, and you'll get two.