### PR TITLE
Improve input sanitization in admin routines

### DIFF
--- a/compat/seopress.php
+++ b/compat/seopress.php
@@ -1,6 +1,6 @@
 <?php
 function siteorigin_panels_seopress_compat( $content ) {
-	$id = empty( $_GET['post'] ) ? $_GET['post_id'] : $_GET['post'];
+       $id = empty( $_GET['post'] ) ? intval( $_GET['post_id'] ) : intval( $_GET['post'] );
 	if ( ! empty( $id ) ) {
 		$page_builder_data = get_post_meta( $id, 'panels_data', true );
 		if ( ! empty( $page_builder_data ) ) {

--- a/inc/admin-layouts.php
+++ b/inc/admin-layouts.php
@@ -234,9 +234,9 @@ class SiteOrigin_Panels_Admin_Layouts {
 		// Get any layouts that the current user could edit.
 		header( 'content-type: application/json' );
 
-		$type = ! empty( $_REQUEST['type'] ) ? $_REQUEST['type'] : 'directory-siteorigin';
-		$search = ! empty( $_REQUEST['search'] ) ? trim( strtolower( $_REQUEST['search'] ) ) : '';
-		$page_num = ! empty( $_REQUEST['page'] ) ? (int) $_REQUEST['page'] : 1;
+$type     = ! empty( $_REQUEST['type'] ) ? sanitize_key( wp_unslash( $_REQUEST['type'] ) ) : 'directory-siteorigin';
+$search   = ! empty( $_REQUEST['search'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['search'] ) ) : '';
+$page_num = ! empty( $_REQUEST['page'] ) ? intval( $_REQUEST['page'] ) : 1;
 
 		$return = array(
 			'title' => '',
@@ -425,37 +425,40 @@ class SiteOrigin_Panels_Admin_Layouts {
 	/**
 	 * Ajax handler to get an individual prebuilt layout
 	 */
-	public function action_get_prebuilt_layout() {
-		if ( empty( $_REQUEST['type'] ) ) {
-			wp_die();
-		}
+       public function action_get_prebuilt_layout() {
+               $type      = isset( $_REQUEST['type'] ) ? sanitize_key( wp_unslash( $_REQUEST['type'] ) ) : '';
+               $layout_id = isset( $_REQUEST['lid'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['lid'] ) ) : '';
 
-		if ( ! isset( $_REQUEST['lid'] ) ) {
-			wp_die();
-		}
+               if ( empty( $type ) ) {
+                       wp_die();
+               }
 
-		if ( empty( $_REQUEST['_panelsnonce'] ) || ! wp_verify_nonce( $_REQUEST['_panelsnonce'], 'panels_action' ) ) {
-			wp_die();
-		}
+               if ( empty( $layout_id ) ) {
+                       wp_die();
+               }
+
+               if ( empty( $_REQUEST['_panelsnonce'] ) || ! wp_verify_nonce( $_REQUEST['_panelsnonce'], 'panels_action' ) ) {
+                       wp_die();
+               }
 
 		header( 'content-type: application/json' );
 		$panels_data = array();
 		$raw_panels_data = false;
 
-		if ( $_REQUEST['type'] == 'prebuilt' ) {
+               if ( $type == 'prebuilt' ) {
 			$layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 
 			if (
-				! is_numeric( $_REQUEST['lid'] ) &&
-				empty( $layouts[ $_REQUEST['lid'] ] )
-			) {
+                               ! is_numeric( $layout_id ) &&
+                               empty( $layouts[ $layout_id ] )
+                       ) {
 				wp_send_json_error( array(
 					'error'   => true,
 					'message' => __( 'Missing layout ID or no such layout exists', 'siteorigin-panels' ),
 				) );
 			}
 
-			$layout = $layouts[ $_REQUEST['lid'] ];
+                       $layout = $layouts[ $layout_id ];
 
 			// Fix the format of this layout
 			if ( ! empty( $layout[ 'filename' ] ) ) {
@@ -470,7 +473,7 @@ class SiteOrigin_Panels_Admin_Layouts {
 			}
 
 			// A theme or plugin could use this to change the data in the layout
-			$panels_data = apply_filters( 'siteorigin_panels_prebuilt_layout', $layout, $_REQUEST['lid'] );
+                       $panels_data = apply_filters( 'siteorigin_panels_prebuilt_layout', $layout, $layout_id );
 
 			// Remove all the layout specific attributes
 			if ( isset( $panels_data['name'] ) ) {
@@ -486,14 +489,14 @@ class SiteOrigin_Panels_Admin_Layouts {
 			}
 
 			$raw_panels_data = true;
-		} elseif ( substr( $_REQUEST['type'], 0, 10 ) == 'directory-' ) {
-			$directory_id = str_replace( 'directory-', '', $_REQUEST['type'] );
+               } elseif ( substr( $type, 0, 10 ) == 'directory-' ) {
+                       $directory_id = str_replace( 'directory-', '', $type );
 
 			$directories = $this->get_directories();
 			$directory = ! empty( $directories[ $directory_id ] ) ? $directories[ $directory_id ] : false;
 
 			if ( ! empty( $directory ) ) {
-				$url = $directory[ 'url' ] . 'layout/' . urlencode( $_REQUEST[ 'lid' ] ) . '/?action=download';
+                               $url = $directory[ 'url' ] . 'layout/' . urlencode( $layout_id ) . '/?action=download';
 
 				if ( ! empty( $directory[ 'args' ] ) && is_array( $directory[ 'args' ] ) ) {
 					$url = add_query_arg( $directory[ 'args' ], $url );
@@ -512,8 +515,8 @@ class SiteOrigin_Panels_Admin_Layouts {
 				}
 			}
 			$raw_panels_data = true;
-		} elseif ( current_user_can( 'edit_post', $_REQUEST['lid'] ) ) {
-			$panels_data = get_post_meta( $_REQUEST['lid'], 'panels_data', true );
+               } elseif ( current_user_can( 'edit_post', $layout_id ) ) {
+                       $panels_data = get_post_meta( $layout_id, 'panels_data', true );
 
 			// Clear id and timestamp for SO widgets to prevent 'newer content version' notification in widget forms.
 			foreach ( $panels_data['widgets'] as &$widget ) {

--- a/inc/admin-widgets-bundle.php
+++ b/inc/admin-widgets-bundle.php
@@ -35,11 +35,11 @@ class SiteOrigin_Panels_Admin_Widgets_Bundle {
 		if ( isset( $_GET[ sanitize_key( 'plugin' ) ] ) && ( isset( $_GET[ sanitize_key( 'siteorigin-pa-install' ) ] ) && 'install-plugin' == $_GET[ sanitize_key( 'siteorigin-pa-install' ) ] ) && current_user_can( 'install_plugins' ) ) {
 			check_admin_referer( 'siteorigin-pa-install' );
 
-			$plugin['name'] = $_GET['plugin_name']; // Plugin name
-			$plugin['slug'] = $_GET['plugin']; // Plugin slug
+                       $plugin['name'] = sanitize_text_field( wp_unslash( $_GET['plugin_name'] ) ); // Plugin name
+                       $plugin['slug'] = sanitize_text_field( wp_unslash( $_GET['plugin'] ) ); // Plugin slug
 
 			if ( ! empty( $_GET['plugin_source'] ) ) {
-				$plugin['source'] = $_GET['plugin_source'];
+                               $plugin['source'] = esc_url_raw( wp_unslash( $_GET['plugin_source'] ) );
 			} else {
 				$plugin['source'] = false;
 			}

--- a/inc/live-editor.php
+++ b/inc/live-editor.php
@@ -24,7 +24,7 @@ class SiteOrigin_Panels_Live_Editor {
 	public function xss_headers() {
 		global $post;
 
-		if ( ! isset( $_GET['_panelsnonce'] ) || ! wp_verify_nonce( $_GET['_panelsnonce'], 'live-editor-preview' ) ) {
+if ( ! isset( $_GET['_panelsnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_panelsnonce'] ) ), 'live-editor-preview' ) ) {
 			// If this class has been loaded, we know we're in the Live Editor.
 			// In the case that data or the nonce isn't valid, wp_die as a security precaution.
 			// This will happen on template_redirect.

--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -30,7 +30,7 @@ class SiteOrigin_Panels_Styles_Admin {
 			);
 		}
 
-		$type = $_REQUEST['type'];
+               $type = isset( $_REQUEST['type'] ) ? sanitize_key( wp_unslash( $_REQUEST['type'] ) ) : '';
 
 		if ( ! in_array( $type, array( 'row', 'cell', 'widget' ) ) ) {
 			wp_die(
@@ -40,16 +40,16 @@ class SiteOrigin_Panels_Styles_Admin {
 			);
 		}
 
-		$post_id = empty( $_REQUEST['postId'] ) ? 0 : $_REQUEST['postId'];
+$post_id = empty( $_REQUEST['postId'] ) ? 0 : intval( $_REQUEST['postId'] );
 		$args = ! empty( $_POST['args'] ) ? json_decode( stripslashes( $_POST['args'] ), true ) : array();
 
-		$current = apply_filters(
-			'siteorigin_panels_general_current_styles',
-			isset( $_REQUEST['style'] ) ? $_REQUEST['style'] : array(),
-			$post_id,
-			$type,
-			$args
-		);
+$current = apply_filters(
+'siteorigin_panels_general_current_styles',
+isset( $_REQUEST['style'] ) ? wp_unslash( $_REQUEST['style'] ) : array(),
+$post_id,
+$type,
+$args
+);
 
 		$current = apply_filters(
 			'siteorigin_panels_general_current_styles_' . $type,

--- a/inc/widgets/post-loop.php
+++ b/inc/widgets/post-loop.php
@@ -88,12 +88,15 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 		}
 	}
 
-	private static function is_legacy_widget_block_preview() {
-		return isset( $_GET['legacy-widget-preview'] ) && (
-			$_GET['legacy-widget-preview']['idBase'] == 'siteorigin-panels-postloop' ||
-			$_GET['legacy-widget-preview']['idBase'] == 'siteorigin-panels-builder'
-		);
-	}
+       private static function is_legacy_widget_block_preview() {
+               if ( empty( $_GET['legacy-widget-preview'] ) ) {
+                       return false;
+               }
+
+               $id_base = isset( $_GET['legacy-widget-preview']['idBase'] ) ? sanitize_key( wp_unslash( $_GET['legacy-widget-preview']['idBase'] ) ) : '';
+
+               return 'siteorigin-panels-postloop' === $id_base || 'siteorigin-panels-builder' === $id_base;
+       }
 
 	private static function is_layout_block_preview() {
 		return isset( $_POST['action'] ) && $_POST['action'] == 'so_panels_layout_block_preview';
@@ -168,12 +171,12 @@ class SiteOrigin_Panels_Widgets_PostLoop extends WP_Widget {
 				if ( isset( $instance['pagination_id'] ) ) {
 					self::$current_pagination_id = $instance['pagination_id'];
 
-					if (
-						isset( $_GET[ 'page-' . self::$current_pagination_id ] ) &&
-						is_numeric( $_GET[ 'page-' . self::$current_pagination_id ] )
-					) {
-						$query_args['paged'] = $_GET[ 'page-' . self::$current_pagination_id ];
-					}
+if (
+isset( $_GET[ 'page-' . self::$current_pagination_id ] ) &&
+is_numeric( $_GET[ 'page-' . self::$current_pagination_id ] )
+) {
+$query_args['paged'] = (int) $_GET[ 'page-' . self::$current_pagination_id ];
+}
 				}
 			} else {
 				if ( get_query_var( 'paged' ) ) {

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -126,7 +126,7 @@ class SiteOrigin_Panels {
 	}
 
 	public static function is_legacy_browser() {
-		$agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
+$agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
 
 		if ( empty( $agent ) ) {
 			return false;


### PR DESCRIPTION
## Summary
- sanitize SEOPress compat ID handling
- sanitize plugin name, slug, and source in Widgets Bundle installer
- sanitize additional request parameters across admin screens

## Testing
- `php -l siteorigin-panels.php` *(fails: `php: command not found`)*