### PR TITLE
Move WooCommerce Compatibility Into a Dedicated Compat File

### DIFF
--- a/compat/woocommerce.php
+++ b/compat/woocommerce.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Compatibility with WooCommerce.
+ */
+class SiteOrigin_Panels_Compat_WooCommerce {
+	public static function single() {
+		static $single;
+
+		return empty( $single ) ? $single = new self() : $single;
+	}
+
+	public function __construct() {
+		add_filter( 'woocommerce_format_content', array( $this, 'generate_shop_content' ), 10, 2 );
+	}
+
+	/**
+	 * Generate post content for the WooCommerce Shop page if it uses a Page Builder layout.
+	 *
+	 * @param string $content     Formatted content.
+	 * @param string $raw_content Raw content before WooCommerce formatting.
+	 *
+	 * @return string
+	 */
+	public function generate_shop_content( $content, $_raw_content = '' ) {
+		if ( ! self::is_shop_description_context() ) {
+			return $content;
+		}
+
+		$shop_page_id = wc_get_page_id( 'shop' );
+		if ( empty( $shop_page_id ) ) {
+			return $content;
+		}
+
+		$shop_page = get_post( $shop_page_id );
+		if ( empty( $shop_page ) ) {
+			return $content;
+		}
+
+		global $post;
+		$original_post = $post;
+
+		// Ensure downstream content checks run against the Shop page context.
+		$post = $shop_page;
+		$content = SiteOrigin_Panels::single()->generate_post_content( $content );
+		$post = $original_post;
+
+		return $content;
+	}
+
+	/**
+	 * Is WooCommerce currently rendering the Shop page archive description.
+	 *
+	 * Mirrors WooCommerce's own archive description conditions to avoid
+	 * intercepting unrelated `wc_format_content()` calls (e.g. checkout TOS).
+	 *
+	 * @return bool
+	 */
+	private static function is_shop_description_context() {
+		return (
+			class_exists( 'WooCommerce' ) &&
+			doing_action( 'woocommerce_archive_description' ) &&
+			! is_search() &&
+			is_post_type_archive( 'product' ) &&
+			in_array( absint( get_query_var( 'paged' ) ), array( 0, 1 ), true )
+		);
+	}
+
+	/**
+	 * Should we use the configured WooCommerce Shop page ID as the current post ID.
+	 *
+	 * @return bool
+	 */
+	public static function should_use_shop_page_id() {
+		if ( ! class_exists( 'WooCommerce' ) || ! is_shop() ) {
+			return false;
+		}
+
+		$shop_page_id = wc_get_page_id( 'shop' );
+		if ( empty( $shop_page_id ) ) {
+			return false;
+		}
+
+		// The shop is a product archive request, even when loop internals shift the queried object.
+		if ( is_post_type_archive( 'product' ) ) {
+			return true;
+		}
+
+		return (int) get_queried_object_id() === (int) $shop_page_id;
+	}
+}

--- a/inc/compatibility.php
+++ b/inc/compatibility.php
@@ -126,6 +126,11 @@ class SiteOrigin_Panels_Compatibility {
 		if ( defined( 'EM_VERSION' ) ) {
 			require_once $this->compat_path . 'events-manager.php';
 		}
+
+		// Compatibility with WooCommerce.
+		if ( class_exists( 'WooCommerce' ) ) {
+			SiteOrigin_Panels_Compat_WooCommerce::single();
+		}
 	}
 
 	public function widgets_init() {

--- a/inc/renderer.php
+++ b/inc/renderer.php
@@ -565,7 +565,7 @@ class SiteOrigin_Panels_Renderer {
 		if ( empty( $post_id ) ) {
 			$post_id = get_the_ID();
 
-			if ( SiteOrigin_Panels::should_use_woocommerce_shop_page_id() ) {
+			if ( SiteOrigin_Panels_Compat_WooCommerce::should_use_shop_page_id() ) {
 				$post_id = wc_get_page_id( 'shop' );
 			}
 		}
@@ -821,7 +821,7 @@ class SiteOrigin_Panels_Renderer {
 		if ( empty( $post_id ) ) {
 			$post_id = get_the_ID();
 
-			if ( SiteOrigin_Panels::should_use_woocommerce_shop_page_id() ) {
+			if ( SiteOrigin_Panels_Compat_WooCommerce::should_use_shop_page_id() ) {
 				$post_id = wc_get_page_id( 'shop' );
 			}
 		}

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -75,7 +75,6 @@ class SiteOrigin_Panels {
 
 		// We need to generate fresh post content.
 		add_filter( 'the_content', array( $this, 'generate_post_content' ) );
-		add_filter( 'woocommerce_format_content', array( $this, 'generate_woocommerce_content' ), 10, 2 );
 		add_filter( 'wp_enqueue_scripts', array( $this, 'generate_post_css' ) );
 
 		// Remove the default excerpt function.
@@ -300,60 +299,6 @@ class SiteOrigin_Panels {
 	}
 
 	/**
-	 * Generate post content for WooCommerce shop page if it's using a PB layout.
-	 *
-	 * @param string $content     Formatted content.
-	 * @param string $raw_content Raw content before WooCommerce formatting.
-	 *
-	 * @return string
-	 *
-	 * @filter woocommerce_format_content
-	 */
-	public function generate_woocommerce_content( $content, $_raw_content = '' ) {
-		if ( ! self::is_woocommerce_shop_description_context() ) {
-			return $content;
-		}
-
-		$shop_page_id = wc_get_page_id( 'shop' );
-		if ( empty( $shop_page_id ) ) {
-			return $content;
-		}
-
-		$shop_page = get_post( $shop_page_id );
-		if ( empty( $shop_page ) ) {
-			return $content;
-		}
-
-		global $post;
-		$original_post = $post;
-
-		// Ensure downstream content checks run against the Shop page context.
-		$post = $shop_page;
-		$content = $this->generate_post_content( $content );
-		$post = $original_post;
-
-		return $content;
-	}
-
-	/**
-	 * Is WooCommerce currently rendering the Shop page archive description.
-	 *
-	 * Mirrors WooCommerce's own archive description conditions to avoid
-	 * intercepting unrelated `wc_format_content()` calls (e.g. checkout TOS).
-	 *
-	 * @return bool
-	 */
-	private static function is_woocommerce_shop_description_context() {
-		return (
-			class_exists( 'WooCommerce' ) &&
-			doing_action( 'woocommerce_archive_description' ) &&
-			! is_search() &&
-			is_post_type_archive( 'product' ) &&
-			in_array( absint( get_query_var( 'paged' ) ), array( 0, 1 ), true )
-		);
-	}
-
-	/**
 	 * Generate post content for the current post.
 	 *
 	 * @return string
@@ -560,21 +505,7 @@ class SiteOrigin_Panels {
 	 * filters while processing non-Shop content.
 	 */
 	public static function should_use_woocommerce_shop_page_id() {
-		if ( ! class_exists( 'WooCommerce' ) || ! is_shop() ) {
-			return false;
-		}
-
-		$shop_page_id = wc_get_page_id( 'shop' );
-		if ( empty( $shop_page_id ) ) {
-			return false;
-		}
-
-		// The shop is a product archive request, even when loop internals shift the queried object.
-		if ( is_post_type_archive( 'product' ) ) {
-			return true;
-		}
-
-		return (int) get_queried_object_id() === (int) $shop_page_id;
+		return SiteOrigin_Panels_Compat_WooCommerce::should_use_shop_page_id();
 	}
 
 	/**

--- a/siteorigin-panels.php
+++ b/siteorigin-panels.php
@@ -482,7 +482,7 @@ class SiteOrigin_Panels {
 	public function get_post_id() {
 		$post_id = get_the_ID();
 
-		if ( self::should_use_woocommerce_shop_page_id() ) {
+		if ( SiteOrigin_Panels_Compat_WooCommerce::should_use_shop_page_id() ) {
 			$post_id = wc_get_page_id( 'shop' );
 		}
 		global $preview;
@@ -496,16 +496,6 @@ class SiteOrigin_Panels {
 		}
 
 		return $post_id;
-	}
-
-	/**
-	 * Should we use the configured WooCommerce Shop page ID as the current post ID.
-	 *
-	 * This is intentionally strict because some WooCommerce rendering contexts can invoke content
-	 * filters while processing non-Shop content.
-	 */
-	public static function should_use_woocommerce_shop_page_id() {
-		return SiteOrigin_Panels_Compat_WooCommerce::should_use_shop_page_id();
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Move WooCommerce-specific Shop content integration out of `SiteOrigin_Panels` and into `compat/woocommerce.php`.
- Load WooCommerce compatibility through `SiteOrigin_Panels_Compatibility`.
- Keep `SiteOrigin_Panels::should_use_woocommerce_shop_page_id()` as a stable delegation point to the new compat class.

## Why
Alex suggested in PR #1310 that WooCommerce compatibility code should live in a dedicated compat file. This change applies that refactor while preserving existing behavior.

## Testing
- `php -l siteorigin-panels.php`
- `php -l inc/compatibility.php`
- `php -l compat/woocommerce.php`
