### PR TITLE
Border: Resolve Multiple Width Issues

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -924,7 +924,7 @@ class SiteOrigin_Panels_Styles {
 					}
 				}
 			} else {
-				// Fallback. Use a single border value for all sides
+				// Fallback. Use a single border value for all sides.
 				$css['border'] = ( ! empty( $style['border_thickness'] ) ? $style['border_thickness'] : '1px' ) . ' solid ' . $style['border_color'];
 			}
 		}


### PR DESCRIPTION
This PR will resolve an invalid output that can occur when the Inline Styles setting is disabled.

Before:
`border: 2px 1px 1px 1px solid #DD3333;`

After:
`border-top: 2px solid #dd3333;
border-right: 1px solid #dd3333;
border-bottom: 1px solid #dd3333;
border-left: 1px solid #dd3333;`