### PR TITLE
Add Filter to Disable Events Manager Compatibility

### DIFF
--- a/compat/events-manager.php
+++ b/compat/events-manager.php
@@ -3,6 +3,10 @@ if ( ! function_exists( 'em_content' ) ) {
 	return;
 }
 
+if ( ! apply_filters( 'siteorigin_panels_compat_events_manager', true ) ) {
+	return;
+}
+
 $em_pb_removed = false;
 
 /**


### PR DESCRIPTION
To disable the compatibility code, add:

`add_filter( 'siteorigin_panels_compat_events_manager', '__return_false' );`