### PR TITLE
Remove `wp_targeted_link_rel` From Preview Generation

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1260,9 +1260,6 @@ class SiteOrigin_Panels_Admin {
 		$GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] = true;
 		$return = SiteOrigin_Panels::renderer()->render( (int) $post_id, false, $panels_data );
 
-		if ( function_exists( 'wp_targeted_link_rel' ) && is_array( $return ) ) {
-			$return = wp_targeted_link_rel( $return );
-		}
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] );
 
 		return $return;


### PR DESCRIPTION
`wp_targeted_link_rel` is now deprecated. No replacement is needed.