### PR TITLE
Fix Clone Type Imports

### DIFF
--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -548,9 +548,9 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 			{{% _.each( items, function( item ) { %}}
 				<div
 					class="so-directory-item
-					{{% if ( typeof item.class != 'undefined' ) { %}}
-						{{%- item.class %}}"
-					{{% } %}}
+					{{% if ( typeof item.class != 'undefined' ) {
+						%}}{{%- item.class %}}{{%
+					} %}}"
 
 					data-layout-id="{{%- item.id %}}"
 					data-layout-type="{{%- item.type %}}"


### PR DESCRIPTION
This PR will fix a layout importing issue introduced by https://github.com/siteorigin/siteorigin-panels/pull/1104
To test this PR, try importing any Clone type and prior to this PR, the importer would hang.

This PR requires both dev, and build.