### PR TITLE
Poylang: Improve Sync Handling

### DIFF
--- a/compat/polylang.php
+++ b/compat/polylang.php
@@ -1,12 +1,14 @@
 <?php
 /**
- * When Polylang duplicates a post, copy over panels_data if it exists.
+ * Ensure that SiteOrigin Panels data is included in Polylang's post meta copy,
+ * and sync.
  */
 function siteorigin_polylang_include_panels_data( $keys, $sync ) {
-	if ( ! $sync ) {
+	if ( $sync ) {
 		$keys[] = 'panels_data';
 	}
 
 	return $keys;
 }
 add_filter( 'pll_copy_post_metas', 'siteorigin_polylang_include_panels_data', 10, 2 );
+add_filter( 'pll_sync_post_fields', 'siteorigin_polylang_include_panels_data', 10, 2 );


### PR DESCRIPTION
This PR adds `pll_sync_post_fields` support which will ensure translations set to sync will be correctly synced. This should prevent a situation where the sync status needs to be "turned off and on again" to work as expected.

It also modifies the sync check to ensure it's enabled when copying the initial post meta.