### PR TITLE
Generalize admin asset conflict handling for compat modules

### DIFF
--- a/compat/admin-asset-conflicts.php
+++ b/compat/admin-asset-conflicts.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Generic admin asset conflict handling for Page Builder screens.
+ */
+class SiteOrigin_Panels_Compat_Admin_Asset_Conflicts {
+	public static function single() {
+		static $single;
+
+		return empty( $single ) ? $single = new self() : $single;
+	}
+
+	public function __construct() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_conflicting_assets' ), 1000 );
+	}
+
+	/**
+	 * Dequeue conflicting plugin assets on Page Builder screens.
+	 *
+	 * @param string $hook_suffix Admin hook suffix.
+	 *
+	 * @return void
+	 */
+	public function dequeue_conflicting_assets( $hook_suffix ) {
+		if ( ! $this->is_siteorigin_builder_screen( $hook_suffix ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+		$should_dequeue = apply_filters( 'siteorigin_panels_admin_conflict_should_dequeue', true, $hook_suffix, $screen );
+		if ( ! $should_dequeue ) {
+			return;
+		}
+
+		$style_handles = apply_filters( 'siteorigin_panels_admin_conflict_style_handles', array(), $hook_suffix, $screen );
+		$script_handles = apply_filters( 'siteorigin_panels_admin_conflict_script_handles', array(), $hook_suffix, $screen );
+
+		$removed = array(
+			'styles'  => array(),
+			'scripts' => array(),
+		);
+
+		foreach ( $this->sanitize_handles( $style_handles ) as $handle ) {
+			if ( wp_style_is( $handle, 'enqueued' ) ) {
+				$removed['styles'][] = $handle;
+			}
+			wp_dequeue_style( $handle );
+		}
+
+		foreach ( $this->sanitize_handles( $script_handles ) as $handle ) {
+			if ( wp_script_is( $handle, 'enqueued' ) ) {
+				$removed['scripts'][] = $handle;
+			}
+			wp_dequeue_script( $handle );
+		}
+
+		$GLOBALS['SITEORIGIN_PANELS_ADMIN_COMPAT']['removed'] = $removed;
+	}
+
+	/**
+	 * Check if current admin screen is a SiteOrigin builder screen.
+	 *
+	 * @param string $hook_suffix Admin hook suffix.
+	 *
+	 * @return bool
+	 */
+	private function is_siteorigin_builder_screen( $hook_suffix ) {
+		if (
+			! is_admin() ||
+			! class_exists( 'SiteOrigin_Panels_Admin' ) ||
+			! SiteOrigin_Panels_Admin::is_admin() ||
+			! function_exists( 'get_current_screen' )
+		) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		if ( empty( $screen ) ) {
+			return false;
+		}
+
+		$screen_id = ! empty( $screen->id ) ? (string) $screen->id : '';
+		$post_type = ! empty( $screen->post_type ) ? (string) $screen->post_type : '';
+		$excluded_screen_matchers = apply_filters(
+			'siteorigin_panels_admin_conflict_excluded_screen_matchers',
+			array(),
+			$hook_suffix,
+			$screen
+		);
+
+		foreach ( $excluded_screen_matchers as $matcher ) {
+			if (
+				! is_string( $matcher ) ||
+				$matcher === ''
+			) {
+				continue;
+			}
+
+			if (
+				false !== strpos( $screen_id, $matcher ) ||
+				false !== strpos( $post_type, $matcher ) ||
+				false !== strpos( (string) $hook_suffix, $matcher )
+			) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Sanitize a list of potential script or style handles.
+	 *
+	 * @param mixed $handles Candidate handles.
+	 *
+	 * @return array
+	 */
+	private function sanitize_handles( $handles ) {
+		if ( ! is_array( $handles ) ) {
+			return array();
+		}
+
+		$handles = array_filter( $handles, 'is_string' );
+		$handles = array_filter( $handles, 'strlen' );
+
+		return array_values( array_unique( $handles ) );
+	}
+}

--- a/compat/admin-asset-conflicts.php
+++ b/compat/admin-asset-conflicts.php
@@ -3,6 +3,16 @@
  * Generic admin asset conflict handling for Page Builder screens.
  */
 class SiteOrigin_Panels_Compat_Admin_Asset_Conflicts {
+	/**
+	 * Removed asset handles for debugging.
+	 *
+	 * @var array
+	 */
+	public $removed = array(
+		'styles'  => array(),
+		'scripts' => array(),
+	);
+
 	public static function single() {
 		static $single;
 
@@ -61,9 +71,7 @@ class SiteOrigin_Panels_Compat_Admin_Asset_Conflicts {
 			wp_dequeue_script( $handle );
 		}
 
-		$GLOBALS['SiteOrigin_Panels_Compat_Admin_Asset_Conflicts'] = array(
-			'removed' => $removed,
-		);
+		$this->removed = $removed;
 	}
 
 	/**

--- a/compat/admin-asset-conflicts.php
+++ b/compat/admin-asset-conflicts.php
@@ -40,6 +40,10 @@ class SiteOrigin_Panels_Compat_Admin_Asset_Conflicts {
 		);
 
 		foreach ( $this->sanitize_handles( $style_handles ) as $handle ) {
+			if ( ! $this->is_style_available_for_dequeue( $handle ) ) {
+				continue;
+			}
+
 			if ( wp_style_is( $handle, 'enqueued' ) ) {
 				$removed['styles'][] = $handle;
 			}
@@ -47,13 +51,47 @@ class SiteOrigin_Panels_Compat_Admin_Asset_Conflicts {
 		}
 
 		foreach ( $this->sanitize_handles( $script_handles ) as $handle ) {
+			if ( ! $this->is_script_available_for_dequeue( $handle ) ) {
+				continue;
+			}
+
 			if ( wp_script_is( $handle, 'enqueued' ) ) {
 				$removed['scripts'][] = $handle;
 			}
 			wp_dequeue_script( $handle );
 		}
 
-		$GLOBALS['SITEORIGIN_PANELS_ADMIN_COMPAT']['removed'] = $removed;
+		$GLOBALS['SiteOrigin_Panels_Compat_Admin_Asset_Conflicts'] = array(
+			'removed' => $removed,
+		);
+	}
+
+	/**
+	 * Check whether a style handle exists in a dequeueable state.
+	 *
+	 * @param string $handle Style handle.
+	 *
+	 * @return bool
+	 */
+	private function is_style_available_for_dequeue( $handle ) {
+		return
+			wp_style_is( $handle, 'registered' ) ||
+			wp_style_is( $handle, 'enqueued' ) ||
+			wp_style_is( $handle, 'queue' );
+	}
+
+	/**
+	 * Check whether a script handle exists in a dequeueable state.
+	 *
+	 * @param string $handle Script handle.
+	 *
+	 * @return bool
+	 */
+	private function is_script_available_for_dequeue( $handle ) {
+		return
+			wp_script_is( $handle, 'registered' ) ||
+			wp_script_is( $handle, 'enqueued' ) ||
+			wp_script_is( $handle, 'queue' );
 	}
 
 	/**

--- a/compat/ditty.php
+++ b/compat/ditty.php
@@ -5,7 +5,9 @@
 class SiteOrigin_Panels_Compat_Ditty {
 	public function __construct() {
 		add_filter( 'siteorigin_panels_the_widget_html', array( $this, 'admin_widget_render_compat' ), 10, 3 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_builder_screen_assets' ), 1000 );
+		add_filter( 'siteorigin_panels_admin_conflict_style_handles', array( $this, 'admin_style_handles' ) );
+		add_filter( 'siteorigin_panels_admin_conflict_script_handles', array( $this, 'admin_script_handles' ) );
+		add_filter( 'siteorigin_panels_admin_conflict_excluded_screen_matchers', array( $this, 'excluded_screen_matchers' ) );
 	}
 
 	/**
@@ -56,108 +58,78 @@ class SiteOrigin_Panels_Compat_Ditty {
 	}
 
 	/**
-	 * Check if current admin screen is a SiteOrigin builder screen outside Ditty admin.
+	 * Register Ditty styles for generic admin conflict handling.
 	 *
-	 * @param string $hook_suffix Admin hook suffix.
+	 * @param array $handles Existing conflict handles.
 	 *
-	 * @return bool
+	 * @return array
 	 */
-	private function is_siteorigin_builder_screen( $hook_suffix ) {
-		if (
-			! is_admin() ||
-			! class_exists( 'SiteOrigin_Panels_Admin' ) ||
-			! SiteOrigin_Panels_Admin::is_admin() ||
-			! function_exists( 'get_current_screen' )
-		) {
-			return false;
-		}
+	public function admin_style_handles( $handles ) {
+		$handles = array_merge(
+			(array) $handles,
+			(array) apply_filters(
+				'siteorigin_panels_ditty_admin_style_handles',
+				array(
+					'ditty-displays',
+					'ditty-admin',
+					'ditty-admin-old',
+					'ditty-settings',
+					'ditty-editor',
+					'ditty-editor-init',
+					'ditty-news-ticker',
+					'ditty-news-ticker-font',
+					'ditty-fontawesome',
+					'ditty-display-cache',
+				)
+			)
+		);
 
-		$screen = get_current_screen();
-		if ( empty( $screen ) ) {
-			return false;
-		}
-
-		$screen_id = ! empty( $screen->id ) ? (string) $screen->id : '';
-		$post_type = ! empty( $screen->post_type ) ? (string) $screen->post_type : '';
-
-		// Do not interfere with Ditty's own admin screens.
-		if (
-			false !== strpos( $screen_id, 'ditty' ) ||
-			false !== strpos( $post_type, 'ditty' ) ||
-			false !== strpos( (string) $hook_suffix, 'ditty' )
-		) {
-			return false;
-		}
-
-		return true;
+		return $handles;
 	}
 
 	/**
-	 * Dequeue Ditty assets on SiteOrigin builder admin screens to avoid UI conflicts.
+	 * Register Ditty scripts for generic admin conflict handling.
 	 *
-	 * @param string $hook_suffix Admin hook suffix.
+	 * @param array $handles Existing conflict handles.
 	 *
-	 * @return void
+	 * @return array
 	 */
-	public function dequeue_builder_screen_assets( $hook_suffix ) {
-		if ( ! $this->is_siteorigin_builder_screen( $hook_suffix ) ) {
-			return;
-		}
-
-		$style_handles = apply_filters(
-			'siteorigin_panels_ditty_admin_style_handles',
-			array(
-				'ditty-displays',
-				'ditty-admin',
-				'ditty-admin-old',
-				'ditty-settings',
-				'ditty-editor',
-				'ditty-editor-init',
-				'ditty-news-ticker',
-				'ditty-news-ticker-font',
-				'ditty-fontawesome',
-				'ditty-display-cache',
+	public function admin_script_handles( $handles ) {
+		$handles = array_merge(
+			(array) $handles,
+			(array) apply_filters(
+				'siteorigin_panels_ditty_admin_script_handles',
+				array(
+					'ditty',
+					'ditty-display-cache',
+					'ditty-slider',
+					'ditty-helpers',
+					'ditty-admin',
+					'ditty-settings',
+					'ditty-editor-init',
+					'ditty-editor',
+					'ditty-display-editor',
+					'ditty-layout-editor',
+					'ditty-fields',
+					'ditty-news-ticker',
+				)
 			)
 		);
 
-		$script_handles = apply_filters(
-			'siteorigin_panels_ditty_admin_script_handles',
-			array(
-				'ditty',
-				'ditty-display-cache',
-				'ditty-slider',
-				'ditty-helpers',
-				'ditty-admin',
-				'ditty-settings',
-				'ditty-editor-init',
-				'ditty-editor',
-				'ditty-display-editor',
-				'ditty-layout-editor',
-				'ditty-fields',
-				'ditty-news-ticker',
-			)
-		);
+		return $handles;
+	}
 
-		$removed = array(
-			'styles'  => array(),
-			'scripts' => array(),
-		);
+	/**
+	 * Exclude Ditty admin screens from generic admin conflict handling.
+	 *
+	 * @param array $matchers Existing screen matchers.
+	 *
+	 * @return array
+	 */
+	public function excluded_screen_matchers( $matchers ) {
+		$matchers = array_merge( (array) $matchers, array( 'ditty' ) );
 
-		foreach ( $style_handles as $handle ) {
-			if ( wp_style_is( $handle, 'enqueued' ) ) {
-				$removed['styles'][] = $handle;
-			}
-			wp_dequeue_style( $handle );
-		}
-
-		foreach ( $script_handles as $handle ) {
-			if ( wp_script_is( $handle, 'enqueued' ) ) {
-				$removed['scripts'][] = $handle;
-			}
-			wp_dequeue_script( $handle );
-		}
-
-		$GLOBALS['SITEORIGIN_PANELS_DITTY_COMPAT']['removed'] = $removed;
+		return $matchers;
 	}
 }
 

--- a/inc/compatibility.php
+++ b/inc/compatibility.php
@@ -39,6 +39,12 @@ class SiteOrigin_Panels_Compatibility {
 	}
 
 	public function init() {
+		// Generic compatibility handling for admin asset conflicts.
+		if ( is_admin() ) {
+			require_once $this->compat_path . 'admin-asset-conflicts.php';
+			SiteOrigin_Panels_Compat_Admin_Asset_Conflicts::single();
+		}
+
 		// Compatibility with Widget Options.
 		if ( class_exists( 'WP_Widget_Options' ) ) {
 			require_once $this->compat_path . 'widget-options.php';


### PR DESCRIPTION
## Summary
- add SiteOrigin_Panels_Compat_Admin_Asset_Conflicts as a central admin_enqueue_scripts compatibility manager
- expose generic filters for conflict handles and excluded screen matchers
- migrate Ditty compatibility to register handles/screen exclusions through the generic filters instead of direct dequeue logic

## Testing
- php -l compat/admin-asset-conflicts.php
- php -l compat/ditty.php
- php -l inc/compatibility.php