### PR TITLE
Fix admin color scheme inheritance for mode button

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1310,7 +1310,7 @@
 						margin-right: -1px;
 					}
 					
-					.button-secondary.button-primary.so-mode {
+					.so-button-mode {
 						border-bottom-left-radius: 0;
 						border-top-left-radius: 0;
 						border-left: 1px solid rgba(0, 0, 0, 0.1);

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -293,7 +293,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 				<input type="button" class="button-primary so-close" tabindex="0" value="<?php esc_attr_e( 'Done', 'siteorigin-panels' ); ?>" />
 
 				<span
-					class="button-secondary button-primary dashicons so-mode"
+					class="button-primary so-button-mode dashicons so-mode"
 					tabindex="0"
 					aria-label="<?php esc_attr_e( 'Access Modes', 'siteorigin-panels' ); ?>"
 					role="button"
@@ -381,7 +381,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 					<input type="button" class="button-primary so-save" tabindex="0" value="<?php esc_attr_e( 'Done', 'siteorigin-panels' ); ?>" />
 
 					<span
-						class="button-secondary button-primary dashicons so-mode"
+						class="button-primary so-button-mode dashicons so-mode"
 						tabindex="0"
 						aria-label="<?php esc_html_e( 'Access Modes', 'siteorigin-panels' ); ?>"
 						role="button"


### PR DESCRIPTION
Resolves https://github.com/siteorigin/siteorigin-panels/issues/1266.

This PR subtly refines the design of the mode button. I believe these adjustments enhance its aesthetic appeal and maintain full functionality across all user color schemes.