### PR TITLE
Fix Ditty Widget Conflict with Page Builder Editor

### DIFF
--- a/compat/ditty.php
+++ b/compat/ditty.php
@@ -2,157 +2,163 @@
 /**
  * Compatibility with Ditty.
  */
-
-/**
- * Prevent Ditty widgets from rendering during Page Builder admin post content generation.
- *
- * This avoids Ditty admin render scripts from affecting the Page Builder admin UI.
- *
- * @param string    $widget_html Widget output.
- * @param WP_Widget $the_widget  Widget object.
- * @param array     $args        Widget args.
- *
- * @return string
- */
-function siteorigin_panels_ditty_admin_widget_render_compat( $widget_html, $the_widget, $args ) {
-	$is_builder_render_context = ! empty( $GLOBALS['SITEORIGIN_PANELS_POST_CONTENT_RENDER'] ) ||
-		! empty( $GLOBALS['SITEORIGIN_PANELS_PREVIEW_RENDER'] );
-
-	if (
-		! is_admin() ||
-		! $is_builder_render_context ||
-		! is_a( $the_widget, 'WP_Widget' )
-	) {
-		return $widget_html;
+class SiteOrigin_Panels_Compat_Ditty {
+	public function __construct() {
+		add_filter( 'siteorigin_panels_the_widget_html', array( $this, 'admin_widget_render_compat' ), 10, 3 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_builder_screen_assets' ), 1000 );
 	}
 
-	$ditty_widget_bases = apply_filters(
-		'siteorigin_panels_ditty_widget_bases',
-		array(
-			'ditty-widget',
-			'mtphr-dnt-widget',
-		)
-	);
+	/**
+	 * Prevent Ditty widgets from rendering during Page Builder admin post content generation.
+	 *
+	 * This avoids Ditty admin render scripts from affecting the Page Builder admin UI.
+	 *
+	 * @param string    $widget_html Widget output.
+	 * @param WP_Widget $the_widget  Widget object.
+	 * @param array     $args        Widget args.
+	 *
+	 * @return string
+	 */
+	public function admin_widget_render_compat( $widget_html, $the_widget, $args ) {
+		$is_builder_render_context = ! empty( $GLOBALS['SITEORIGIN_PANELS_POST_CONTENT_RENDER'] ) ||
+			! empty( $GLOBALS['SITEORIGIN_PANELS_PREVIEW_RENDER'] );
 
-	if ( ! in_array( $the_widget->id_base, $ditty_widget_bases, true ) ) {
-		return $widget_html;
-	}
-
-	if ( empty( $GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT'] ) ) {
-		$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT'] = array( 'hits' => array() );
-	}
-	$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT']['hits'][] = array(
-		'id_base'   => $the_widget->id_base,
-		'widget_id' => ! empty( $args['widget_id'] ) ? $args['widget_id'] : '',
-	);
-
-	// Return an HTML comment so the renderer short-circuits the widget output path.
-	return '<!-- Ditty widget output suppressed in Page Builder admin render context. -->';
-}
-add_filter( 'siteorigin_panels_the_widget_html', 'siteorigin_panels_ditty_admin_widget_render_compat', 10, 3 );
-
-/**
- * Check if current admin screen is a SiteOrigin builder screen outside Ditty admin.
- *
- * @param string $hook_suffix Admin hook suffix.
- *
- * @return bool
- */
-function siteorigin_panels_ditty_is_siteorigin_builder_screen( $hook_suffix ) {
-	if (
-		! is_admin() ||
-		! class_exists( 'SiteOrigin_Panels_Admin' ) ||
-		! SiteOrigin_Panels_Admin::is_admin() ||
-		! function_exists( 'get_current_screen' )
-	) {
-		return false;
-	}
-
-	$screen = get_current_screen();
-	if ( empty( $screen ) ) {
-		return false;
-	}
-
-	$screen_id = ! empty( $screen->id ) ? (string) $screen->id : '';
-	$post_type = ! empty( $screen->post_type ) ? (string) $screen->post_type : '';
-
-	// Do not interfere with Ditty's own admin screens.
-	if (
-		false !== strpos( $screen_id, 'ditty' ) ||
-		false !== strpos( $post_type, 'ditty' ) ||
-		false !== strpos( (string) $hook_suffix, 'ditty' )
-	) {
-		return false;
-	}
-
-	return true;
-}
-
-/**
- * Dequeue Ditty assets on SiteOrigin builder admin screens to avoid UI conflicts.
- *
- * @param string $hook_suffix Admin hook suffix.
- *
- * @return void
- */
-function siteorigin_panels_ditty_dequeue_builder_screen_assets( $hook_suffix ) {
-	if ( ! siteorigin_panels_ditty_is_siteorigin_builder_screen( $hook_suffix ) ) {
-		return;
-	}
-
-	$style_handles = apply_filters(
-		'siteorigin_panels_ditty_admin_style_handles',
-		array(
-			'ditty-displays',
-			'ditty-admin',
-			'ditty-admin-old',
-			'ditty-settings',
-			'ditty-editor',
-			'ditty-editor-init',
-			'ditty-news-ticker',
-			'ditty-news-ticker-font',
-			'ditty-fontawesome',
-			'ditty-display-cache',
-		)
-	);
-
-	$script_handles = apply_filters(
-		'siteorigin_panels_ditty_admin_script_handles',
-		array(
-			'ditty',
-			'ditty-display-cache',
-			'ditty-slider',
-			'ditty-helpers',
-			'ditty-admin',
-			'ditty-settings',
-			'ditty-editor-init',
-			'ditty-editor',
-			'ditty-display-editor',
-			'ditty-layout-editor',
-			'ditty-fields',
-			'ditty-news-ticker',
-		)
-	);
-
-	$removed = array(
-		'styles'  => array(),
-		'scripts' => array(),
-	);
-
-	foreach ( $style_handles as $handle ) {
-		if ( wp_style_is( $handle, 'enqueued' ) ) {
-			$removed['styles'][] = $handle;
+		if (
+			! is_admin() ||
+			! $is_builder_render_context ||
+			! is_a( $the_widget, 'WP_Widget' )
+		) {
+			return $widget_html;
 		}
-		wp_dequeue_style( $handle );
-	}
 
-	foreach ( $script_handles as $handle ) {
-		if ( wp_script_is( $handle, 'enqueued' ) ) {
-			$removed['scripts'][] = $handle;
+		$ditty_widget_bases = apply_filters(
+			'siteorigin_panels_ditty_widget_bases',
+			array(
+				'ditty-widget',
+				'mtphr-dnt-widget',
+			)
+		);
+
+		if ( ! in_array( $the_widget->id_base, $ditty_widget_bases, true ) ) {
+			return $widget_html;
 		}
-		wp_dequeue_script( $handle );
+
+		if ( empty( $GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT'] ) ) {
+			$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT'] = array( 'hits' => array() );
+		}
+		$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT']['hits'][] = array(
+			'id_base'   => $the_widget->id_base,
+			'widget_id' => ! empty( $args['widget_id'] ) ? $args['widget_id'] : '',
+		);
+
+		// Return an HTML comment so the renderer short-circuits the widget output path.
+		return '<!-- ' . esc_html__( 'Ditty widget output suppressed in Page Builder admin render context.', 'siteorigin-panels' ) . ' -->';
 	}
 
-	$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT']['removed'] = $removed;
+	/**
+	 * Check if current admin screen is a SiteOrigin builder screen outside Ditty admin.
+	 *
+	 * @param string $hook_suffix Admin hook suffix.
+	 *
+	 * @return bool
+	 */
+	private function is_siteorigin_builder_screen( $hook_suffix ) {
+		if (
+			! is_admin() ||
+			! class_exists( 'SiteOrigin_Panels_Admin' ) ||
+			! SiteOrigin_Panels_Admin::is_admin() ||
+			! function_exists( 'get_current_screen' )
+		) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		if ( empty( $screen ) ) {
+			return false;
+		}
+
+		$screen_id = ! empty( $screen->id ) ? (string) $screen->id : '';
+		$post_type = ! empty( $screen->post_type ) ? (string) $screen->post_type : '';
+
+		// Do not interfere with Ditty's own admin screens.
+		if (
+			false !== strpos( $screen_id, 'ditty' ) ||
+			false !== strpos( $post_type, 'ditty' ) ||
+			false !== strpos( (string) $hook_suffix, 'ditty' )
+		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Dequeue Ditty assets on SiteOrigin builder admin screens to avoid UI conflicts.
+	 *
+	 * @param string $hook_suffix Admin hook suffix.
+	 *
+	 * @return void
+	 */
+	public function dequeue_builder_screen_assets( $hook_suffix ) {
+		if ( ! $this->is_siteorigin_builder_screen( $hook_suffix ) ) {
+			return;
+		}
+
+		$style_handles = apply_filters(
+			'siteorigin_panels_ditty_admin_style_handles',
+			array(
+				'ditty-displays',
+				'ditty-admin',
+				'ditty-admin-old',
+				'ditty-settings',
+				'ditty-editor',
+				'ditty-editor-init',
+				'ditty-news-ticker',
+				'ditty-news-ticker-font',
+				'ditty-fontawesome',
+				'ditty-display-cache',
+			)
+		);
+
+		$script_handles = apply_filters(
+			'siteorigin_panels_ditty_admin_script_handles',
+			array(
+				'ditty',
+				'ditty-display-cache',
+				'ditty-slider',
+				'ditty-helpers',
+				'ditty-admin',
+				'ditty-settings',
+				'ditty-editor-init',
+				'ditty-editor',
+				'ditty-display-editor',
+				'ditty-layout-editor',
+				'ditty-fields',
+				'ditty-news-ticker',
+			)
+		);
+
+		$removed = array(
+			'styles'  => array(),
+			'scripts' => array(),
+		);
+
+		foreach ( $style_handles as $handle ) {
+			if ( wp_style_is( $handle, 'enqueued' ) ) {
+				$removed['styles'][] = $handle;
+			}
+			wp_dequeue_style( $handle );
+		}
+
+		foreach ( $script_handles as $handle ) {
+			if ( wp_script_is( $handle, 'enqueued' ) ) {
+				$removed['scripts'][] = $handle;
+			}
+			wp_dequeue_script( $handle );
+		}
+
+		$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT']['removed'] = $removed;
+	}
 }
-add_action( 'admin_enqueue_scripts', 'siteorigin_panels_ditty_dequeue_builder_screen_assets', 1000 );
+
+new SiteOrigin_Panels_Compat_Ditty();

--- a/compat/ditty.php
+++ b/compat/ditty.php
@@ -3,6 +3,19 @@
  * Compatibility with Ditty.
  */
 class SiteOrigin_Panels_Compat_Ditty {
+	/**
+	 * Internal compatibility state for debugging.
+	 *
+	 * @var array
+	 */
+	private $compat_state = array(
+		'hits'    => array(),
+		'removed' => array(
+			'styles'  => array(),
+			'scripts' => array(),
+		),
+	);
+
 	public function __construct() {
 		add_filter( 'siteorigin_panels_the_widget_html', array( $this, 'admin_widget_render_compat' ), 10, 3 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_builder_screen_assets' ), 1000 );
@@ -43,10 +56,7 @@ class SiteOrigin_Panels_Compat_Ditty {
 			return $widget_html;
 		}
 
-		if ( empty( $GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT'] ) ) {
-			$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT'] = array( 'hits' => array() );
-		}
-		$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT']['hits'][] = array(
+		$this->compat_state['hits'][] = array(
 			'id_base'   => $the_widget->id_base,
 			'widget_id' => ! empty( $args['widget_id'] ) ? $args['widget_id'] : '',
 		);
@@ -157,7 +167,7 @@ class SiteOrigin_Panels_Compat_Ditty {
 			wp_dequeue_script( $handle );
 		}
 
-		$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT']['removed'] = $removed;
+		$this->compat_state['removed'] = $removed;
 	}
 }
 

--- a/compat/ditty.php
+++ b/compat/ditty.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Compatibility with Ditty.
+ */
+
+/**
+ * Prevent Ditty widgets from rendering during Page Builder admin post content generation.
+ *
+ * This avoids Ditty admin render scripts from affecting the Page Builder admin UI.
+ *
+ * @param string    $widget_html Widget output.
+ * @param WP_Widget $the_widget  Widget object.
+ * @param array     $args        Widget args.
+ *
+ * @return string
+ */
+function siteorigin_panels_ditty_admin_widget_render_compat( $widget_html, $the_widget, $args ) {
+	$is_builder_render_context = ! empty( $GLOBALS['SITEORIGIN_PANELS_POST_CONTENT_RENDER'] ) ||
+		! empty( $GLOBALS['SITEORIGIN_PANELS_PREVIEW_RENDER'] );
+
+	if (
+		! is_admin() ||
+		! $is_builder_render_context ||
+		! is_a( $the_widget, 'WP_Widget' )
+	) {
+		return $widget_html;
+	}
+
+	$ditty_widget_bases = apply_filters(
+		'siteorigin_panels_ditty_widget_bases',
+		array(
+			'ditty-widget',
+			'mtphr-dnt-widget',
+		)
+	);
+
+	if ( ! in_array( $the_widget->id_base, $ditty_widget_bases, true ) ) {
+		return $widget_html;
+	}
+
+	if ( empty( $GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT'] ) ) {
+		$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT'] = array( 'hits' => array() );
+	}
+	$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT']['hits'][] = array(
+		'id_base'   => $the_widget->id_base,
+		'widget_id' => ! empty( $args['widget_id'] ) ? $args['widget_id'] : '',
+	);
+
+	// Return an HTML comment so the renderer short-circuits the widget output path.
+	return '<!-- Ditty widget output suppressed in Page Builder admin render context. -->';
+}
+add_filter( 'siteorigin_panels_the_widget_html', 'siteorigin_panels_ditty_admin_widget_render_compat', 10, 3 );
+
+/**
+ * Check if current admin screen is a SiteOrigin builder screen outside Ditty admin.
+ *
+ * @param string $hook_suffix Admin hook suffix.
+ *
+ * @return bool
+ */
+function siteorigin_panels_ditty_is_siteorigin_builder_screen( $hook_suffix ) {
+	if (
+		! is_admin() ||
+		! class_exists( 'SiteOrigin_Panels_Admin' ) ||
+		! SiteOrigin_Panels_Admin::is_admin() ||
+		! function_exists( 'get_current_screen' )
+	) {
+		return false;
+	}
+
+	$screen = get_current_screen();
+	if ( empty( $screen ) ) {
+		return false;
+	}
+
+	$screen_id = ! empty( $screen->id ) ? (string) $screen->id : '';
+	$post_type = ! empty( $screen->post_type ) ? (string) $screen->post_type : '';
+
+	// Do not interfere with Ditty's own admin screens.
+	if (
+		false !== strpos( $screen_id, 'ditty' ) ||
+		false !== strpos( $post_type, 'ditty' ) ||
+		false !== strpos( (string) $hook_suffix, 'ditty' )
+	) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Dequeue Ditty assets on SiteOrigin builder admin screens to avoid UI conflicts.
+ *
+ * @param string $hook_suffix Admin hook suffix.
+ *
+ * @return void
+ */
+function siteorigin_panels_ditty_dequeue_builder_screen_assets( $hook_suffix ) {
+	if ( ! siteorigin_panels_ditty_is_siteorigin_builder_screen( $hook_suffix ) ) {
+		return;
+	}
+
+	$style_handles = apply_filters(
+		'siteorigin_panels_ditty_admin_style_handles',
+		array(
+			'ditty-displays',
+			'ditty-admin',
+			'ditty-admin-old',
+			'ditty-settings',
+			'ditty-editor',
+			'ditty-editor-init',
+			'ditty-news-ticker',
+			'ditty-news-ticker-font',
+			'ditty-fontawesome',
+			'ditty-display-cache',
+		)
+	);
+
+	$script_handles = apply_filters(
+		'siteorigin_panels_ditty_admin_script_handles',
+		array(
+			'ditty',
+			'ditty-display-cache',
+			'ditty-slider',
+			'ditty-helpers',
+			'ditty-admin',
+			'ditty-settings',
+			'ditty-editor-init',
+			'ditty-editor',
+			'ditty-display-editor',
+			'ditty-layout-editor',
+			'ditty-fields',
+			'ditty-news-ticker',
+		)
+	);
+
+	$removed = array(
+		'styles'  => array(),
+		'scripts' => array(),
+	);
+
+	foreach ( $style_handles as $handle ) {
+		if ( wp_style_is( $handle, 'enqueued' ) ) {
+			$removed['styles'][] = $handle;
+		}
+		wp_dequeue_style( $handle );
+	}
+
+	foreach ( $script_handles as $handle ) {
+		if ( wp_script_is( $handle, 'enqueued' ) ) {
+			$removed['scripts'][] = $handle;
+		}
+		wp_dequeue_script( $handle );
+	}
+
+	$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT']['removed'] = $removed;
+}
+add_action( 'admin_enqueue_scripts', 'siteorigin_panels_ditty_dequeue_builder_screen_assets', 1000 );

--- a/inc/compatibility.php
+++ b/inc/compatibility.php
@@ -126,6 +126,11 @@ class SiteOrigin_Panels_Compatibility {
 		if ( defined( 'EM_VERSION' ) ) {
 			require_once $this->compat_path . 'events-manager.php';
 		}
+
+		// Compatibility with Ditty.
+		if ( defined( 'DITTY_VERSION' ) ) {
+			require_once $this->compat_path . 'ditty.php';
+		}
 	}
 
 	public function widgets_init() {


### PR DESCRIPTION
## Summary
- Load Ditty Compatibility Only When Ditty Is Active.
- Suppress Ditty Widget Output During Page Builder Content Render Context.
- Suppress Ditty Widget Output During Page Builder Preview Render Context.
- Dequeue Ditty Styles And Scripts On SiteOrigin Builder Admin Screens.
- Keep Ditty Admin Screens Untouched By Compatibility Logic.

## Testing
- Install Ditty 3.1.63 And Add The Ditty Widget In Page Builder.
- Confirm The Builder UI No Longer Breaks When The Widget Is Added.
- Confirm Ditty Plugin Admin Screens Continue To Load Normally.

Fixes #1174
