### PR TITLE
Widget: Remove Title Focus Delay & Default to Title Field By Default

### DIFF
--- a/js/siteorigin-panels/dialog/widget.js
+++ b/js/siteorigin-panels/dialog/widget.js
@@ -99,7 +99,7 @@ module.exports = panels.view.dialog.extend( {
 
 		this.on( 'open_dialog_complete', function() {
 			// If the title isn't visible, focus the first input.
-			const focusTarget = this.$( '.so-title' ).first();
+			const focusTarget = this.$( '.so-title-editable' );
 			if ( focusTarget.length ) {
 				focusTarget.trigger( 'focus' );
 			} else {


### PR DESCRIPTION
This PR will remove the delay from the Widget Title field. This PR will also improve fallback handling when the title field isn't editable - there was a chance a field other than the title would be focused.