### PR TITLE
Fix Events Manager Publish Status Regression

### DIFF
--- a/compat/events-manager.php
+++ b/compat/events-manager.php
@@ -24,6 +24,26 @@ class SiteOrigin_Panels_Compat_Events_Manager {
 		add_action( 'em_event_duplicate_pre', array( $this, 'duplicate_pre' ) );
 		add_filter( 'em_event_get_event_meta', array( $this, 'filter_duplicate_meta' ) );
 		add_filter( 'em_event_duplicate', array( $this, 'duplicate_copy_panels_data' ), 10, 2 );
+		add_filter( 'siteorigin_panels_copy_content_update_method', array( $this, 'copy_content_update_method' ), 10, 4 );
+	}
+
+	/**
+	 * Events Manager can force event status to draft during wp_update_post content sync.
+	 * Use a direct post_content update for Events Manager post types in this context.
+	 *
+	 * @param string $method      Update method.
+	 * @param object $post        Post object.
+	 * @param int    $post_id     Post ID.
+	 * @param array  $panels_data Panels data.
+	 *
+	 * @return string
+	 */
+	public function copy_content_update_method( $method, $post, $post_id, $panels_data ) {
+		if ( in_array( get_post_type( $post_id ), array( 'event', 'event-recurring' ), true ) ) {
+			return 'direct_db';
+		}
+
+		return $method;
 	}
 
 	/**

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -284,21 +284,7 @@ class SiteOrigin_Panels_Admin {
 				);
 
 				if ( $copy_content_update_method === 'direct_db' ) {
-					global $wpdb;
-					$wpdb->update(
-						$wpdb->posts,
-						array(
-							'post_content'      => $post->post_content,
-							'post_modified'     => current_time( 'mysql' ),
-							'post_modified_gmt' => current_time( 'mysql', true ),
-						),
-						array(
-							'ID' => $post->ID,
-						),
-						array( '%s', '%s', '%s' ),
-						array( '%d' )
-					);
-					clean_post_cache( $post->ID );
+					$this->copy_content_update_post_direct_db( $post );
 				} else {
 					$copy_content_update_args = array(
 						'ID'           => $post->ID,
@@ -322,6 +308,32 @@ class SiteOrigin_Panels_Admin {
 		}
 
 		$this->in_save_post = false;
+	}
+
+	/**
+	 * Update post content directly in the posts table and clear cache.
+	 *
+	 * @param WP_Post $post Post to update.
+	 *
+	 * @return void
+	 */
+	private function copy_content_update_post_direct_db( $post ) {
+		global $wpdb;
+
+		$wpdb->update(
+			$wpdb->posts,
+			array(
+				'post_content'      => $post->post_content,
+				'post_modified'     => current_time( 'mysql' ),
+				'post_modified_gmt' => current_time( 'mysql', true ),
+			),
+			array(
+				'ID' => $post->ID,
+			),
+			array( '%s', '%s', '%s' ),
+			array( '%d' )
+		);
+		clean_post_cache( $post->ID );
 	}
 
 	/*

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -275,16 +275,16 @@ class SiteOrigin_Panels_Admin {
 					$post->post_content .= $post_css;
 					$post->post_content .= '</style>';
 				}
-				$copy_content_fire_after_hooks = true;
+				$copy_content_update_method = apply_filters(
+					'siteorigin_panels_copy_content_update_method',
+					'wp_update_post',
+					$post,
+					$post_id,
+					$panels_data
+				);
 
-				// Events Manager validates event data in wp_insert_post_data and can force
-				// draft during our internal post_content sync. Bypass that pass for EM events.
-				if (
-					defined( 'EM_VERSION' ) &&
-					in_array( get_post_type( $post_id ), array( 'event', 'event-recurring' ), true )
-				) {
+				if ( $copy_content_update_method === 'direct_db' ) {
 					global $wpdb;
-					$copy_content_fire_after_hooks = false;
 					$wpdb->update(
 						$wpdb->posts,
 						array(
@@ -304,7 +304,7 @@ class SiteOrigin_Panels_Admin {
 						'ID'           => $post->ID,
 						'post_content' => $post->post_content,
 					);
-					wp_update_post( $copy_content_update_args, false, $copy_content_fire_after_hooks );
+					wp_update_post( $copy_content_update_args, false, true );
 				}
 			}
 		} else {

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -275,7 +275,37 @@ class SiteOrigin_Panels_Admin {
 					$post->post_content .= $post_css;
 					$post->post_content .= '</style>';
 				}
-				wp_update_post( $post );
+				$copy_content_fire_after_hooks = true;
+
+				// Events Manager validates event data in wp_insert_post_data and can force
+				// draft during our internal post_content sync. Bypass that pass for EM events.
+				if (
+					defined( 'EM_VERSION' ) &&
+					in_array( get_post_type( $post_id ), array( 'event', 'event-recurring' ), true )
+				) {
+					global $wpdb;
+					$copy_content_fire_after_hooks = false;
+					$wpdb->update(
+						$wpdb->posts,
+						array(
+							'post_content'      => $post->post_content,
+							'post_modified'     => current_time( 'mysql' ),
+							'post_modified_gmt' => current_time( 'mysql', true ),
+						),
+						array(
+							'ID' => $post->ID,
+						),
+						array( '%s', '%s', '%s' ),
+						array( '%d' )
+					);
+					clean_post_cache( $post->ID );
+				} else {
+					$copy_content_update_args = array(
+						'ID'           => $post->ID,
+						'post_content' => $post->post_content,
+					);
+					wp_update_post( $copy_content_update_args, false, $copy_content_fire_after_hooks );
+				}
 			}
 		} else {
 			// There are no widgets or rows, so delete the panels data.


### PR DESCRIPTION
## Summary
- Fix a publish regression for Events Manager event post types when Page Builder "Copy Content" is enabled.
- Avoid running a secondary `wp_update_post()` save cycle for Events Manager events during Page Builder content sync.
- For `event` and `event-recurring` post types, sync `post_content` directly to the posts table and clear post cache.

## Problem
When duplicating/editing an Events Manager event with Page Builder data present, publishing from the single event edit screen could revert to Draft during Page Builder's copied-content sync.

## Issue
User-reported bug (no matching open GitHub issue found at the time of PR creation).

## Testing
- Duplicate an Events Manager event containing Page Builder data.
- Change date/time and publish from the single event edit screen.
- Confirm status remains `publish`.
- Confirm behavior is unchanged for non-Events-Manager post types.
