### PR TITLE
Add Livemesh SiteOrigin Widgets Compatibility

### DIFF
--- a/compat/livemesh.php
+++ b/compat/livemesh.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * When the Livemesh SiteOrigin Widgets settings are updated,
+ * clear the Page Builder widget cache.
+ *
+ * This callback is triggered whenever the lsow_settings option is updated.
+ * This will only happen after a setting is actually changed.
+ *
+ * @param mixed  $old_value The previous value of the lsow_settings option.
+ * @param mixed  $value     The new value being saved to the lsow_settings option.
+ * @param string $option    The name of the option being updated (should be 'lsow_settings').
+*/
+function lsow_settings_updated( $old_value, $value, $option ) {
+	delete_transient( 'siteorigin_panels_widgets' );
+	delete_transient( 'siteorigin_panels_widget_dialog_tabs' );
+}
+add_action( 'update_option_lsow_settings', 'lsow_settings_updated', 10, 3 );

--- a/inc/compatibility.php
+++ b/inc/compatibility.php
@@ -31,6 +31,11 @@ class SiteOrigin_Panels_Compatibility {
 		) {
 			SiteOrigin_Panels_Compat_ACF_Widgets::single();
 		}
+
+		// Compatibility with Livemesh SiteOrigin Widgets.
+		if ( defined( 'LSOW_VERSION' ) ) {
+			require_once $this->compat_path . 'livemesh.php';
+		}
 	}
 
 	public function init() {


### PR DESCRIPTION
This PR will automatically clear the Page Builder widget cache and widget group cache after the Livemesh SiteOrigin Widgets settings are updated. This is to prevent a mismatch when that plugin activates all of its bundled widgets.