### PR TITLE
Implement iframe support for SiteOrigin Layouts Block

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -131,9 +131,19 @@ function SiteOriginPanelsLayoutBlock(props) {
   }, []); // Setup the panels builder on mount; tear it down on unmount.
 
   wp.element.useEffect(function () {
-    isMountedRef.current = true; // ownerDocument resolves to the iframe document when the editor is iframed (WP 6.3+/7.0).
+    isMountedRef.current = true; // Resolve iframe document and whether script/content run inside an iframe.
 
     var iframeDoc = panelsContainer.current.ownerDocument;
+    var isScriptInIframe = window.self !== window.top;
+    var isContentInIframe = iframeDoc !== window.document;
+    var soDocument = iframeDoc; // Block native HTML5 dragstart so the Block Editor doesn't intercept panel drags.
+
+    var onContainerDragStart = function onContainerDragStart(e) {
+      e.stopPropagation();
+      e.preventDefault();
+    };
+
+    panelsContainer.current.addEventListener('dragstart', onContainerDragStart);
     var $panelsContainer = jQuery(panelsContainer.current);
     var config = {
       editorType: 'standalone',
@@ -149,21 +159,24 @@ function SiteOriginPanelsLayoutBlock(props) {
 
     var initialPanelsData = JSON.parse(JSON.stringify(jQuery.extend({}, panelsData))); // Disable block selection while dragging rows or widgets.
 
-    var rowOrWidgetMouseDown = function rowOrWidgetMouseDown() {
+    var rowOrWidgetMouseDown = function rowOrWidgetMouseDown(e) {
+      // toggleSelection(false) tells the block editor to not start its own drag-selection
+      // handling. Do NOT stopPropagation here — jQuery UI sortable binds its mousedown
+      // handler on the sortable container (an ancestor), so stopping propagation would
+      // prevent jQuery UI from ever seeing the event and starting the drag.
       if (typeof onRowOrWidgetMouseDownRef.current === 'function') {
         onRowOrWidgetMouseDownRef.current();
       }
 
       var rowOrWidgetMouseUp = function rowOrWidgetMouseUp() {
-        // Use iframeDoc: mouseup fires inside the iframe, not on the parent document.
-        jQuery(iframeDoc).off('mouseup', rowOrWidgetMouseUp);
+        jQuery(soDocument).off('mouseup', rowOrWidgetMouseUp);
 
         if (typeof onRowOrWidgetMouseUpRef.current === 'function') {
           onRowOrWidgetMouseUpRef.current();
         }
       };
 
-      jQuery(iframeDoc).on('mouseup', rowOrWidgetMouseUp);
+      jQuery(soDocument).on('mouseup', rowOrWidgetMouseUp);
     };
 
     builderViewRef.current.on('row_added', function () {
@@ -199,10 +212,47 @@ function SiteOriginPanelsLayoutBlock(props) {
       window.soPanelsBuilderView = [];
     }
 
-    window.soPanelsBuilderView.push(builderViewRef.current);
+    window.soPanelsBuilderView.push(builderViewRef.current); // If in an iframe, patch jQuery UI instances so their document/window use iframeDoc.
+
+    if (isContentInIframe || isScriptInIframe) {
+      var iframeWindow = iframeDoc.defaultView;
+
+      var patchJQueryUIDocuments = function patchJQueryUIDocuments() {
+        if (!builderViewRef.current) {
+          return;
+        }
+
+        builderViewRef.current.$('.so-rows-container, .widgets-container').each(function () {
+          var inst = jQuery(this).sortable('instance');
+
+          if (inst && inst.document && inst.document[0] !== iframeDoc) {
+            inst.document = jQuery(iframeDoc);
+            inst.window = jQuery(iframeWindow);
+          }
+        });
+        builderViewRef.current.$('.resize-handle').each(function () {
+          var inst = jQuery(this).draggable('instance');
+
+          if (inst && inst.document && inst.document[0] !== iframeDoc) {
+            inst.document = jQuery(iframeDoc);
+            inst.window = jQuery(iframeWindow);
+          }
+        });
+      }; // Patch initial instances after first render.
+
+
+      setTimeout(patchJQueryUIDocuments, 0); // Re-patch whenever a new row or widget is added (new instances are created).
+
+      builderViewRef.current.on('row_added widget_added', patchJQueryUIDocuments);
+    }
+
     setPanelsInitialized(true);
     return function () {
       isMountedRef.current = false;
+
+      if (panelsContainer.current) {
+        panelsContainer.current.removeEventListener('dragstart', onContainerDragStart);
+      }
 
       if (builderViewRef.current) {
         // Remove builder from global builder list.

--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -1,391 +1,281 @@
 "use strict";
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
 
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _iterableToArrayLimit(arr, i) { if (!(Symbol.iterator in Object(arr) || Object.prototype.toString.call(arr) === "[object Arguments]")) { return; } var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
+/**
+ * Checks if two panels data objects are equal.
+ * @param {Object} newPanelsData - The new panels data object.
+ * @param {Object} oldPanelsData - The old panels data object.
+ * @returns {boolean} - Returns true if the two panels data objects are equal, otherwise false.
+ */
+function SiteOriginIsPanelsEqual(newPanelsData, oldPanelsData) {
+  if (newPanelsData === oldPanelsData) {
+    return true;
   }
 
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
+  if (!newPanelsData || !oldPanelsData) {
+    return newPanelsData === oldPanelsData;
+  } // If neither newPanelsData nor oldPanelsData are objects, assume they're not the same.
 
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
 
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
+  if (_typeof(newPanelsData) !== 'object' || _typeof(oldPanelsData) !== 'object') {
+    return false;
+  }
 
-    return _possibleConstructorReturn(this, result);
-  };
+  var keys = Object.keys(newPanelsData);
+
+  if (keys.length !== Object.keys(oldPanelsData).length) {
+    return false;
+  }
+
+  return keys.every(function (k) {
+    return SiteOriginIsPanelsEqual(newPanelsData[k], oldPanelsData[k]);
+  });
 }
 
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+function SiteOriginPanelsLayoutBlock(props) {
+  var editing = props.editing,
+      panelsData = props.panelsData,
+      onContentChange = props.onContentChange,
+      onRowOrWidgetMouseDown = props.onRowOrWidgetMouseDown,
+      onRowOrWidgetMouseUp = props.onRowOrWidgetMouseUp; // State
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+  var _wp$element$useState = wp.element.useState(true),
+      _wp$element$useState2 = _slicedToArray(_wp$element$useState, 2),
+      loadingPreview = _wp$element$useState2[0],
+      setLoadingPreview = _wp$element$useState2[1];
 
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+  var _wp$element$useState3 = wp.element.useState(''),
+      _wp$element$useState4 = _slicedToArray(_wp$element$useState3, 2),
+      previewHtml = _wp$element$useState4[0],
+      setPreviewHtml = _wp$element$useState4[1];
 
-var SiteOriginPanelsLayoutBlock =
-/*#__PURE__*/
-function (_wp$element$Component) {
-  _inherits(SiteOriginPanelsLayoutBlock, _wp$element$Component);
+  var _wp$element$useState5 = wp.element.useState(!editing),
+      _wp$element$useState6 = _slicedToArray(_wp$element$useState5, 2),
+      previewInitialized = _wp$element$useState6[0],
+      setPreviewInitialized = _wp$element$useState6[1];
 
-  var _super = _createSuper(SiteOriginPanelsLayoutBlock);
+  var _wp$element$useState7 = wp.element.useState(false),
+      _wp$element$useState8 = _slicedToArray(_wp$element$useState7, 2),
+      pendingPreviewRequest = _wp$element$useState8[0],
+      setPendingPreviewRequest = _wp$element$useState8[1];
 
-  function SiteOriginPanelsLayoutBlock(props) {
-    var _this2;
+  var _wp$element$useState9 = wp.element.useState(false),
+      _wp$element$useState10 = _slicedToArray(_wp$element$useState9, 2),
+      panelsInitialized = _wp$element$useState10[0],
+      setPanelsInitialized = _wp$element$useState10[1]; // DOM and instance refs
 
-    _classCallCheck(this, SiteOriginPanelsLayoutBlock);
 
-    _this2 = _super.call(this, props);
+  var panelsContainer = wp.element.useRef(null);
+  var previewContainer = wp.element.useRef(null);
+  var builderViewRef = wp.element.useRef(null);
+  var fetchPreviewTimer = wp.element.useRef(null);
+  var currentFetchRequest = wp.element.useRef(null);
+  var isMountedRef = wp.element.useRef(false); // Keep prop callbacks current so the mount-only setup effect always calls the latest version.
 
-    _this2.initializeState(props);
+  var onContentChangeRef = wp.element.useRef(onContentChange);
+  var onRowOrWidgetMouseDownRef = wp.element.useRef(onRowOrWidgetMouseDown);
+  var onRowOrWidgetMouseUpRef = wp.element.useRef(onRowOrWidgetMouseUp);
+  wp.element.useEffect(function () {
+    onContentChangeRef.current = onContentChange;
+  }, [onContentChange]);
+  wp.element.useEffect(function () {
+    onRowOrWidgetMouseDownRef.current = onRowOrWidgetMouseDown;
+  }, [onRowOrWidgetMouseDown]);
+  wp.element.useEffect(function () {
+    onRowOrWidgetMouseUpRef.current = onRowOrWidgetMouseUp;
+  }, [onRowOrWidgetMouseUp]); // Fetch a preview from the server and update state.
 
-    _this2.panelsContainer = wp.element.createRef();
-    _this2.previewContainer = wp.element.createRef();
-    _this2.fetchPreviewTimer = null;
-    _this2.currentFetchRequest = null;
-    return _this2;
-  }
-
-  _createClass(SiteOriginPanelsLayoutBlock, [{
-    key: "initializeState",
-    value: function initializeState(props) {
-      var newState = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
-      var hasPanelsData = props.panelsData && _typeof(props.panelsData) === 'object' && Object.keys(props.panelsData).length > 0;
-      var isDefaultModeEdit = window.soPanelsBlockEditorAdmin.defaultMode === 'edit';
-      var editMode = hasPanelsData === true ? isDefaultModeEdit : true;
-      this.initialState = {
-        editing: editMode,
-        loadingPreview: true,
-        previewHtml: '',
-        previewInitialized: !editMode,
-        pendingPreviewRequest: false,
-        panelsInitialized: false
-      }; // Depending on when this function is called, we need to update the
-      // state differently.
-
-      if (newState) {
-        this.state = _objectSpread({}, this.initialState);
-      } else {
-        this.setState(_objectSpread({}, this.initialState));
-      }
+  var fetchPreview = wp.element.useCallback(function () {
+    if (!isMountedRef.current) {
+      return;
     }
-  }, {
-    key: "componentDidMount",
-    value: function componentDidMount() {
-      this.isStillMounted = true;
 
-      if (!this.state.panelsInitialized) {
-        this.setupPanels();
+    setPreviewInitialized(false); // Capture the iframe document now so the deferred trigger uses the correct context.
+
+    var iframeDoc = panelsContainer.current ? panelsContainer.current.ownerDocument : document;
+    var fetchRequest = jQuery.post({
+      url: window.soPanelsBlockEditorAdmin.previewUrl,
+      data: {
+        action: 'so_panels_layout_block_preview',
+        panelsData: JSON.stringify(builderViewRef.current.getData())
       }
+    }).then(function (preview) {
+      if (!isMountedRef.current) {
+        return;
+      } // Wait until previewHTML has finished updating to cut
+      // down on the chance of nothing being rendered.
+
+
+      setTimeout(function () {
+        jQuery(iframeDoc).trigger('panels_setup_preview');
+      }, 1000);
+
+      if (fetchRequest === currentFetchRequest.current && preview) {
+        setPreviewHtml(preview);
+        setLoadingPreview(false);
+        setPreviewInitialized(false);
+        setPendingPreviewRequest(false);
+      }
+    });
+    currentFetchRequest.current = fetchRequest;
+    return fetchRequest;
+  }, []); // Setup the panels builder on mount; tear it down on unmount.
+
+  wp.element.useEffect(function () {
+    isMountedRef.current = true; // ownerDocument resolves to the iframe document when the editor is iframed (WP 6.3+/7.0).
+
+    var iframeDoc = panelsContainer.current.ownerDocument;
+    var $panelsContainer = jQuery(panelsContainer.current);
+    var config = {
+      editorType: 'standalone',
+      loadLiveEditor: false,
+      postId: window.soPanelsBlockEditorAdmin.postId,
+      editorPreview: window.soPanelsBlockEditorAdmin.liveEditor
+    };
+    var builderModel = new panels.model.builder();
+    builderViewRef.current = new panels.view.builder({
+      model: builderModel,
+      config: config
+    }); // Make sure panelsData is defined and clone so that we don't alter the underlying attribute.
+
+    var initialPanelsData = JSON.parse(JSON.stringify(jQuery.extend({}, panelsData))); // Disable block selection while dragging rows or widgets.
+
+    var rowOrWidgetMouseDown = function rowOrWidgetMouseDown() {
+      if (typeof onRowOrWidgetMouseDownRef.current === 'function') {
+        onRowOrWidgetMouseDownRef.current();
+      }
+
+      var rowOrWidgetMouseUp = function rowOrWidgetMouseUp() {
+        // Use iframeDoc: mouseup fires inside the iframe, not on the parent document.
+        jQuery(iframeDoc).off('mouseup', rowOrWidgetMouseUp);
+
+        if (typeof onRowOrWidgetMouseUpRef.current === 'function') {
+          onRowOrWidgetMouseUpRef.current();
+        }
+      };
+
+      jQuery(iframeDoc).on('mouseup', rowOrWidgetMouseUp);
+    };
+
+    builderViewRef.current.on('row_added', function () {
+      builderViewRef.current.$('.so-row-move').off('mousedown', rowOrWidgetMouseDown);
+      builderViewRef.current.$('.so-row-move').on('mousedown', rowOrWidgetMouseDown);
+      builderViewRef.current.$('.so-widget').off('mousedown', rowOrWidgetMouseDown);
+      builderViewRef.current.$('.so-widget').on('mousedown', rowOrWidgetMouseDown);
+    });
+    builderViewRef.current.on('widget_added', function () {
+      builderViewRef.current.$('.so-widget').off('mousedown', rowOrWidgetMouseDown);
+      builderViewRef.current.$('.so-widget').on('mousedown', rowOrWidgetMouseDown);
+    });
+    builderViewRef.current.render().attach({
+      container: $panelsContainer
+    }).setData(initialPanelsData);
+    builderViewRef.current.trigger('builder_resize');
+    builderViewRef.current.on('content_change', function () {
+      var newPanelsData = builderViewRef.current.getData();
+
+      if (!SiteOriginIsPanelsEqual(initialPanelsData, newPanelsData)) {
+        if (typeof onContentChangeRef.current === 'function') {
+          onContentChangeRef.current(newPanelsData);
+        }
+
+        setLoadingPreview(true);
+        setPreviewHtml('');
+      }
+    }); // Use iframeDoc so panels scripts inside the iframe receive the setup event.
+
+    jQuery(iframeDoc).trigger('panels_setup', builderViewRef.current);
+
+    if (typeof window.soPanelsBuilderView === 'undefined') {
+      window.soPanelsBuilderView = [];
     }
-  }, {
-    key: "componentWillUnmount",
-    value: function componentWillUnmount() {
-      var _this3 = this;
 
-      this.isStillMounted = false;
+    window.soPanelsBuilderView.push(builderViewRef.current);
+    setPanelsInitialized(true);
+    return function () {
+      isMountedRef.current = false;
 
-      if (this.builderView) {
+      if (builderViewRef.current) {
         // Remove builder from global builder list.
         if (typeof window.soPanelsBuilderView !== 'undefined') {
           window.soPanelsBuilderView = window.soPanelsBuilderView.filter(function (view) {
-            return view !== _this3.builderView;
+            return view !== builderViewRef.current;
           });
         }
 
-        delete this.builderView;
+        builderViewRef.current = null;
       }
 
-      if (this.currentFetchRequest && typeof this.currentFetchRequest.abort === 'function') {
-        this.currentFetchRequest.abort();
+      if (currentFetchRequest.current && typeof currentFetchRequest.current.abort === 'function') {
+        currentFetchRequest.current.abort();
       }
 
-      clearTimeout(this.fetchPreviewTimer);
+      clearTimeout(fetchPreviewTimer.current);
 
-      if (this.panelsContainer) {
-        jQuery(this.panelsContainer.current).empty();
+      if (panelsContainer.current) {
+        jQuery(panelsContainer.current).empty();
       }
 
-      if (this.previewContainer) {
-        jQuery(this.previewContainer.current).empty();
+      if (previewContainer.current) {
+        jQuery(previewContainer.current).empty();
       }
+    };
+  }, []); // Schedule a preview fetch or fire setup when preview loading state changes.
 
-      this.initializeState(this.props, false);
+  wp.element.useEffect(function () {
+    if (!panelsInitialized) {
+      return;
     }
-  }, {
-    key: "componentDidUpdate",
-    value: function componentDidUpdate(prevProps) {
-      if (!this.isStillMounted || !this.state.panelsInitialized) {
-        return;
-      }
 
-      if (this.state.loadingPreview) {
-        if (!this.state.pendingPreviewRequest) {
-          this.setState({
-            pendingPreviewRequest: true
-          });
-          clearTimeout(this.fetchPreviewTimer);
-          var current = this;
-          this.fetchPreviewTimer = setTimeout(function () {
-            current.fetchPreview(current.props);
-          }, 1000);
-        }
-      } else if (!this.state.previewInitialized) {
-        jQuery(document).trigger('panels_setup_preview');
-        this.setState({
-          previewInitialized: true
-        });
-      }
-    }
-  }, {
-    key: "setupPanels",
-    value: function setupPanels() {
-      var _this4 = this;
-
-      if (this.state.panelsInitialized || !this.isStillMounted) {
-        return;
-      }
-
-      var $panelsContainer = jQuery(this.panelsContainer.current);
-      var config = {
-        editorType: 'standalone',
-        loadLiveEditor: false,
-        postId: window.soPanelsBlockEditorAdmin.postId,
-        editorPreview: window.soPanelsBlockEditorAdmin.liveEditor
-      };
-      var builderModel = new panels.model.builder();
-      this.builderView = new panels.view.builder({
-        model: builderModel,
-        config: config
-      }); // Make sure panelsData is defined and clone so that we don't alter the underlying attribute.
-
-      var panelsData = JSON.parse(JSON.stringify(jQuery.extend({}, this.props.panelsData))); // Disable block selection while dragging rows or widgets.
-
-      var rowOrWidgetMouseDown = function rowOrWidgetMouseDown() {
-        if (typeof _this4.props.onRowOrWidgetMouseDown === 'function') {
-          _this4.props.onRowOrWidgetMouseDown();
-        }
-
-        var rowOrWidgetMouseUp = function rowOrWidgetMouseUp() {
-          jQuery(document).off('mouseup', rowOrWidgetMouseUp);
-
-          if (typeof _this4.props.onRowOrWidgetMouseUp === 'function') {
-            _this4.props.onRowOrWidgetMouseUp();
-          }
-        };
-
-        jQuery(document).on('mouseup', rowOrWidgetMouseUp);
-      };
-
-      this.builderView.on('row_added', function () {
-        _this4.builderView.$('.so-row-move').off('mousedown', rowOrWidgetMouseDown);
-
-        _this4.builderView.$('.so-row-move').on('mousedown', rowOrWidgetMouseDown);
-
-        _this4.builderView.$('.so-widget').off('mousedown', rowOrWidgetMouseDown);
-
-        _this4.builderView.$('.so-widget').on('mousedown', rowOrWidgetMouseDown);
-      });
-      this.builderView.on('widget_added', function () {
-        _this4.builderView.$('.so-widget').off('mousedown', rowOrWidgetMouseDown);
-
-        _this4.builderView.$('.so-widget').on('mousedown', rowOrWidgetMouseDown);
-      });
-      this.builderView.render().attach({
-        container: $panelsContainer
-      }).setData(panelsData);
-      this.builderView.trigger('builder_resize');
-      /**
-       * Checks if two panels data objects are equal.
-       * @param {Object} newPanelsData - The new panels data object.
-       * @param {Object} oldPanelsData - The old panels data object.
-       * @returns {boolean} - Returns true if the two panels data objects are equal, otherwise false.
-       */
-
-      var SiteOriginIsPanelsEqual = function SiteOriginIsPanelsEqual(newPanelsData, oldPanelsData) {
-        if (newPanelsData === oldPanelsData) {
-          return true;
-        }
-
-        if (!newPanelsData || !oldPanelsData) {
-          return newPanelsData === oldPanelsData;
-        } // If neither newPanelsData nor oldPanelsData are objects, assume they're not the same.
-
-
-        if (_typeof(newPanelsData) !== 'object' || _typeof(oldPanelsData) !== 'object') {
-          return false;
-        }
-
-        var keys = Object.keys(newPanelsData);
-
-        if (keys.length !== Object.keys(oldPanelsData).length) {
-          return false;
-        }
-
-        return keys.every(function (k) {
-          return SiteOriginIsPanelsEqual(newPanelsData[k], oldPanelsData[k]);
-        });
-      };
-
-      this.builderView.on('content_change', function () {
-        var newPanelsData = _this4.builderView.getData();
-
-        _this4.panelsDataChanged = !SiteOriginIsPanelsEqual(panelsData, newPanelsData);
-
-        if (_this4.panelsDataChanged) {
-          if (_this4.props.onContentChange && typeof _this4.props.onContentChange === 'function') {
-            _this4.props.onContentChange(newPanelsData);
-          }
-
-          _this4.setState({
-            loadingPreview: true,
-            previewHtml: ''
-          });
-        }
-      });
-      jQuery(document).trigger('panels_setup', this.builderView);
-
-      if (typeof window.soPanelsBuilderView == 'undefined') {
-        window.soPanelsBuilderView = [];
-      }
-
-      window.soPanelsBuilderView.push(this.builderView);
-      this.setState({
-        panelsInitialized: true
-      });
-    }
-  }, {
-    key: "fetchPreview",
-    value: function fetchPreview(props) {
-      var _this5 = this;
-
-      if (!this.isStillMounted) {
-        return;
-      }
-
-      this.setState({
-        previewInitialized: false
-      });
-      var fetchRequest = this.currentFetchRequest = jQuery.post({
-        url: window.soPanelsBlockEditorAdmin.previewUrl,
-        data: {
-          action: 'so_panels_layout_block_preview',
-          panelsData: JSON.stringify(this.builderView.getData())
-        }
-      }).then(function (preview) {
-        if (!_this5.isStillMounted) {
-          return;
-        }
-
-        setTimeout(function () {
-          jQuery(document).trigger('panels_setup_preview');
+    if (loadingPreview) {
+      if (!pendingPreviewRequest) {
+        setPendingPreviewRequest(true);
+        clearTimeout(fetchPreviewTimer.current);
+        fetchPreviewTimer.current = setTimeout(function () {
+          return fetchPreview();
         }, 1000);
+      }
+    } else if (!previewInitialized) {
+      var iframeDoc = panelsContainer.current ? panelsContainer.current.ownerDocument : document;
+      jQuery(iframeDoc).trigger('panels_setup_preview');
+      setPreviewInitialized(true);
+    }
+  }, [loadingPreview, panelsInitialized, pendingPreviewRequest, previewInitialized, fetchPreview]); // Trigger a layout recalculation whenever we switch back into edit mode.
 
-        if (fetchRequest === _this5.currentFetchRequest && preview) {
-          _this5.setState({
-            previewHtml: preview
-          }, // Wait until previewHTML has finished updating to cut
-          // down on the chance of nothing being rendered.
-          function () {
-            _this5.setState({
-              loadingPreview: false,
-              previewInitialized: false,
-              pendingPreviewRequest: false
-            });
-          });
+  wp.element.useEffect(function () {
+    if (editing && builderViewRef.current) {
+      setTimeout(function () {
+        if (builderViewRef.current) {
+          builderViewRef.current.trigger('builder_resize');
         }
       });
-      return fetchRequest;
     }
-  }, {
-    key: "render",
-    value: function render() {
-      var _this6 = this;
-
-      var panelsData = this.props.panelsData;
-
-      var switchToEditing = function switchToEditing() {
-        _this6.setState({
-          editing: true
-        });
-
-        var _this = _this6;
-        setTimeout(function () {
-          _this.builderView.trigger('builder_resize');
-        });
-      };
-
-      var switchToPreview = function switchToPreview() {
-        if (panelsData) {
-          _this6.setState({
-            editing: false
-          });
-        }
-      };
-
-      return React.createElement(wp.element.Fragment, null, React.createElement(wp.blockEditor.BlockControls, null, React.createElement(wp.components.Toolbar, {
-        label: wp.i18n.__('Page Builder Mode.', 'siteorigin-panels')
-      }, this.state.editing ? React.createElement(wp.components.ToolbarButton, {
-        icon: "visibility",
-        className: "components-icon-button components-toolbar__control",
-        label: wp.i18n.__('Preview layout.', 'siteorigin-panels'),
-        onClick: switchToPreview
-      }) : React.createElement(wp.components.ToolbarButton, {
-        icon: "edit",
-        className: "components-icon-button components-toolbar__control",
-        label: wp.i18n.__('Edit layout.', 'siteorigin-panels'),
-        onClick: switchToEditing
-      }))), React.createElement("div", {
-        key: "layout-block",
-        className: "siteorigin-panels-layout-block-container",
-        ref: this.panelsContainer,
-        hidden: !this.state.editing
-      }), React.createElement("div", {
-        key: "preview",
-        className: "so-panels-block-layout-preview-container",
-        hidden: this.state.editing
-      }, this.state.loadingPreview ? React.createElement("div", {
-        className: "so-panels-spinner-container"
-      }, React.createElement("span", null, React.createElement(wp.components.Spinner, null))) : React.createElement("div", {
-        className: "so-panels-raw-html-container",
-        ref: this.previewContainer
-      }, React.createElement(wp.element.RawHTML, null, this.state.previewHtml))));
-    }
-  }]);
-
-  return SiteOriginPanelsLayoutBlock;
-}(wp.element.Component);
+  }, [editing]);
+  return React.createElement(wp.element.Fragment, null, React.createElement("div", {
+    key: "layout-block",
+    className: "siteorigin-panels-layout-block-container",
+    ref: panelsContainer,
+    hidden: !editing
+  }), React.createElement("div", {
+    key: "preview",
+    className: "so-panels-block-layout-preview-container",
+    hidden: editing
+  }, loadingPreview ? React.createElement("div", {
+    className: "so-panels-spinner-container"
+  }, React.createElement("span", null, React.createElement(wp.components.Spinner, null))) : React.createElement("div", {
+    className: "so-panels-raw-html-container",
+    ref: previewContainer
+  }, React.createElement(wp.element.RawHTML, null, previewHtml))));
+}
 
 var hasLayoutCategory = wp.blocks.getCategories().some(function (category) {
   return category.slug === 'layout';
@@ -411,12 +301,30 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
       type: 'string'
     }
   },
+  apiVersion: 3,
   edit: function edit(_ref) {
     var attributes = _ref.attributes,
         setAttributes = _ref.setAttributes,
         toggleSelection = _ref.toggleSelection;
+    var blockProps = wp.blockEditor.useBlockProps(); // Derive the initial editing state once.
 
-    var onLayoutBlockContentChange = function onLayoutBlockContentChange(newPanelsData) {
+    var hasPanelsData = attributes.panelsData && _typeof(attributes.panelsData) === 'object' && Object.keys(attributes.panelsData).length > 0;
+    var initialEditing = hasPanelsData ? window.soPanelsBlockEditorAdmin.defaultMode === 'edit' : true;
+
+    var _wp$element$useState11 = wp.element.useState(initialEditing),
+        _wp$element$useState12 = _slicedToArray(_wp$element$useState11, 2),
+        editing = _wp$element$useState12[0],
+        setEditing = _wp$element$useState12[1];
+
+    var switchToEditing = wp.element.useCallback(function () {
+      setEditing(true);
+    }, []);
+    var switchToPreview = wp.element.useCallback(function () {
+      if (attributes.panelsData) {
+        setEditing(false);
+      }
+    }, [attributes.panelsData]);
+    var onLayoutBlockContentChange = wp.element.useCallback(function (newPanelsData) {
       if (newPanelsData.widgets !== null && _typeof(newPanelsData.widgets) === 'object' && Object.keys(newPanelsData.widgets).length > 0) {
         // Send panelsData to server for sanitization.
         var isNewWPBlockEditor = jQuery('.widgets-php').length;
@@ -456,22 +364,32 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
           contentPreview: null
         });
       }
-    };
-
-    var disableSelection = function disableSelection() {
+    }, [setAttributes]);
+    var disableSelection = wp.element.useCallback(function () {
       toggleSelection(false);
-    };
-
-    var enableSelection = function enableSelection() {
+    }, [toggleSelection]);
+    var enableSelection = wp.element.useCallback(function () {
       toggleSelection(true);
-    };
-
-    return React.createElement(SiteOriginPanelsLayoutBlock, {
+    }, [toggleSelection]);
+    return React.createElement(wp.element.Fragment, null, React.createElement(wp.blockEditor.BlockControls, null, React.createElement(wp.components.Toolbar, {
+      label: wp.i18n.__('Page Builder Mode.', 'siteorigin-panels')
+    }, editing ? React.createElement(wp.components.ToolbarButton, {
+      icon: "visibility",
+      className: "components-icon-button components-toolbar__control",
+      label: wp.i18n.__('Preview layout.', 'siteorigin-panels'),
+      onClick: switchToPreview
+    }) : React.createElement(wp.components.ToolbarButton, {
+      icon: "edit",
+      className: "components-icon-button components-toolbar__control",
+      label: wp.i18n.__('Edit layout.', 'siteorigin-panels'),
+      onClick: switchToEditing
+    }))), React.createElement("div", blockProps, React.createElement(SiteOriginPanelsLayoutBlock, {
+      editing: editing,
       panelsData: attributes.panelsData,
       onContentChange: onLayoutBlockContentChange,
       onRowOrWidgetMouseDown: disableSelection,
       onRowOrWidgetMouseUp: enableSelection
-    });
+    })));
   }
 });
 jQuery(function () {

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -104,8 +104,19 @@ function SiteOriginPanelsLayoutBlock( props ) {
 	wp.element.useEffect( () => {
 		isMountedRef.current = true;
 
-		// ownerDocument resolves to the iframe document when the editor is iframed (WP 6.3+/7.0).
+		// Resolve iframe document and whether script/content run inside an iframe.
 		const iframeDoc = panelsContainer.current.ownerDocument;
+		const isScriptInIframe = window.self !== window.top;
+		const isContentInIframe = iframeDoc !== window.document;
+		const soDocument = iframeDoc;
+
+		// Block native HTML5 dragstart so the Block Editor doesn't intercept panel drags.
+		var onContainerDragStart = function( e ) {
+			e.stopPropagation();
+			e.preventDefault();
+		};
+		panelsContainer.current.addEventListener( 'dragstart', onContainerDragStart );
+
 		var $panelsContainer = jQuery( panelsContainer.current );
 
 		var config = {
@@ -126,18 +137,21 @@ function SiteOriginPanelsLayoutBlock( props ) {
 		var initialPanelsData = JSON.parse( JSON.stringify( jQuery.extend( {}, panelsData ) ) );
 
 		// Disable block selection while dragging rows or widgets.
-		let rowOrWidgetMouseDown = () => {
+		let rowOrWidgetMouseDown = ( e ) => {
+			// toggleSelection(false) tells the block editor to not start its own drag-selection
+			// handling. Do NOT stopPropagation here — jQuery UI sortable binds its mousedown
+			// handler on the sortable container (an ancestor), so stopping propagation would
+			// prevent jQuery UI from ever seeing the event and starting the drag.
 			if ( typeof onRowOrWidgetMouseDownRef.current === 'function' ) {
 				onRowOrWidgetMouseDownRef.current();
 			}
 			let rowOrWidgetMouseUp = () => {
-				// Use iframeDoc: mouseup fires inside the iframe, not on the parent document.
-				jQuery( iframeDoc ).off( 'mouseup', rowOrWidgetMouseUp );
+				jQuery( soDocument ).off( 'mouseup', rowOrWidgetMouseUp );
 				if ( typeof onRowOrWidgetMouseUpRef.current === 'function' ) {
 					onRowOrWidgetMouseUpRef.current();
 				}
 			};
-			jQuery( iframeDoc ).on( 'mouseup', rowOrWidgetMouseUp );
+			jQuery( soDocument ).on( 'mouseup', rowOrWidgetMouseUp );
 		};
 
 		builderViewRef.current.on( 'row_added', () => {
@@ -181,10 +195,42 @@ function SiteOriginPanelsLayoutBlock( props ) {
 		}
 		window.soPanelsBuilderView.push( builderViewRef.current );
 
+		// If in an iframe, patch jQuery UI instances so their document/window use iframeDoc.
+		if ( isContentInIframe || isScriptInIframe ) {
+			const iframeWindow = iframeDoc.defaultView;
+			const patchJQueryUIDocuments = () => {
+				if ( ! builderViewRef.current ) {
+					return;
+				}
+				builderViewRef.current.$( '.so-rows-container, .widgets-container' ).each( function() {
+					const inst = jQuery( this ).sortable( 'instance' );
+					if ( inst && inst.document && inst.document[0] !== iframeDoc ) {
+						inst.document = jQuery( iframeDoc );
+						inst.window   = jQuery( iframeWindow );
+					}
+				} );
+				builderViewRef.current.$( '.resize-handle' ).each( function() {
+					const inst = jQuery( this ).draggable( 'instance' );
+					if ( inst && inst.document && inst.document[0] !== iframeDoc ) {
+						inst.document = jQuery( iframeDoc );
+						inst.window   = jQuery( iframeWindow );
+					}
+				} );
+			};
+			// Patch initial instances after first render.
+			setTimeout( patchJQueryUIDocuments, 0 );
+			// Re-patch whenever a new row or widget is added (new instances are created).
+			builderViewRef.current.on( 'row_added widget_added', patchJQueryUIDocuments );
+		}
+
 		setPanelsInitialized( true );
 
 		return () => {
 			isMountedRef.current = false;
+
+			if ( panelsContainer.current ) {
+				panelsContainer.current.removeEventListener( 'dragstart', onContainerDragStart );
+			}
 
 			if ( builderViewRef.current ) {
 				// Remove builder from global builder list.

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -1,113 +1,112 @@
-class SiteOriginPanelsLayoutBlock extends wp.element.Component {
-	constructor( props ) {
-		super( props );
-
-		this.initializeState( props );
-
-		this.panelsContainer = wp.element.createRef();
-		this.previewContainer = wp.element.createRef();
-		this.fetchPreviewTimer = null;
-		this.currentFetchRequest = null;
+/**
+ * Checks if two panels data objects are equal.
+ * @param {Object} newPanelsData - The new panels data object.
+ * @param {Object} oldPanelsData - The old panels data object.
+ * @returns {boolean} - Returns true if the two panels data objects are equal, otherwise false.
+ */
+function SiteOriginIsPanelsEqual( newPanelsData, oldPanelsData ) {
+	if ( newPanelsData === oldPanelsData ) {
+		return true;
 	}
 
-	initializeState(props, newState = true) {
-		const hasPanelsData = props.panelsData &&
-			typeof props.panelsData === 'object' &&
-			Object.keys( props.panelsData ).length > 0;
-			
-		const isDefaultModeEdit = window.soPanelsBlockEditorAdmin.defaultMode === 'edit';
-		const editMode = hasPanelsData === true ? isDefaultModeEdit : true;
-
-		this.initialState = {
-			editing: editMode,
-			loadingPreview: true,
-			previewHtml: '',
-			previewInitialized: ! editMode,
-			pendingPreviewRequest: false,
-			panelsInitialized: false,
-		};
-
-		// Depending on when this function is called, we need to update the
-		// state differently.
-		if ( newState ) {
-			this.state = { ...this.initialState };
-		} else {
-			this.setState( { ...this.initialState } );
-		}
+	if ( ! newPanelsData || ! oldPanelsData ) {
+		return newPanelsData === oldPanelsData;
 	}
 
-	componentDidMount() {
-		this.isStillMounted = true;
-		if ( ! this.state.panelsInitialized ) {
-			this.setupPanels();
-		}
+	// If neither newPanelsData nor oldPanelsData are objects, assume they're not the same.
+	if (
+		typeof( newPanelsData ) !== 'object' ||
+		typeof( oldPanelsData ) !== 'object'
+	) {
+		return false;
 	}
 
-	componentWillUnmount() {
-		this.isStillMounted = false;
-
-		if ( this.builderView ) {
-			// Remove builder from global builder list.
-			if ( typeof window.soPanelsBuilderView !== 'undefined' ) {
-				window.soPanelsBuilderView = window.soPanelsBuilderView.filter( view => view !== this.builderView );
-			}
-
-			delete this.builderView;
-		}
-
-		if (
-			this.currentFetchRequest &&
-			typeof this.currentFetchRequest.abort === 'function'
-		) {
-			this.currentFetchRequest.abort();
-		}
-
-		clearTimeout( this.fetchPreviewTimer );
-
-		if ( this.panelsContainer ) {
-			jQuery( this.panelsContainer.current ).empty();
-		}
-
-		if ( this.previewContainer ) {
-			jQuery( this.previewContainer.current ).empty();
-		}
-
-		this.initializeState(
-			this.props,
-			false
-		);
+	var keys = Object.keys( newPanelsData );
+	if ( keys.length !== Object.keys( oldPanelsData ).length ) {
+		return false;
 	}
 
-	componentDidUpdate( prevProps ) {
-		if ( ! this.isStillMounted || ! this.state.panelsInitialized ) {
+	return keys.every( k => SiteOriginIsPanelsEqual(
+		newPanelsData[ k ], oldPanelsData[ k ]
+	) );
+}
+
+function SiteOriginPanelsLayoutBlock( props ) {
+	const { editing, panelsData, onContentChange, onRowOrWidgetMouseDown, onRowOrWidgetMouseUp } = props;
+
+	// State
+	const [ loadingPreview, setLoadingPreview ] = wp.element.useState( true );
+	const [ previewHtml, setPreviewHtml ] = wp.element.useState( '' );
+	const [ previewInitialized, setPreviewInitialized ] = wp.element.useState( ! editing );
+	const [ pendingPreviewRequest, setPendingPreviewRequest ] = wp.element.useState( false );
+	const [ panelsInitialized, setPanelsInitialized ] = wp.element.useState( false );
+
+	// DOM and instance refs
+	const panelsContainer = wp.element.useRef( null );
+	const previewContainer = wp.element.useRef( null );
+	const builderViewRef = wp.element.useRef( null );
+	const fetchPreviewTimer = wp.element.useRef( null );
+	const currentFetchRequest = wp.element.useRef( null );
+	const isMountedRef = wp.element.useRef( false );
+
+	// Keep prop callbacks current so the mount-only setup effect always calls the latest version.
+	const onContentChangeRef = wp.element.useRef( onContentChange );
+	const onRowOrWidgetMouseDownRef = wp.element.useRef( onRowOrWidgetMouseDown );
+	const onRowOrWidgetMouseUpRef = wp.element.useRef( onRowOrWidgetMouseUp );
+	wp.element.useEffect( () => { onContentChangeRef.current = onContentChange; }, [ onContentChange ] );
+	wp.element.useEffect( () => { onRowOrWidgetMouseDownRef.current = onRowOrWidgetMouseDown; }, [ onRowOrWidgetMouseDown ] );
+	wp.element.useEffect( () => { onRowOrWidgetMouseUpRef.current = onRowOrWidgetMouseUp; }, [ onRowOrWidgetMouseUp ] );
+
+	// Fetch a preview from the server and update state.
+	const fetchPreview = wp.element.useCallback( () => {
+		if ( ! isMountedRef.current ) {
 			return;
 		}
 
-		if ( this.state.loadingPreview ) {
-			if ( ! this.state.pendingPreviewRequest ) {
-				this.setState({
-					pendingPreviewRequest: true,
-				} );
-				clearTimeout(this.fetchPreviewTimer);
-				var current = this;
-				this.fetchPreviewTimer = setTimeout( function() {
-					current.fetchPreview( current.props );
-				}, 1000 );
+		setPreviewInitialized( false );
+
+		// Capture the iframe document now so the deferred trigger uses the correct context.
+		const iframeDoc = panelsContainer.current
+			? panelsContainer.current.ownerDocument
+			: document;
+
+		const fetchRequest = jQuery.post( {
+			url: window.soPanelsBlockEditorAdmin.previewUrl,
+			data: {
+				action: 'so_panels_layout_block_preview',
+				panelsData: JSON.stringify( builderViewRef.current.getData() ),
 			}
-		} else if ( ! this.state.previewInitialized ) {
-			jQuery( document ).trigger( 'panels_setup_preview' );
-			this.setState( {
-				previewInitialized: true,
-			} );
-		}
-	}
+		} )
+		.then( ( preview ) => {
+			if ( ! isMountedRef.current ) {
+				return;
+			}
 
-	setupPanels() {
-		if ( this.state.panelsInitialized || ! this.isStillMounted ) {
-			return;
-		}
+			// Wait until previewHTML has finished updating to cut
+			// down on the chance of nothing being rendered.
+			setTimeout( function() {
+				jQuery( iframeDoc ).trigger( 'panels_setup_preview' );
+			}, 1000 );
 
-		var $panelsContainer = jQuery( this.panelsContainer.current );
+			if ( fetchRequest === currentFetchRequest.current && preview ) {
+				setPreviewHtml( preview );
+				setLoadingPreview( false );
+				setPreviewInitialized( false );
+				setPendingPreviewRequest( false );
+			}
+		} );
+
+		currentFetchRequest.current = fetchRequest;
+		return fetchRequest;
+	}, [] );
+
+	// Setup the panels builder on mount; tear it down on unmount.
+	wp.element.useEffect( () => {
+		isMountedRef.current = true;
+
+		// ownerDocument resolves to the iframe document when the editor is iframed (WP 6.3+/7.0).
+		const iframeDoc = panelsContainer.current.ownerDocument;
+		var $panelsContainer = jQuery( panelsContainer.current );
 
 		var config = {
 			editorType: 'standalone',
@@ -118,226 +117,161 @@ class SiteOriginPanelsLayoutBlock extends wp.element.Component {
 
 		var builderModel = new panels.model.builder();
 
-		this.builderView = new panels.view.builder( {
+		builderViewRef.current = new panels.view.builder( {
 			model: builderModel,
 			config: config
 		} );
 
 		// Make sure panelsData is defined and clone so that we don't alter the underlying attribute.
-		var panelsData = JSON.parse( JSON.stringify( jQuery.extend( {}, this.props.panelsData ) ) );
+		var initialPanelsData = JSON.parse( JSON.stringify( jQuery.extend( {}, panelsData ) ) );
 
 		// Disable block selection while dragging rows or widgets.
 		let rowOrWidgetMouseDown = () => {
-			if ( typeof this.props.onRowOrWidgetMouseDown === 'function' ) {
-				this.props.onRowOrWidgetMouseDown();
+			if ( typeof onRowOrWidgetMouseDownRef.current === 'function' ) {
+				onRowOrWidgetMouseDownRef.current();
 			}
 			let rowOrWidgetMouseUp = () => {
-				jQuery( document ).off( 'mouseup', rowOrWidgetMouseUp );
-				if ( typeof this.props.onRowOrWidgetMouseUp === 'function' ) {
-					this.props.onRowOrWidgetMouseUp();
+				// Use iframeDoc: mouseup fires inside the iframe, not on the parent document.
+				jQuery( iframeDoc ).off( 'mouseup', rowOrWidgetMouseUp );
+				if ( typeof onRowOrWidgetMouseUpRef.current === 'function' ) {
+					onRowOrWidgetMouseUpRef.current();
 				}
 			};
-			jQuery( document ).on( 'mouseup', rowOrWidgetMouseUp );
+			jQuery( iframeDoc ).on( 'mouseup', rowOrWidgetMouseUp );
 		};
 
-		this.builderView.on( 'row_added', () => {
-			this.builderView.$( '.so-row-move' ).off( 'mousedown', rowOrWidgetMouseDown );
-			this.builderView.$( '.so-row-move' ).on( 'mousedown', rowOrWidgetMouseDown );
-			this.builderView.$( '.so-widget' ).off( 'mousedown', rowOrWidgetMouseDown );
-			this.builderView.$( '.so-widget' ).on( 'mousedown', rowOrWidgetMouseDown );
+		builderViewRef.current.on( 'row_added', () => {
+			builderViewRef.current.$( '.so-row-move' ).off( 'mousedown', rowOrWidgetMouseDown );
+			builderViewRef.current.$( '.so-row-move' ).on( 'mousedown', rowOrWidgetMouseDown );
+			builderViewRef.current.$( '.so-widget' ).off( 'mousedown', rowOrWidgetMouseDown );
+			builderViewRef.current.$( '.so-widget' ).on( 'mousedown', rowOrWidgetMouseDown );
 		} );
 
-		this.builderView.on( 'widget_added', () => {
-			this.builderView.$( '.so-widget' ).off( 'mousedown', rowOrWidgetMouseDown );
-			this.builderView.$( '.so-widget' ).on( 'mousedown', rowOrWidgetMouseDown );
+		builderViewRef.current.on( 'widget_added', () => {
+			builderViewRef.current.$( '.so-widget' ).off( 'mousedown', rowOrWidgetMouseDown );
+			builderViewRef.current.$( '.so-widget' ).on( 'mousedown', rowOrWidgetMouseDown );
 		} );
 
-		this.builderView
+		builderViewRef.current
 		.render()
 		.attach( {
 			container: $panelsContainer
 		} )
-		.setData( panelsData );
+		.setData( initialPanelsData );
 
-		this.builderView.trigger( 'builder_resize' );
+		builderViewRef.current.trigger( 'builder_resize' );
 
-		/**
-		 * Checks if two panels data objects are equal.
-		 * @param {Object} newPanelsData - The new panels data object.
-		 * @param {Object} oldPanelsData - The old panels data object.
-		 * @returns {boolean} - Returns true if the two panels data objects are equal, otherwise false.
-		 */
-		var SiteOriginIsPanelsEqual = function( newPanelsData, oldPanelsData ) {
-			if ( newPanelsData === oldPanelsData ) {
-				return true;
-			}
+		builderViewRef.current.on( 'content_change', () => {
+			const newPanelsData = builderViewRef.current.getData();
 
-			if ( ! newPanelsData || ! oldPanelsData ) {
-				return newPanelsData === oldPanelsData;
-			}
-
-			// If neither newPanelsData nor oldPanelsData are objects, assume they're not the same.
-			if (
-				typeof( newPanelsData ) !== 'object' ||
-				typeof( oldPanelsData ) !== 'object'
-			) {
-				return false;
-			}
-
-			var keys = Object.keys( newPanelsData );
-			if ( keys.length !== Object.keys( oldPanelsData ).length ) {
-				return false;
-			}
-
-			return keys.every( k => SiteOriginIsPanelsEqual(
-				newPanelsData[ k ], oldPanelsData[ k ]
-			) );
-		}
-
-		this.builderView.on( 'content_change', () => {
-			const newPanelsData = this.builderView.getData();
-
-			this.panelsDataChanged = ! SiteOriginIsPanelsEqual( panelsData, newPanelsData );
-			if ( this.panelsDataChanged ) {
-				if (
-					this.props.onContentChange &&
-					typeof this.props.onContentChange === 'function'
-				) {
-					this.props.onContentChange( newPanelsData );
+			if ( ! SiteOriginIsPanelsEqual( initialPanelsData, newPanelsData ) ) {
+				if ( typeof onContentChangeRef.current === 'function' ) {
+					onContentChangeRef.current( newPanelsData );
 				}
-				this.setState( {
-					loadingPreview: true,
-					previewHtml: ''
-				} );
+				setLoadingPreview( true );
+				setPreviewHtml( '' );
 			}
 		} );
 
+		// Use iframeDoc so panels scripts inside the iframe receive the setup event.
+		jQuery( iframeDoc ).trigger( 'panels_setup', builderViewRef.current );
 
-		jQuery( document ).trigger( 'panels_setup', this.builderView );
-
-		if ( typeof window.soPanelsBuilderView == 'undefined' ) {
+		if ( typeof window.soPanelsBuilderView === 'undefined' ) {
 			window.soPanelsBuilderView = [];
 		}
-		window.soPanelsBuilderView.push( this.builderView );
+		window.soPanelsBuilderView.push( builderViewRef.current );
 
-		this.setState({
-			panelsInitialized: true
-		} );
-	}
+		setPanelsInitialized( true );
 
-	fetchPreview( props ) {
-		if ( ! this.isStillMounted ) {
+		return () => {
+			isMountedRef.current = false;
+
+			if ( builderViewRef.current ) {
+				// Remove builder from global builder list.
+				if ( typeof window.soPanelsBuilderView !== 'undefined' ) {
+					window.soPanelsBuilderView = window.soPanelsBuilderView.filter(
+						view => view !== builderViewRef.current
+					);
+				}
+				builderViewRef.current = null;
+			}
+
+			if (
+				currentFetchRequest.current &&
+				typeof currentFetchRequest.current.abort === 'function'
+			) {
+				currentFetchRequest.current.abort();
+			}
+
+			clearTimeout( fetchPreviewTimer.current );
+
+			if ( panelsContainer.current ) {
+				jQuery( panelsContainer.current ).empty();
+			}
+
+			if ( previewContainer.current ) {
+				jQuery( previewContainer.current ).empty();
+			}
+		};
+	}, [] );
+
+	// Schedule a preview fetch or fire setup when preview loading state changes.
+	wp.element.useEffect( () => {
+		if ( ! panelsInitialized ) {
 			return;
 		}
 
-		this.setState( {
-			previewInitialized: false,
-		} );
-
-		const fetchRequest = this.currentFetchRequest = jQuery.post( {
-			url: window.soPanelsBlockEditorAdmin.previewUrl,
-			data: {
-				action: 'so_panels_layout_block_preview',
-				panelsData: JSON.stringify( this.builderView.getData() ),
+		if ( loadingPreview ) {
+			if ( ! pendingPreviewRequest ) {
+				setPendingPreviewRequest( true );
+				clearTimeout( fetchPreviewTimer.current );
+				fetchPreviewTimer.current = setTimeout( () => fetchPreview(), 1000 );
 			}
-		} )
-		.then( ( preview ) => {
-			if ( ! this.isStillMounted ) {
-				return;
-			}
+		} else if ( ! previewInitialized ) {
+			const iframeDoc = panelsContainer.current
+				? panelsContainer.current.ownerDocument
+				: document;
+			jQuery( iframeDoc ).trigger( 'panels_setup_preview' );
+			setPreviewInitialized( true );
+		}
+	}, [ loadingPreview, panelsInitialized, pendingPreviewRequest, previewInitialized, fetchPreview ] );
 
-			setTimeout(function() {
-				jQuery(document).trigger('panels_setup_preview');
-			}, 1000);
-			if (
-				fetchRequest === this.currentFetchRequest &&
-				preview
-			) {
-				this.setState( {
-						previewHtml: preview,
-					},
-					// Wait until previewHTML has finished updating to cut
-					// down on the chance of nothing being rendered.
-					() => {
-						this.setState( {
-							loadingPreview: false,
-							previewInitialized: false,
-							pendingPreviewRequest: false,
-						} );
-					}
-				);
-			}
-		} );
-		return fetchRequest;
-	}
-
-	render() {
-		const { panelsData } = this.props;
-
-		let switchToEditing = () => {
-			this.setState( { editing: true } );
-
-			const _this = this;
-
-			setTimeout( function() {
-				_this.builderView.trigger( 'builder_resize' );
+	// Trigger a layout recalculation whenever we switch back into edit mode.
+	wp.element.useEffect( () => {
+		if ( editing && builderViewRef.current ) {
+			setTimeout( () => {
+				if ( builderViewRef.current ) {
+					builderViewRef.current.trigger( 'builder_resize' );
+				}
 			} );
 		}
+	}, [ editing ] );
 
-		let switchToPreview = () => {
-			if ( panelsData ) {
-				this.setState({
-					editing: false,
-				});
-			}
-		}
-
-		return (
-			<wp.element.Fragment>
-				<wp.blockEditor.BlockControls>
-				<wp.components.Toolbar label={ wp.i18n.__( 'Page Builder Mode.', 'siteorigin-panels' ) }>
-					{this.state.editing ? (
-					<wp.components.ToolbarButton
-						icon="visibility"
-						className="components-icon-button components-toolbar__control"
-						label={ wp.i18n.__( 'Preview layout.', 'siteorigin-panels' ) }
-						onClick={ switchToPreview }
-					/>
-					) : (
-					<wp.components.ToolbarButton
-						icon="edit"
-						className="components-icon-button components-toolbar__control"
-						label={ wp.i18n.__( 'Edit layout.', 'siteorigin-panels' ) }
-						onClick={ switchToEditing }
-					/>
-					)}
-				</wp.components.Toolbar>
-				</wp.blockEditor.BlockControls>
-				<div
-				key="layout-block"
-				className="siteorigin-panels-layout-block-container"
-				ref={ this.panelsContainer }
-				hidden={ ! this.state.editing }
-				/>
-				<div
-					key="preview"
-					className="so-panels-block-layout-preview-container"
-					hidden={ this.state.editing }
-				>
-				{ this.state.loadingPreview ? (
-					<div className="so-panels-spinner-container">
-						<span><wp.components.Spinner/></span>
-					</div>
-				) : (
-					<div className="so-panels-raw-html-container" ref={ this.previewContainer }>
-						<wp.element.RawHTML>{ this.state.previewHtml }</wp.element.RawHTML>
-					</div>
-				) }
+	return (
+		<wp.element.Fragment>
+			<div
+			 key="layout-block"
+			 className="siteorigin-panels-layout-block-container"
+			 ref={ panelsContainer }
+			 hidden={ ! editing }
+			/>
+			<div
+				key="preview"
+				className="so-panels-block-layout-preview-container"
+				hidden={ editing }
+			>
+			{ loadingPreview ? (
+				<div className="so-panels-spinner-container">
+					<span><wp.components.Spinner/></span>
 				</div>
-			</wp.element.Fragment>
-		);
-	}
-
+			) : (
+				<div className="so-panels-raw-html-container" ref={ previewContainer }>
+					<wp.element.RawHTML>{ previewHtml }</wp.element.RawHTML>
+				</div>
+			) }
+			</div>
+		</wp.element.Fragment>
+	);
 }
 
 var hasLayoutCategory = wp.blocks.getCategories().some( function( category ) {
@@ -370,11 +304,35 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 		}
 	},
 
+	apiVersion: 3,
+
 	edit( { attributes, setAttributes, toggleSelection } ) {
-		let onLayoutBlockContentChange = ( newPanelsData ) => {
+		const blockProps = wp.blockEditor.useBlockProps();
+
+		// Derive the initial editing state once.
+		const hasPanelsData = attributes.panelsData &&
+			typeof attributes.panelsData === 'object' &&
+			Object.keys( attributes.panelsData ).length > 0;
+		const initialEditing = hasPanelsData
+			? window.soPanelsBlockEditorAdmin.defaultMode === 'edit'
+			: true;
+
+		const [ editing, setEditing ] = wp.element.useState( initialEditing );
+
+		const switchToEditing = wp.element.useCallback( () => {
+			setEditing( true );
+		}, [] );
+
+		const switchToPreview = wp.element.useCallback( () => {
+			if ( attributes.panelsData ) {
+				setEditing( false );
+			}
+		}, [ attributes.panelsData ] );
+
+		const onLayoutBlockContentChange = wp.element.useCallback( ( newPanelsData ) => {
 
 			if (
-				newPanelsData.widgets !== null && 
+				newPanelsData.widgets !== null &&
 			    typeof newPanelsData.widgets === 'object' &&
 			    Object.keys( newPanelsData.widgets ).length > 0
 			) {
@@ -417,23 +375,47 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 					contentPreview: null,
 				} );
 			}
-		};
+		}, [ setAttributes ] );
 
-		let disableSelection = ( ) => {
+		const disableSelection = wp.element.useCallback( () => {
 			toggleSelection( false );
-		};
+		}, [ toggleSelection ] );
 
-		let enableSelection = ( ) => {
+		const enableSelection = wp.element.useCallback( () => {
 			toggleSelection( true );
-		};
+		}, [ toggleSelection ] );
 
 		return (
-			<SiteOriginPanelsLayoutBlock
-				panelsData={attributes.panelsData}
-				onContentChange={onLayoutBlockContentChange}
-				onRowOrWidgetMouseDown={disableSelection}
-				onRowOrWidgetMouseUp={enableSelection}
-			/>
+			<wp.element.Fragment>
+				<wp.blockEditor.BlockControls>
+				<wp.components.Toolbar label={ wp.i18n.__( 'Page Builder Mode.', 'siteorigin-panels' ) }>
+					{ editing ? (
+					<wp.components.ToolbarButton
+						icon="visibility"
+						className="components-icon-button components-toolbar__control"
+						label={ wp.i18n.__( 'Preview layout.', 'siteorigin-panels' ) }
+						onClick={ switchToPreview }
+					/>
+					) : (
+					<wp.components.ToolbarButton
+						icon="edit"
+						className="components-icon-button components-toolbar__control"
+						label={ wp.i18n.__( 'Edit layout.', 'siteorigin-panels' ) }
+						onClick={ switchToEditing }
+					/>
+					) }
+				</wp.components.Toolbar>
+				</wp.blockEditor.BlockControls>
+				<div { ...blockProps }>
+					<SiteOriginPanelsLayoutBlock
+						editing={ editing }
+						panelsData={ attributes.panelsData }
+						onContentChange={ onLayoutBlockContentChange }
+						onRowOrWidgetMouseDown={ disableSelection }
+						onRowOrWidgetMouseUp={ enableSelection }
+					/>
+				</div>
+			</wp.element.Fragment>
 		);
 	}
 } );

--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -80,6 +80,7 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 					'wp-blocks',
 					'wp-i18n',
 					'wp-element',
+					'wp-block-editor',
 					'wp-components',
 					'wp-compose',
 					'wp-data',

--- a/js/siteorigin-panels/view/cell.js
+++ b/js/siteorigin-panels/view/cell.js
@@ -104,13 +104,17 @@ module.exports = Backbone.View.extend( {
 				}
 			},
 			helper: function ( e, el ) {
+				// Append to the iframe body when inside an iframed editor, otherwise admin body.
+				var targetBody = ( el[0].ownerDocument !== document )
+					? el[0].ownerDocument.body
+					: document.body;
 				var helper = el.clone()
 					.css( {
 						'width': el.outerWidth() + 'px',
 						'z-index': 10000,
 						'position': 'fixed'
 					} )
-					.addClass( 'widget-being-dragged' ).appendTo( 'body' );
+					.addClass( 'widget-being-dragged' ).appendTo( targetBody );
 
 				// Center the helper to the mouse cursor.
 				if ( el.outerWidth() > 720 ) {


### PR DESCRIPTION
This PR adds API Version 3 support for the SiteOrigin Layouts block, which is required for full compatibility with WordPress 7.0. This PR is very similar to https://github.com/siteorigin/so-widgets-bundle/pull/2276

### High-level overview
- Converted SO Layout Block class to a functional component.
- Moved `editing` state and `BlockControls` into the block `edit()` so the block becomes selectable and the toolbar appears.
- Added concise, iframe-aware logic to resolve whether script/content runs inside an iframe.
- Prevented native `dragstart` events from bubbling out of the panels container (stop `dragstart`) so Gutenberg's HTML5 drag handlers can't hijack interactions.
- Adjusted how the jQuery UI drag helper is inserted in `cell.js`:
  - `appendTo` now uses the dragged element's owner document body (iframe body when relevant), instead of always appending to the admin `body`.
- Patched jQuery UI instances at runtime (after builder render) so their internal `document`/`window` properties point to the iframe's `document`/`window` when the editor is iframed. This fixes:
  - mousemove/mouseup tracking across iframe boundaries;
  - containment and scroll calculations for `draggable`/`sortable` (fixes errors like `overflowOffset is undefined`).

### Testing instructions
To test this PR, follow the following steps:

- Run build:dev and build:release. Test using built release.
- Add a SiteOrigin Layouts block to a page.
- Import the Consultant Prebuilt layout.
- Save.
- Confirm preview looks as expected.
- Reload.
- Confirm preview is present.
- Switch to SO Layout Block to Edit mode.
- Try re-ordering some of the rows and widgets.
- Resize one of the multi-column rows.

Repeat this process in the following setups:
- Current WP release version (pre-WP 7.0).
- 7.0 RC.
- Classic Editor with Page Builder active (any version of WP is fine).

### Notes
Some styling changes are required for the Layouts Block. These aren't directly related to WP 7.0 or this PR, so they'll be included in an upcoming PR.