### PR TITLE
Add Conditional Premium Layouts Sidebar Tab

### DIFF
--- a/inc/admin-layouts.php
+++ b/inc/admin-layouts.php
@@ -51,6 +51,22 @@ class SiteOrigin_Panels_Admin_Layouts {
 			);
 		}
 
+		if ( apply_filters( 'siteorigin_panels_premium_layouts_enabled', false ) ) {
+			$directories['siteorigin-premium'] = array(
+				// The title of the premium layouts directory in the sidebar.
+				'title' => __( 'Premium Layouts', 'siteorigin-panels' ),
+				// The URL of the directory.
+				'url'   => self::LAYOUT_URL,
+				// Any additional arguments to pass to the layouts server.
+				'args'  => apply_filters(
+					'siteorigin_panels_premium_layouts_directory_args',
+					array(
+						'access' => 'premium',
+					)
+				),
+			);
+		}
+
 		return $directories;
 	}
 


### PR DESCRIPTION
## Summary
- Add a conditional external directory entry for Premium Layouts in the Prebuilt Layouts sidebar.
- Keep the feature off by default via a new filter.
- Add a dedicated filter for premium directory query arguments.

## Details
- New boolean filter: siteorigin_panels_premium_layouts_enabled (default false).
- New args filter: siteorigin_panels_premium_layouts_directory_args (default access=premium).
- New directory key: siteorigin-premium with label Premium Layouts.

## Why
Premium layouts currently load through the existing Layouts Directory flow, but there is no separate sidebar tab to showcase premium content. This adds the conditional tab support needed for Premium integration while remaining fully backward-compatible.

## Validation
- php -l inc/admin-layouts.php
