### PR TITLE
Layout Directory Pagination & Search Fixes

### DIFF
--- a/js/siteorigin-panels/dialog/prebuilt.js
+++ b/js/siteorigin-panels/dialog/prebuilt.js
@@ -559,47 +559,13 @@ module.exports = panels.view.dialog.extend( {
 		return deferredLayout.promise();
 	},
 
-	filterByTitle: function( title ) {
-
-		if ( title === '' ) {
-			this.$( '.so-directory-items-wrapper .so-directory-item' ).removeClass( 'so-hidden so-search-hidden' );
-		} else {
-			this.$( '.so-directory-items' ).removeClass( 'so-search-hidden' );
-			var $items = this.getItems();
-
-			$items.each( function() {
-				let $$ = $( this );
-				let found = $$.find( '.so-title' ).text().toLowerCase().includes( title );
-
-				if ( found && $$.hasClass( 'so-hidden' ) ) {
-					$$.removeClass( 'so-hidden so-search-hidden' )
-				} else if ( ! found ) {
-					$$.addClass( 'so-hidden so-search-hidden' );
-				}
-			} );
-
-		}
-
-		// Show or hide the no results message.
-		this.$( '.so-directory-items' ).toggleClass(
-			'so-empty',
-			! this.$('.so-directory-items-wrapper .so-directory-item:not(.so-hidden)').length
-		);
-
-		this.updatePagination();
-	},
-
 	/**
 	 * Handle an update to the search
 	 */
 	searchHandler: function ( e ) {
 		if ( e.keyCode === 13 ) {
 			var search = $( e.currentTarget ).val().toLowerCase();
-			if ( this.currentTab.match( '^directory-' ) ) {
-				this.filterByTitle( search );
-			} else {
-				this.displayLayoutDirectory( search, 1, this.currentTab );
-			}
+			this.displayLayoutDirectory( search, 1, this.currentTab );
 		}
 	},
 


### PR DESCRIPTION
[Layout Directory: Fix Next Button Not Appearing Correctly](https://github.com/siteorigin/siteorigin-panels/commit/82a190f3b18d310530f90f6923cd8cdb4bcf882a)
Previously, the next button would never appear. Now it will.

**To test**:  Open the Layout Directory and if the Next button appears with the defaults, it works as expected.

[Layout Directory: Fix pagination](https://github.com/siteorigin/siteorigin-panels/commit/ad6d1be0ecf79c15dc2f9b7d9cccf06eeb2460a3)
If the Next button somehow did appear for the Layout Directory, the items wouldn't be visible after changing page. This PR ensures they are.

**To test**:  Open the Layout Directory and navigate to the next page. If you see different items, it worked as expected.

[Layout Directory: Remove Inline Title Search](https://github.com/siteorigin/siteorigin-panels/commit/3a412109a25092f23b37d2cc53c391cb1c538765)
The inline title search was really only useful initially. It's now redundant due to the improved server-side filtering already in place. Removing it prevents pagination, missing search results, etc. Prior to this PR, you wouldn't be able to go to the next page and not all items would be listed.

**To test**: Open the Layout Directory and search for Hero. The Pagination should function as expected, and you should be able to see all items.
