### PR TITLE
Fix Row Preview Percentage Alignment

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1713,7 +1713,7 @@
 				}
 
 				.row-cell-column input {
-					width: 58px;
+					width: 100%;
 				}
 
 				button {
@@ -1726,6 +1726,69 @@
 
 				.row-cell-column {
 					flex: 1;
+					display: flex;
+					align-items: center;
+					gap: 8px;
+
+					.so-row-count-control {
+						display: inline-block;
+						overflow: hidden;
+						position: relative;
+						width: 58px;
+						border-radius: 0;
+					}
+
+					.so-row-count-stepper {
+						align-items: center;
+						background: #f6f6f6;
+						border-radius: 0;
+						display: flex;
+						flex-direction: column;
+						height: calc( 100% - 2px );
+						justify-content: center;
+						position: absolute;
+						right: 1px;
+						top: 1px;
+						width: 18px;
+						z-index: 3;
+						overflow: hidden;
+					}
+
+					.so-row-count-step {
+						align-items: center;
+						background: transparent;
+						border: 0;
+						color: #5e6d72;
+						cursor: pointer;
+						display: inline-flex;
+						font-size: 12px;
+						font-weight: bold;
+						height: 50%;
+						justify-content: center;
+						line-height: 1;
+						margin: 0;
+						padding: 0;
+						width: 100%;
+						margin-top: 0;
+						border-radius: 0;
+
+						&:hover {
+							color: #1d2327;
+						}
+					}
+
+					.so-row-field {
+						-moz-appearance: textfield;
+						padding-right: 18px;
+						border-radius: 0;
+						margin: 0;
+
+						&::-webkit-outer-spin-button,
+						&::-webkit-inner-spin-button {
+							-webkit-appearance: none;
+							margin: 0;
+						}
+					}
 				}
 
 				.cell-resize-container {

--- a/css/admin.less
+++ b/css/admin.less
@@ -1736,6 +1736,10 @@
 						position: relative;
 						width: 58px;
 						border-radius: 0;
+
+						&:focus-within .so-row-field {
+							border-color: #3c434a;
+						}
 					}
 
 					.so-row-count-stepper {
@@ -1994,6 +1998,10 @@
 							overflow: hidden;
 							position: relative;
 							width: 80px;
+
+							&:focus-within .preview-cell-weight-input {
+								border-color: #8c8f94;
+							}
 						}
 
 						.preview-cell-stepper {

--- a/css/admin.less
+++ b/css/admin.less
@@ -1907,17 +1907,18 @@
 						}
 
 						.preview-cell-unit {
-							left: 10px;
-							position: absolute;
-							top: -1.5px;
-							z-index: 1;
+							cursor: pointer;
+							display: inline-block;
 							line-height: 1;
+							margin-left: 2px;
 						}
 
 						.preview-cell-container {
 							left: 50%;
 							position: absolute;
 							top: 50%;
+							.transform( translate( -50%, -50% ) );
+							width: 80px;
 						}
 
 						.preview-cell-weight,
@@ -1935,11 +1936,11 @@
 
 						.preview-cell-weight,
 						.preview-cell-weight-input[type="text"] {
-							padding: 10px 31px 10px 0;
+							padding: 10px 0;
 						}
 
 						.preview-cell-weight-input[type="number"] {
-							padding: 10px 13px 10px 5px;
+							padding: 10px 0;
 						}
 
 						.preview-cell-weight,
@@ -1948,15 +1949,25 @@
 							border: 1px solid #d0d0d0;
 							cursor: pointer;
 							line-height: 1.4em !important;
-							margin: -0.95em 0 0 -40px;
+							margin: 0;
 							overflow: hidden;
-							position: absolute;
-							text-align: right;
+							position: relative;
+							text-align: center;
 							width: 80px;
 
 							&:hover {
 								background: #f6f6f6;
 							}
+						}
+
+						.preview-cell-weight {
+							align-items: center;
+							display: flex;
+							justify-content: center;
+						}
+
+						.preview-cell-weight-value {
+							display: inline-block;
 						}
 
 						.preview-cell-weight-input {

--- a/css/admin.less
+++ b/css/admin.less
@@ -1861,7 +1861,7 @@
 				white-space: nowrap;
 
 				.preview-cell, .preview-cell-in,
-				.preview-cell-weight {
+				.preview-cell-weight-input {
 					.box-sizing( border-box );
 				}
 
@@ -1906,75 +1906,90 @@
 							box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
 						}
 
-						.preview-cell-unit {
-							cursor: pointer;
-							display: inline-block;
-							line-height: 1;
-							margin-left: 2px;
-						}
-
 						.preview-cell-container {
 							left: 50%;
 							position: absolute;
 							top: 50%;
 							.transform( translate( -50%, -50% ) );
-							width: 80px;
 						}
 
-						.preview-cell-weight,
-						.preview-cell-weight-input,
-						.preview-cell-unit {
-							color: #5e6d72;
-							font-family: Arial,Helvetica Neue,Helvetica,sans-serif;
-							font-size: 17px;
-							font-weight: bold;
-						}
-
-						.preview-cell-weight-input[type="number"] {
-							z-index: 2;
-						}
-
-						.preview-cell-weight,
-						.preview-cell-weight-input[type="text"] {
-							padding: 10px 0;
-						}
-
-						.preview-cell-weight-input[type="number"] {
-							padding: 10px 0;
-						}
-
-						.preview-cell-weight,
-						.preview-cell-weight-input {
-							background: #fff;
-							border: 1px solid #d0d0d0;
-							cursor: pointer;
-							line-height: 1.4em !important;
-							margin: 0;
-							overflow: hidden;
-							position: relative;
-							text-align: center;
-							width: 80px;
-
-							&:hover {
-								background: #f6f6f6;
-							}
-						}
-
-						.preview-cell-weight {
+						.preview-cell-weight-control {
 							align-items: center;
 							display: flex;
 							justify-content: center;
 						}
 
-						.preview-cell-weight-value {
-							display: inline-block;
+						.preview-cell-weight-field {
+							position: relative;
+							width: 80px;
+						}
+
+						.preview-cell-stepper {
+							align-items: center;
+							background: #f6f6f6;
+							border-radius: 3px;
+							display: flex;
+							flex-direction: column;
+							height: calc( 100% - 2px );
+							justify-content: center;
+							position: absolute;
+							right: 1px;
+							top: 1px;
+							width: 18px;
+							z-index: 3;
+						}
+
+						.preview-cell-step {
+							align-items: center;
+							background: transparent;
+							border: 0;
+							color: #5e6d72;
+							cursor: pointer;
+							display: inline-flex;
+							font-size: 12px;
+							font-weight: bold;
+							height: 50%;
+							justify-content: center;
+							line-height: 1;
+							margin: 0;
+							padding: 0;
+							width: 100%;
+
+							&:hover {
+								color: #1d2327;
+							}
 						}
 
 						.preview-cell-weight-input {
+							-moz-appearance: textfield;
 							.box-shadow( none );
-							background: #f6f6f6;
-							border-radius: 3px;
+							background: #fff;
 							border: 1px solid #d0d0d0;
+							border-radius: 3px;
+							color: #5e6d72;
+							cursor: pointer;
+							font-family: Arial,Helvetica Neue,Helvetica,sans-serif;
+							font-size: 17px;
+							font-weight: bold;
+							line-height: 1.4em !important;
+							margin: 0;
+							overflow: hidden;
+							padding: 10px 18px 10px 0;
+							position: relative;
+							text-align: center;
+							width: 100%;
+							z-index: 2;
+
+							&::-webkit-outer-spin-button,
+							&::-webkit-inner-spin-button {
+								-webkit-appearance: none;
+								margin: 0;
+							}
+
+							&:hover,
+							&:focus {
+								background: #f6f6f6;
+							}
 						}
 					}
 

--- a/css/admin.less
+++ b/css/admin.less
@@ -1756,7 +1756,7 @@
 
 					.so-row-count-step {
 						align-items: center;
-						background: transparent;
+						background: #f6f6f6;
 						border: 0;
 						color: #5e6d72;
 						cursor: pointer;
@@ -1772,13 +1772,17 @@
 						margin-top: 0;
 						border-radius: 0;
 
-						&:hover {
+						&:hover,
+						&:focus,
+						&:focus-visible {
+							background: #f6f6f6;
 							color: #1d2327;
 						}
 					}
 
 					.so-row-field {
 						-moz-appearance: textfield;
+						border: 1px solid #8c8f94;
 						padding-right: 18px;
 						border-radius: 0;
 						margin: 0;
@@ -1787,6 +1791,10 @@
 						&::-webkit-inner-spin-button {
 							-webkit-appearance: none;
 							margin: 0;
+						}
+
+						&:focus {
+							border-color: #3c434a;
 						}
 					}
 				}
@@ -2006,7 +2014,7 @@
 
 						.preview-cell-step {
 							align-items: center;
-							background: transparent;
+							background: #f6f6f6;
 							border: 0;
 							border-radius: 0;
 							color: #5e6d72;
@@ -2021,8 +2029,13 @@
 							padding: 0;
 							width: 100%;
 
-							&:hover {
+							&:hover,
+							&:focus,
+							&:focus-visible {
+								background: #f6f6f6;
+								box-shadow: none;
 								color: #1d2327;
+								outline: none;
 							}
 						}
 
@@ -2053,9 +2066,8 @@
 								margin: 0;
 							}
 
-							&:hover,
 							&:focus {
-								background: #f6f6f6;
+								border-color: #8c8f94;
 							}
 						}
 					}

--- a/css/admin.less
+++ b/css/admin.less
@@ -1983,6 +1983,7 @@
 						}
 
 						.preview-cell-weight-field {
+							overflow: hidden;
 							position: relative;
 							width: 80px;
 						}
@@ -1990,11 +1991,12 @@
 						.preview-cell-stepper {
 							align-items: center;
 							background: #f6f6f6;
-							border-radius: 3px;
+							border-radius: 0;
 							display: flex;
 							flex-direction: column;
 							height: calc( 100% - 2px );
 							justify-content: center;
+							overflow: hidden;
 							position: absolute;
 							right: 1px;
 							top: 1px;
@@ -2006,6 +2008,7 @@
 							align-items: center;
 							background: transparent;
 							border: 0;
+							border-radius: 0;
 							color: #5e6d72;
 							cursor: pointer;
 							display: inline-flex;
@@ -2025,10 +2028,11 @@
 
 						.preview-cell-weight-input {
 							-moz-appearance: textfield;
+							.box-sizing( border-box );
 							.box-shadow( none );
 							background: #fff;
 							border: 1px solid #d0d0d0;
-							border-radius: 3px;
+							border-radius: 0;
 							color: #5e6d72;
 							cursor: pointer;
 							font-family: Arial,Helvetica Neue,Helvetica,sans-serif;

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -50,6 +50,7 @@ module.exports = panels.view.dialog.extend({
 		// Changing the row.
 		'click .row-set-form .so-row-field': 'changeCellTotal',
 		'change .row-set-form .so-row-field': 'changeCellTotal',
+		'click .row-set-form .so-row-count-step': 'adjustCellCount',
 		'click .cell-resize-sizing span': 'changeCellRatio',
 		'click .cell-resize-direction ': 'changeSizeDirection',
 
@@ -179,6 +180,8 @@ module.exports = panels.view.dialog.extend({
 			// Set the initial value of the
 			this.$( 'input[name="cells"].so-row-field' ).val( this.model.get( 'cells' ).length );
 		}
+
+		this.$( 'input[name="cells"].so-row-field' ).attr( 'aria-live', 'polite' );
 
 		return this;
 	},
@@ -707,6 +710,30 @@ module.exports = panels.view.dialog.extend({
 
 	getCurrentCellCount: function() {
 		return parseInt( this.$('.row-set-form input[name="cells"]').val() );
+	},
+
+	adjustCellCount: function( e ) {
+		e.preventDefault();
+		var $control = $( e.currentTarget ).closest( '.so-row-count-control' );
+		var $input = $control.find( 'input[name="cells"].so-row-field' ).first();
+
+		if ( ! $input.length ) {
+			$input = this.$( '.row-set-form input[name="cells"].so-row-field' ).first();
+		}
+
+		if ( ! $input.length ) {
+			return;
+		}
+
+		var delta = $( e.currentTarget ).hasClass( 'so-row-count-step-up' ) ? 1 : -1;
+		var input = $input.get( 0 );
+		if ( delta > 0 ) {
+			input.stepUp();
+		} else {
+			input.stepDown();
+		}
+
+		this.changeCellTotal();
 	},
 
 	changeCellTotal: function ( cellRatio = 0 ) {

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -476,6 +476,7 @@ module.exports = panels.view.dialog.extend({
 						max: maxSize,
 						'aria-label': label,
 					} )
+					.data( 'initialWeight', $( this ).val() )
 					.on( 'focus', function() {
 						clearTimeout( timeout );
 						// Disable the draggable while entering values.
@@ -516,7 +517,18 @@ module.exports = panels.view.dialog.extend({
 							resizeCells( parent );
 						}
 					} )
-					.on( 'blur', resizeCells )
+					.on( 'blur', function() {
+						// Only trigger resize if the value actually changed to avoid
+						// unnecessary DOM regeneration that causes visual movement.
+						var current = $( this ).val();
+						var initial = $( this ).data( 'initialWeight' );
+						if ( current !== initial && ! $( this ).hasClass( 'no-user-interacted' ) ) {
+							resizeCells();
+						} else {
+							// Re-enable drag handles without rebuilding the preview.
+							thisDialog.$( '.resize-handle' ).css( 'pointer-events', '' ).draggable( 'enable' );
+						}
+					} )
 					.on( 'click', function () {
 						$( this ).trigger( 'select' );
 					} );

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -53,18 +53,6 @@ module.exports = panels.view.dialog.extend({
 		'click .cell-resize-sizing span': 'changeCellRatio',
 		'click .cell-resize-direction ': 'changeSizeDirection',
 
-		// If user clicks the column size indicator, focus the field.
-		'click .preview-cell-unit ': function( e ) {
-			var $weight = $( e.target ).closest( '.preview-cell-weight' );
-			var $weightInput = $weight.siblings( '.preview-cell-weight-input:visible' );
-			if ( $weightInput.length ) {
-				$weightInput.first().trigger( 'focus' );
-				return;
-			}
-
-			$weight.trigger( 'focus' );
-		},
-
 		'keyup .cell-resize-direction': function( e ) {
 			panels.helpers.accessibility.triggerClickOnEnter( e, true );
 		},
@@ -343,10 +331,10 @@ module.exports = panels.view.dialog.extend({
 							);
 
 						$( this ).data( 'newCellClone' ).css( 'width', rowPreview.width() * ncw + 'px' )
-							.find( '.preview-cell-weight-value' ).text( Math.round( ncw * 1000 ) / 10 );
+							.find( '.preview-cell-weight-input' ).val( Math.round( ncw * 1000 ) / 10 );
 
 						$( this ).data( 'prevCellClone' ).css( 'width', rowPreview.width() * pcw + 'px' )
-							.find( '.preview-cell-weight-value' ).text( Math.round( pcw * 1000 ) / 10 );
+							.find( '.preview-cell-weight-input' ).val( Math.round( pcw * 1000 ) / 10 );
 					},
 					stop: function (e, ui) {
 						// Remove the clones
@@ -389,154 +377,167 @@ module.exports = panels.view.dialog.extend({
 
 			}.bind(this));
 
-			newCell.find( '.preview-cell-weight' ).on( 'click', function( ci ) {
+			var resizeCells = function( refocusIndex = false ) {
+				timeout = setTimeout( function() {
+					var rowPreviewInputs = rowPreview.find( '.preview-cell-weight-input' );
+					// If there are no weight inputs, then skip this.
+					if ( rowPreviewInputs.length === 0 ) {
+						return false;
+					}
 
-				// Disable the draggable while entering values.
-				thisDialog.$( '.resize-handle' ).css( 'pointer-event', 'none' ).draggable( 'disable' );
+					var rowWeights = [],
+						rowChanged = [],
+						changedSum = 0,
+						unchangedSum = 0;
 
-				var resizeCells = function( refocusIndex = false ) {
-					timeout = setTimeout( function() {
-						var rowPreviewInputs = rowPreview.find( '.preview-cell-weight-input' );
-						// If there are no weight inputs, then skip this.
-						if ( rowPreviewInputs.length === 0 ) {
-							return false;
+					rowPreviewInputs.each( function( i, el ) {
+						var val = parseFloat( $( el ).val() );
+						if ( isNaN( val ) ) {
+							val = 1 / thisDialog.row.cells.length;
+						} else {
+							val = Math.round( val * 10 ) / 1000;
 						}
 
-						var rowWeights = [],
-							rowChanged = [],
-							changedSum = 0,
-							unchangedSum = 0;
+						// Check within 3 decimal points.
+						var changed = ! $( el ).hasClass( 'no-user-interacted' );
 
-						rowPreviewInputs.each( function( i, el ) {
-							var val = parseFloat( $( el ).val() );
-							if ( isNaN( val ) ) {
-								val = 1 / thisDialog.row.cells.length;
-							} else {
-								val = Math.round( val * 10 ) / 1000;
+						rowWeights.push( val );
+						rowChanged.push( changed );
+
+						if ( changed ) {
+							changedSum += val;
+						} else {
+							unchangedSum += val;
+						}
+					} );
+
+					if ( changedSum > 0 && unchangedSum > 0 && 1 - changedSum > 0 ) {
+						// Balance out the unchanged rows to occupy the weight left over by the changed sum.
+						for ( var i = 0; i < rowWeights.length; i++ ) {
+							if ( ! rowChanged[ i ] ) {
+								rowWeights[ i ] = (
+										rowWeights[ i ] / unchangedSum
+									) * (
+										1 - changedSum
+									);
 							}
+						}
+					}
 
-							// Check within 3 decimal points.
-							var changed = ! $( el ).hasClass( 'no-user-interacted' );
+					// Last check to ensure total weight is 1.
+					var sum = _.reduce( rowWeights, function ( memo, num ) {
+						return memo + num;
+					} );
 
-							rowWeights.push( val );
-							rowChanged.push( changed );
+					rowWeights = rowWeights.map( function( w ) {
+						return w / sum;
+					} );
 
-							if ( changed ) {
-								changedSum += val;
-							} else {
-								unchangedSum += val;
-							}
+					// Set the new cell weights and regenerate the preview.
+					if ( Math.min.apply( Math, rowWeights ) > 0.01 ) {
+						thisDialog.row.cells.each( function( cell, i ) {
+							cell.set( 'weight', rowWeights[ i ] );
 						} );
+					}
 
-						if ( changedSum > 0 && unchangedSum > 0 && 1 - changedSum > 0 ) {
-							// Balance out the unchanged rows to occupy the weight left over by the changed sum.
-							for ( var i = 0; i < rowWeights.length; i++ ) {
-								if ( ! rowChanged[ i ] ) {
-									rowWeights[ i ] = (
-											rowWeights[ i ] / unchangedSum
-										) * (
-											1 - changedSum
-										);
+					// Now lets animate the cells into their new widths.
+					rowPreview.find( '.preview-cell' ).each( function ( i, el ) {
+						var cellWeight = thisDialog.row.cells.at( i ).get( 'weight');
+						$( el ).animate( { 'width': Math.round( cellWeight * 1000 ) / 10 + "%" }, 250 );
+						$( el ).find( '.preview-cell-weight-input' ).val( Math.round( cellWeight * 1000 ) / 10 );
+					});
+
+					setTimeout( function() {
+						// So the draggable handle is not hidden.
+						thisDialog.regenerateRowPreview();
+
+						if ( typeof refocusIndex === 'number' ) {
+							var $refocusInput = thisDialog.$( '.row-preview .preview-cell-weight-input' ).eq( refocusIndex );
+							if ( $refocusInput.length ) {
+								$refocusInput.focus().select();
+							}
+						}
+					}, 260 );
+
+				}, 100 );
+			}
+
+			newCell.find( '.preview-cell-weight-input' ).each( function( ci ) {
+				var columnId = ci + 1;
+				var maxSize = 100 - ( thisDialog.row.cells.length - 1 );
+				var label = panelsOptions.loc.row.cellInput.replace( '%s', columnId );
+
+				$( this )
+					.attr( {
+						id: 'column-' + columnId,
+						max: maxSize,
+						'aria-label': label,
+					} )
+					.on( 'focus', function() {
+						clearTimeout( timeout );
+						// Disable the draggable while entering values.
+						thisDialog.$( '.resize-handle' ).css( 'pointer-events', 'none' ).draggable( 'disable' );
+					} )
+					.on( 'keyup', function( e ) {
+						if ( e.keyCode !== 9 ) {
+							// Only register the interaction if the user didn't press tab.
+							$( this ).removeClass( 'no-user-interacted' );
+						}
+
+						// Enter is pressed.
+						if ( e.keyCode === 13 ) {
+							e.preventDefault();
+							resizeCells();
+						}
+
+						// Up or down is pressed.
+						if ( e.keyCode === 38 || e.keyCode === 40 ) {
+							e.preventDefault();
+							var currentVal = parseFloat( $( this ).val() );
+							var maxVal = parseFloat( $( this ).attr( 'max' ) );
+
+							if ( ! isNaN( currentVal ) ) {
+								var nextVal = e.keyCode === 38 ? currentVal + 1 : currentVal - 1;
+								if ( nextVal < 1 ) {
+									nextVal = 1;
 								}
+								if ( ! isNaN( maxVal ) && nextVal > maxVal ) {
+									nextVal = maxVal;
+								}
+								$( this ).val( nextVal ).removeClass( 'no-user-interacted' );
 							}
+
+							// During the row regeneration, the inputs are removed and re-added so we need the id to refocus.
+							var parent = $( e.target ).parents( '.preview-cell' ).index();
+
+							resizeCells( parent );
 						}
-
-						// Last check to ensure total weight is 1.
-						var sum = _.reduce( rowWeights, function ( memo, num ) {
-							return memo + num;
-						} );
-
-						rowWeights = rowWeights.map( function( w ) {
-							return w / sum;
-						} );
-
-						// Set the new cell weights and regenerate the preview.
-						if ( Math.min.apply( Math, rowWeights ) > 0.01 ) {
-							thisDialog.row.cells.each( function( cell, i ) {
-								cell.set( 'weight', rowWeights[ i ] );
-							} );
-						}
-
-						// Now lets animate the cells into their new widths.
-						rowPreview.find( '.preview-cell' ).each( function ( i, el ) {
-							var cellWeight = thisDialog.row.cells.at( i ).get( 'weight');
-							$( el ).animate( { 'width': Math.round( cellWeight * 1000 ) / 10 + "%" }, 250 );
-							$( el ).find( '.preview-cell-weight-input' ).val( Math.round( cellWeight * 1000 ) / 10 );
-						});
-
-						setTimeout( function() {
-							if ( typeof refocusIndex === 'number' ) {
-								rowPreviewInputs.get( refocusIndex ).focus();
-							}
-
-							// So the draggable handle is not hidden.
-							thisDialog.regenerateRowPreview.bind( thisDialog )
-						}, 260 );
-
-					}, 100 );
-				}
-
-				rowPreview.find( '.preview-cell-weight' ).each( function( ci ) {
-					var columnId = ci + 1;
-					var $$ = jQuery( this ).hide();
-					var maxSize = 100 - ( thisDialog.row.cells.length - 1 );
-					var label = panelsOptions.loc.row.cellInput.replace( '%s', columnId );
-
-					$( `<input
-						type="number"
-						class="preview-cell-weight-input no-user-interacted"
-						id="column-${ columnId }"
-						min="1"
-						max="${ maxSize }"
-						aria-label="${ label }"
-					/>` )
-						.val( parseFloat( $$.find( '.preview-cell-weight-value' ).text() ) ).insertAfter( $$ )
-						.on( 'focus', function() {
-							clearTimeout( timeout );
-							$( this ).attr( 'type', 'number' );
-						} )
-						.on( 'keyup', function( e ) {
-							if ( e.keyCode !== 9 ) {
-								// Only register the interaction if the user didn't press tab.
-								$( this ).removeClass( 'no-user-interacted' );
-							}
-
-							// Enter is pressed.
-							if ( e.keyCode === 13 ) {
-								e.preventDefault();
-								resizeCells();
-							}
-
-							// Up or down is pressed.
-							if ( e.keyCode === 38 || e.keyCode === 40 ) {
-								e.preventDefault();
-								// During the row regeneration, the inputs are removed and re-added so we need the id to refocus.
-								var parent = $( e.target ).parents( '.preview-cell' ).index();
-
-								resizeCells( parent );
-							}
-						} )
-						.on( 'blur', resizeCells )
-						.on( 'click', function () {
-							// If the input is already focused, the user has clicked a step.
-							if ( $( this ).is( ':focus' ) ) {
-								resizeCells();
-							}
-							$( this ).trigger( 'select' );
-						} );
-				} );
-
-				$( this ).siblings( '.preview-cell-weight-input' ).trigger( 'select' );
-
-				// When the field blurs, we convert the inputs to text to prevent an overlap with the step counter with the percentage.
-				rowPreview.find( '.preview-cell-weight-input' ).on( 'blur', function() {
-					rowPreview.find( '.preview-cell-weight-input' ).attr( 'type', 'text' );
-				} );
+					} )
+					.on( 'blur', resizeCells )
+					.on( 'click', function () {
+						$( this ).trigger( 'select' );
+					} );
 			} );
 
-			// When a user tabs to  one of the column previews, switch all of them to inputs.
-			newCell.find( '.preview-cell-weight' ).on( 'focus', function( e ) {
-				$( e.target ).trigger( 'click' );
+			newCell.find( '.preview-cell-step' ).on( 'click', function() {
+				var $input = $( this ).closest( '.preview-cell-weight-control' ).find( '.preview-cell-weight-input' );
+				var currentVal = parseFloat( $input.val() );
+
+				if ( isNaN( currentVal ) ) {
+					return;
+				}
+
+				var newVal = $( this ).hasClass( 'preview-cell-step-up' )
+					? currentVal + 1
+					: currentVal - 1;
+
+				if ( newVal < 1 ) {
+					return;
+				}
+
+				$input.val( newVal ).removeClass( 'no-user-interacted' );
+				var parent = $input.parents( '.preview-cell' ).index();
+				resizeCells( parent );
 			} );
 
 		}, this);
@@ -623,7 +624,7 @@ module.exports = panels.view.dialog.extend({
 			var cell = thisDialog.row.cells.at(i);
 			$(el)
 				.css('width', cell.get('weight') * 100 + "%")
-				.find( '.preview-cell-weight-value' ).text( Math.round( cell.get('weight') * 1000 ) / 10 );
+				.find( '.preview-cell-weight-input' ).val( Math.round( cell.get('weight') * 1000 ) / 10 );
 		});
 	},
 
@@ -652,8 +653,8 @@ module.exports = panels.view.dialog.extend({
 
 	updateActiveCellClass: function() {
 		$( '.so-active-ratio' ).removeClass( 'so-active-ratio' );
-		var activeCellRatio = this.$( '.preview-cell-weight' ).map( function() {
-			return Math.trunc( Number( $( this ).find( '.preview-cell-weight-value' ).text() ) );
+		var activeCellRatio = this.$( '.preview-cell-weight-input' ).map( function() {
+			return Math.trunc( Number( $( this ).val() ) );
 		} ).get();
 
 		var cellsCount = this.getCurrentCellCount();
@@ -776,12 +777,11 @@ module.exports = panels.view.dialog.extend({
 				// // Now lets animate the cells into their new widths
 				this.$( '.preview-cell' ).each( function( i, el ) {
 					var width = Math.round( thisDialog.row.cells.at( i ).get( 'weight' ) * 1000 ) / 10;
-					var $previewCellWeight = $( el ).find( '.preview-cell-weight' );
-					var $previewCellWeightValue = $previewCellWeight.find( '.preview-cell-weight-value' );
+					var $input = $( el ).find( '.preview-cell-weight-input' );
 					// To prevent a jump, don't animate cells that haven't changed size.
-					if ( parseFloat( $previewCellWeightValue.text() ) != width ) {
+					if ( parseFloat( $input.val() ) != width ) {
 						$( el ).animate( { 'width': width + "%" }, 250 );
-						$previewCellWeightValue.text( width );
+						$input.val( width );
 					}
 				} );
 

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -55,7 +55,14 @@ module.exports = panels.view.dialog.extend({
 
 		// If user clicks the column size indicator, focus the field.
 		'click .preview-cell-unit ': function( e ) {
-			$( e.target ).next().trigger( 'focus' );
+			var $weight = $( e.target ).closest( '.preview-cell-weight' );
+			var $weightInput = $weight.siblings( '.preview-cell-weight-input:visible' );
+			if ( $weightInput.length ) {
+				$weightInput.first().trigger( 'focus' );
+				return;
+			}
+
+			$weight.trigger( 'focus' );
 		},
 
 		'keyup .cell-resize-direction': function( e ) {
@@ -336,10 +343,10 @@ module.exports = panels.view.dialog.extend({
 							);
 
 						$( this ).data( 'newCellClone' ).css( 'width', rowPreview.width() * ncw + 'px' )
-							.find('.preview-cell-weight').html(Math.round(ncw * 1000) / 10);
+							.find( '.preview-cell-weight-value' ).text( Math.round( ncw * 1000 ) / 10 );
 
 						$( this ).data( 'prevCellClone' ).css( 'width', rowPreview.width() * pcw + 'px' )
-							.find('.preview-cell-weight').html(Math.round(pcw * 1000) / 10);
+							.find( '.preview-cell-weight-value' ).text( Math.round( pcw * 1000 ) / 10 );
 					},
 					stop: function (e, ui) {
 						// Remove the clones
@@ -483,7 +490,7 @@ module.exports = panels.view.dialog.extend({
 						max="${ maxSize }"
 						aria-label="${ label }"
 					/>` )
-						.val( parseFloat( $$.html() ) ).insertAfter( $$ )
+						.val( parseFloat( $$.find( '.preview-cell-weight-value' ).text() ) ).insertAfter( $$ )
 						.on( 'focus', function() {
 							clearTimeout( timeout );
 							$( this ).attr( 'type', 'number' );
@@ -616,7 +623,7 @@ module.exports = panels.view.dialog.extend({
 			var cell = thisDialog.row.cells.at(i);
 			$(el)
 				.css('width', cell.get('weight') * 100 + "%")
-				.find('.preview-cell-weight').html(Math.round(cell.get('weight') * 1000) / 10);
+				.find( '.preview-cell-weight-value' ).text( Math.round( cell.get('weight') * 1000 ) / 10 );
 		});
 	},
 
@@ -646,7 +653,7 @@ module.exports = panels.view.dialog.extend({
 	updateActiveCellClass: function() {
 		$( '.so-active-ratio' ).removeClass( 'so-active-ratio' );
 		var activeCellRatio = this.$( '.preview-cell-weight' ).map( function() {
-			return Math.trunc( Number( $( this ).text() ) );
+			return Math.trunc( Number( $( this ).find( '.preview-cell-weight-value' ).text() ) );
 		} ).get();
 
 		var cellsCount = this.getCurrentCellCount();
@@ -770,10 +777,11 @@ module.exports = panels.view.dialog.extend({
 				this.$( '.preview-cell' ).each( function( i, el ) {
 					var width = Math.round( thisDialog.row.cells.at( i ).get( 'weight' ) * 1000 ) / 10;
 					var $previewCellWeight = $( el ).find( '.preview-cell-weight' );
+					var $previewCellWeightValue = $previewCellWeight.find( '.preview-cell-weight-value' );
 					// To prevent a jump, don't animate cells that haven't changed size.
-					if ( parseInt( $previewCellWeight.text() ) != width ) {
+					if ( parseFloat( $previewCellWeightValue.text() ) != width ) {
 						$( el ).animate( { 'width': width + "%" }, 250 );
-						$previewCellWeight.html( width );
+						$previewCellWeightValue.text( width );
 					}
 				} );
 

--- a/js/siteorigin-panels/view/cell.js
+++ b/js/siteorigin-panels/view/cell.js
@@ -204,10 +204,10 @@ module.exports = Backbone.View.extend( {
 					);
 
 				$( this ).data( 'newCellClone' ).css( 'width', containerWidth * ncw + 'px'  )
-					.find( '.preview-cell-weight' ).html( Math.round( ncw * 1000 ) / 10 );
+					.find( '.preview-cell-weight-value' ).text( Math.round( ncw * 1000 ) / 10 );
 
 				$( this ).data( 'prevCellClone' ).css( 'width', containerWidth * pcw + 'px' )
-					.find( '.preview-cell-weight' ).html( Math.round( pcw * 1000 ) / 10 );
+					.find( '.preview-cell-weight-value' ).text( Math.round( pcw * 1000 ) / 10 );
 			},
 			stop: function ( e, ui ) {
 				// Remove the clones

--- a/js/siteorigin-panels/view/cell.js
+++ b/js/siteorigin-panels/view/cell.js
@@ -204,10 +204,10 @@ module.exports = Backbone.View.extend( {
 					);
 
 				$( this ).data( 'newCellClone' ).css( 'width', containerWidth * ncw + 'px'  )
-					.find( '.preview-cell-weight-value' ).text( Math.round( ncw * 1000 ) / 10 );
+					.find( '.preview-cell-weight-input' ).val( Math.round( ncw * 1000 ) / 10 );
 
 				$( this ).data( 'prevCellClone' ).css( 'width', containerWidth * pcw + 'px' )
-					.find( '.preview-cell-weight-value' ).text( Math.round( pcw * 1000 ) / 10 );
+					.find( '.preview-cell-weight-input' ).val( Math.round( pcw * 1000 ) / 10 );
 			},
 			stop: function ( e, ui ) {
 				// Remove the clones

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -402,17 +402,30 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 	</div>
 </script>
 
-<script type="text/template" id="siteorigin-panels-dialog-row-cell-preview">
-	<div class="preview-cell" style="width: {{%- weight*100 %}}%">
-		<div class="preview-cell-in">
-			<div class="preview-cell-container">
-				<div class="preview-cell-weight" tabIndex="0">
-					<span class="preview-cell-weight-value">{{% print( Math.round( weight * 1000 ) / 10 ) %}}</span><span class="preview-cell-unit">%</span>
+	<script type="text/template" id="siteorigin-panels-dialog-row-cell-preview">
+		<div class="preview-cell" style="width: {{%- weight*100 %}}%">
+			<div class="preview-cell-in">
+				<div class="preview-cell-container">
+					<div class="preview-cell-weight-control">
+						<div class="preview-cell-weight-field">
+							<input
+								type="text"
+								inputmode="decimal"
+								class="preview-cell-weight-input no-user-interacted"
+								value="{{% print( Math.round( weight * 1000 ) / 10 ) %}}"
+								min="1"
+								tabIndex="0"
+							/>
+							<div class="preview-cell-stepper">
+								<button type="button" class="preview-cell-step preview-cell-step-up" tabindex="-1">+</button>
+								<button type="button" class="preview-cell-step preview-cell-step-down" tabindex="-1">&minus;</button>
+							</div>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-</script>
+	</script>
 
 <script type="text/template" id="siteorigin-panels-dialog-prebuilt">
 	<div class="dialog-data">

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -406,8 +406,9 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 	<div class="preview-cell" style="width: {{%- weight*100 %}}%">
 		<div class="preview-cell-in">
 			<div class="preview-cell-container">
-				<span class="preview-cell-unit">%</span>
-				<div class="preview-cell-weight" tabIndex="0">{{% print( Math.round( weight * 1000 ) / 10 ) %}}</div>
+				<div class="preview-cell-weight" tabIndex="0">
+					<span class="preview-cell-weight-value">{{% print( Math.round( weight * 1000 ) / 10 ) %}}</span><span class="preview-cell-unit">%</span>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -421,7 +421,7 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 		<div class="preview-cell" style="width: {{%- weight*100 %}}%">
 			<div class="preview-cell-in">
 				<div class="preview-cell-container">
-					<div class="preview-cell-weight-control">
+					<div class="preview-cell-weight-control" role="group" aria-label="<?php esc_attr_e( 'Column width controls', 'siteorigin-panels' ); ?>">
 						<div class="preview-cell-weight-field">
 							<input
 								type="text"
@@ -432,8 +432,8 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 								tabIndex="0"
 							/>
 							<div class="preview-cell-stepper">
-								<button type="button" class="preview-cell-step preview-cell-step-up">+</button>
-								<button type="button" class="preview-cell-step preview-cell-step-down">&minus;</button>
+								<button type="button" class="preview-cell-step preview-cell-step-up" aria-label="<?php esc_attr_e( 'Increase column width', 'siteorigin-panels' ); ?>">+</button>
+								<button type="button" class="preview-cell-step preview-cell-step-down" aria-label="<?php esc_attr_e( 'Decrease column width', 'siteorigin-panels' ); ?>">&minus;</button>
 							</div>
 						</div>
 					</div>

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -333,13 +333,28 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 
 		<div class="content">
 
-			<div class="row-set-form">
-				<div class="row-cell-column">
-					<?php
-					esc_html_e( 'Column Count:', 'siteorigin-panels' );
-					echo apply_filters( 'siteorigin_panels_row_column_count_input', '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="2" />' );
-					?>
-				</div>
+					<div class="row-set-form" role="group" aria-label="<?php esc_attr_e( 'Column count controls', 'siteorigin-panels' ); ?>">
+						<div class="row-cell-column">
+							<?php
+							$column_count_input = apply_filters( 'siteorigin_panels_row_column_count_input', '<input type="number" min="1" max="12" name="cells" id="so-row-count-input" class="so-row-field" value="2" />' );
+							?>
+							<label class="so-row-count-label" for="so-row-count-input"><?php esc_html_e( 'Column Count:', 'siteorigin-panels' ); ?></label>
+							<div class="so-row-count-control">
+								<label class="so-row-count-input-label">
+									<span class="screen-reader-text">
+										<?php esc_html_e( 'Column Count', 'siteorigin-panels' ); ?>
+									</span>
+									<?php echo $column_count_input; ?>
+								</label>
+								<span class="screen-reader-text">
+									<?php esc_html_e( 'Use arrow keys or type a number between 1 and 12.', 'siteorigin-panels' ); ?>
+								</span>
+								<div class="so-row-count-stepper">
+									<button type="button" class="so-row-count-step so-row-count-step-up">+</button>
+									<button type="button" class="so-row-count-step so-row-count-step-down">&minus;</button>
+								</div>
+							</div>
+						</div>
 
 				<div class="cell-resize-container">
 					<span class="cell-resize-label">
@@ -417,8 +432,8 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 								tabIndex="0"
 							/>
 							<div class="preview-cell-stepper">
-								<button type="button" class="preview-cell-step preview-cell-step-up" tabindex="-1">+</button>
-								<button type="button" class="preview-cell-step preview-cell-step-down" tabindex="-1">&minus;</button>
+								<button type="button" class="preview-cell-step preview-cell-step-up">+</button>
+								<button type="button" class="preview-cell-step preview-cell-step-down">&minus;</button>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary
- Rework the row preview weight markup so the numeric value and percent symbol render as one component.
- Replace fragile text/HTML updates with targeted updates to a dedicated `.preview-cell-weight-value` node.
- Center the preview label container with a single positioning model to avoid drift and overflow in different rendering contexts.

## Issue
This PR fixes: #1212
Issue URL: https://github.com/siteorigin/siteorigin-panels/issues/1212

## Testing
- Open Row Edit dialog and verify preview labels remain centered.
- Verify `%` remains inside the preview box during drag and manual input updates.
- Verify clicking `%` still focuses the editable value/input.
