### PR TITLE
Fix WooCommerce Shop Page Context Handling

### DIFF
--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -530,6 +530,17 @@ class SiteOrigin_Panels {
 			return false;
 		}
 
+		// The shop is a product archive request, even when loop internals shift the queried object.
+		if ( is_post_type_archive( 'product' ) ) {
+			return true;
+		}
+
+		// Fall back to the actual post being filtered for contexts where queried object is unstable.
+		global $post;
+		if ( ! empty( $post ) && (int) $post->ID === (int) $shop_page_id ) {
+			return true;
+		}
+
 		return (int) get_queried_object_id() === (int) $shop_page_id;
 	}
 

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -75,7 +75,7 @@ class SiteOrigin_Panels {
 
 		// We need to generate fresh post content.
 		add_filter( 'the_content', array( $this, 'generate_post_content' ) );
-		add_filter( 'woocommerce_format_content', array( $this, 'generate_woocommerce_content' ) );
+		add_filter( 'woocommerce_format_content', array( $this, 'generate_woocommerce_content' ), 10, 2 );
 		add_filter( 'wp_enqueue_scripts', array( $this, 'generate_post_css' ) );
 
 		// Remove the default excerpt function.
@@ -302,16 +302,55 @@ class SiteOrigin_Panels {
 	/**
 	 * Generate post content for WooCommerce shop page if it's using a PB layout.
 	 *
+	 * @param string $content     Formatted content.
+	 * @param string $raw_content Raw content before WooCommerce formatting.
+	 *
 	 * @return string
 	 *
 	 * @filter woocommerce_format_content
 	 */
-	public function generate_woocommerce_content( $content ) {
-		if ( self::should_use_woocommerce_shop_page_id() ) {
-			return $this->generate_post_content( $content );
+	public function generate_woocommerce_content( $content, $_raw_content = '' ) {
+		if ( ! self::is_woocommerce_shop_description_context() ) {
+			return $content;
 		}
 
+		$shop_page_id = wc_get_page_id( 'shop' );
+		if ( empty( $shop_page_id ) ) {
+			return $content;
+		}
+
+		$shop_page = get_post( $shop_page_id );
+		if ( empty( $shop_page ) ) {
+			return $content;
+		}
+
+		global $post;
+		$original_post = $post;
+
+		// Ensure downstream content checks run against the Shop page context.
+		$post = $shop_page;
+		$content = $this->generate_post_content( $content );
+		$post = $original_post;
+
 		return $content;
+	}
+
+	/**
+	 * Is WooCommerce currently rendering the Shop page archive description.
+	 *
+	 * Mirrors WooCommerce's own archive description conditions to avoid
+	 * intercepting unrelated `wc_format_content()` calls (e.g. checkout TOS).
+	 *
+	 * @return bool
+	 */
+	private static function is_woocommerce_shop_description_context() {
+		return (
+			class_exists( 'WooCommerce' ) &&
+			doing_action( 'woocommerce_archive_description' ) &&
+			! is_search() &&
+			is_post_type_archive( 'product' ) &&
+			in_array( absint( get_query_var( 'paged' ) ), array( 0, 1 ), true )
+		);
 	}
 
 	/**
@@ -532,12 +571,6 @@ class SiteOrigin_Panels {
 
 		// The shop is a product archive request, even when loop internals shift the queried object.
 		if ( is_post_type_archive( 'product' ) ) {
-			return true;
-		}
-
-		// Fall back to the actual post being filtered for contexts where queried object is unstable.
-		global $post;
-		if ( ! empty( $post ) && (int) $post->ID === (int) $shop_page_id ) {
 			return true;
 		}
 


### PR DESCRIPTION
## Summary
- Scope SiteOrigin Page Builder WooCommerce content rendering to the Shop archive description context only.
- Avoid intercepting unrelated `woocommerce_format_content` calls (for example, checkout Terms and Conditions content).
- Preserve Shop page Page Builder rendering by temporarily setting the global post to the configured Shop page during render.

## Testing
- Confirmed Shop page logs render path and Page Builder content output.
- Confirmed checkout Terms and Conditions path is skipped and no Shop content leakage occurs.
- Ran `php -l siteorigin-panels.php`.