### PR TITLE
Prevent Encoded Quotes When Editing Widget Titles

### DIFF
--- a/js/siteorigin-panels/dialog/widget.js
+++ b/js/siteorigin-panels/dialog/widget.js
@@ -118,7 +118,8 @@ module.exports = panels.view.dialog.extend( {
 		this.renderDialog( this.parseDialogContent( $( '#siteorigin-panels-dialog-widget' ).html(), {} ) );
 		this.loadForm();
 
-		const title = _.escape( this.model.getWidgetField( 'title' ) );
+		const rawTitle = this.model.getWidgetField( 'title' );
+		const title = _.escape( rawTitle ).replace( /&quot;/g, '"' );
 		this.$( '.so-title .widget-name' ).text( title );
 		this.$( '.so-edit-title' ).val( title );
 


### PR DESCRIPTION
<img width="537" alt="437573890-adc1a2f8-8749-49cd-b976-6debd3c1c525" src="https://github.com/user-attachments/assets/26272096-f553-436b-920e-29b7108a27f4" />
