### PR TITLE
Add Compatibility for Events Manager.

### DIFF
--- a/compat/events-manager.php
+++ b/compat/events-manager.php
@@ -1,0 +1,55 @@
+<?php
+if ( ! function_exists( 'em_content' ) ) {
+	return;
+}
+
+$em_pb_removed = false;
+
+/**
+ * Disable Page Builder for Events Manager post types.
+ *
+ * This function checks if the current post is an Events Manager post type
+ * and if Page Builder is enabled for it. If both conditions are met, it
+ * disables Page Builder for the content. This is done to prevent Page Builder
+ * from interfering with the Events Manager content, and vice versa.
+ *
+ * `loop_start` is used due to when the Events Manager plugin sets up its
+ * content replacement.
+ *
+ * @return void
+ */
+function siteorigin_panels_event_manager_loop_start() {
+	$em_post_types = array( 'event-recurring', 'event' );
+
+	// Is the current post an $em_post_types post?
+	$post_type = get_post_type();
+	if ( ! in_array( $post_type, $em_post_types ) ) {
+		return;
+	}
+
+	// Is Page Builder enabled for Events Manager post types?
+	$pb_post_types = siteorigin_panels_setting( 'post-types' );
+	if ( empty( $pb_post_types ) || ! array_intersect( $em_post_types, $pb_post_types ) ) {
+		return;
+	}
+
+	global $em_pb_removed;
+	$em_pb_removed = true;
+
+	add_filter( 'siteorigin_panels_filter_content_enabled', '__return_false' );
+}
+add_action( 'loop_start', 'siteorigin_panels_event_manager_loop_start' );
+
+/**
+ * Re-enable Page Builder for `the_content` filter if it
+ * was disabled at the start of the loop.
+ */
+function siteorigin_panels_event_manager_loop_end() {
+	global $em_pb_removed;
+
+	if ( $em_pb_removed ) {
+		remove_filter( 'siteorigin_panels_filter_content_enabled', '__return_false' );
+	}
+
+}
+add_action( 'loop_end' , 'siteorigin_panels_event_manager_loop_end' );

--- a/inc/compatibility.php
+++ b/inc/compatibility.php
@@ -116,6 +116,11 @@ class SiteOrigin_Panels_Compatibility {
 		if ( class_exists( 'PUM_Site' )) {
 			require_once $this->compat_path . 'popup-maker.php';
 		}
+
+		// Compatibility with Events Manager.
+		if ( defined( 'EM_VERSION' ) ) {
+			require_once $this->compat_path . 'events-manager.php';
+		}
 	}
 
 	public function widgets_init() {


### PR DESCRIPTION
This PR adds compatibility for [the Events Manager plugin](https://wordpress.org/plugins/events-manager/). We both replace `the_content` with our respective output so I've opted to let the Events Manager handle rendering Page Builder.