### PR TITLE
Builder Widget: Refresh Panel Data on Lot to Prevent Unexpected Changes

### DIFF
--- a/js/siteorigin-panels/jquery/setup-builder-widget.js
+++ b/js/siteorigin-panels/jquery/setup-builder-widget.js
@@ -38,6 +38,10 @@ module.exports = function ( config, force ) {
 		// Save panels data when we close the dialog, if we're in a dialog
 		var dialog = $$.closest( '.so-panels-dialog-wrapper' ).data( 'view' );
 		if ( ! _.isUndefined( dialog ) ) {
+			// Refresh the panelsData when the dialog is initially opened to
+			// prevent triggering unexpected change notifications.
+			builderModel.refreshPanelsData();
+			
 			dialog.on( 'close_dialog', function () {
 				builderModel.refreshPanelsData();
 			} );


### PR DESCRIPTION
A build is required to test this PR.