### PR TITLE
Match Column Count Controls to Integrated Stepper Style

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -1713,7 +1713,7 @@
 				}
 
 				.row-cell-column input {
-					width: 58px;
+					width: 100%;
 				}
 
 				button {
@@ -1726,6 +1726,59 @@
 
 				.row-cell-column {
 					flex: 1;
+
+					.so-row-count-control {
+						display: inline-block;
+						position: relative;
+						width: 58px;
+					}
+
+					.so-row-count-stepper {
+						align-items: center;
+						background: #f6f6f6;
+						border-radius: 3px;
+						display: flex;
+						flex-direction: column;
+						height: calc( 100% - 2px );
+						justify-content: center;
+						position: absolute;
+						right: 1px;
+						top: 1px;
+						width: 18px;
+						z-index: 3;
+					}
+
+					.so-row-count-step {
+						align-items: center;
+						background: transparent;
+						border: 0;
+						color: #5e6d72;
+						cursor: pointer;
+						display: inline-flex;
+						font-size: 12px;
+						font-weight: bold;
+						height: 50%;
+						justify-content: center;
+						line-height: 1;
+						margin: 0;
+						padding: 0;
+						width: 100%;
+
+						&:hover {
+							color: #1d2327;
+						}
+					}
+
+					.so-row-field {
+						-moz-appearance: textfield;
+						padding-right: 18px;
+
+						&::-webkit-outer-spin-button,
+						&::-webkit-inner-spin-button {
+							-webkit-appearance: none;
+							margin: 0;
+						}
+					}
 				}
 
 				.cell-resize-container {

--- a/css/admin.less
+++ b/css/admin.less
@@ -1729,14 +1729,15 @@
 
 					.so-row-count-control {
 						display: inline-block;
+						overflow: hidden;
 						position: relative;
 						width: 58px;
+						border-radius: 3px;
 					}
 
 					.so-row-count-stepper {
 						align-items: center;
 						background: #f6f6f6;
-						border-radius: 3px;
 						display: flex;
 						flex-direction: column;
 						height: calc( 100% - 2px );
@@ -1746,6 +1747,7 @@
 						top: 1px;
 						width: 18px;
 						z-index: 3;
+						overflow: hidden;
 					}
 
 					.so-row-count-step {
@@ -1763,6 +1765,8 @@
 						margin: 0;
 						padding: 0;
 						width: 100%;
+						margin-top: 0;
+						border-radius: 0;
 
 						&:hover {
 							color: #1d2327;
@@ -1772,6 +1776,8 @@
 					.so-row-field {
 						-moz-appearance: textfield;
 						padding-right: 18px;
+						border-radius: 3px;
+						margin: 0;
 
 						&::-webkit-outer-spin-button,
 						&::-webkit-inner-spin-button {

--- a/css/admin.less
+++ b/css/admin.less
@@ -1726,18 +1726,22 @@
 
 				.row-cell-column {
 					flex: 1;
+					display: flex;
+					align-items: center;
+					gap: 8px;
 
 					.so-row-count-control {
 						display: inline-block;
 						overflow: hidden;
 						position: relative;
 						width: 58px;
-						border-radius: 3px;
+						border-radius: 0;
 					}
 
 					.so-row-count-stepper {
 						align-items: center;
 						background: #f6f6f6;
+						border-radius: 0;
 						display: flex;
 						flex-direction: column;
 						height: calc( 100% - 2px );
@@ -1776,7 +1780,7 @@
 					.so-row-field {
 						-moz-appearance: textfield;
 						padding-right: 18px;
-						border-radius: 3px;
+						border-radius: 0;
 						margin: 0;
 
 						&::-webkit-outer-spin-button,

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -704,7 +704,13 @@ module.exports = panels.view.dialog.extend({
 
 	adjustCellCount: function( e ) {
 		e.preventDefault();
-		var $input = this.$( '.row-set-form input[name="cells"].so-row-field' ).first();
+		var $control = $( e.currentTarget ).closest( '.so-row-count-control' );
+		var $input = $control.find( 'input[name="cells"].so-row-field' ).first();
+
+		if ( ! $input.length ) {
+			$input = this.$( '.row-set-form input[name="cells"].so-row-field' ).first();
+		}
+
 		if ( ! $input.length ) {
 			return;
 		}

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -715,13 +715,38 @@ module.exports = panels.view.dialog.extend({
 			return;
 		}
 
-		var currentValue = parseInt( $input.val(), 10 );
-		if ( _.isNaN( currentValue ) ) {
-			currentValue = this.row && this.row.cells ? this.row.cells.length : 1;
+		var delta = $( e.currentTarget ).hasClass( 'so-row-count-step-up' ) ? 1 : -1;
+		var input = $input.get( 0 );
+		var minValue = parseInt( $input.attr( 'min' ), 10 );
+		var maxValue = parseInt( $input.attr( 'max' ), 10 );
+
+		if ( input && typeof input.stepUp === 'function' && typeof input.stepDown === 'function' ) {
+			if ( delta > 0 ) {
+				input.stepUp();
+			} else {
+				input.stepDown();
+			}
+		} else {
+			var currentValue = parseInt( $input.val(), 10 );
+			if ( _.isNaN( currentValue ) ) {
+				currentValue = this.row && this.row.cells ? this.row.cells.length : 1;
+			}
+			$input.val( currentValue + delta );
 		}
 
-		var delta = $( e.currentTarget ).hasClass( 'so-row-count-step-up' ) ? 1 : -1;
-		var nextValue = Math.max( 1, Math.min( 12, currentValue + delta ) );
+		var nextValue = parseInt( $input.val(), 10 );
+		if ( _.isNaN( nextValue ) ) {
+			nextValue = this.row && this.row.cells ? this.row.cells.length : 1;
+		}
+
+		if ( ! _.isNaN( minValue ) ) {
+			nextValue = Math.max( minValue, nextValue );
+		}
+
+		if ( ! _.isNaN( maxValue ) ) {
+			nextValue = Math.min( maxValue, nextValue );
+		}
+
 		$input.val( nextValue );
 
 		this.changeCellTotal();

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -186,6 +186,8 @@ module.exports = panels.view.dialog.extend({
 			this.$( 'input[name="cells"].so-row-field' ).val( this.model.get( 'cells' ).length );
 		}
 
+		this.$( 'input[name="cells"].so-row-field' ).attr( 'aria-live', 'polite' );
+
 		return this;
 	},
 

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -719,37 +719,11 @@ module.exports = panels.view.dialog.extend({
 
 		var delta = $( e.currentTarget ).hasClass( 'so-row-count-step-up' ) ? 1 : -1;
 		var input = $input.get( 0 );
-		var minValue = parseInt( $input.attr( 'min' ), 10 );
-		var maxValue = parseInt( $input.attr( 'max' ), 10 );
-
-		if ( input && typeof input.stepUp === 'function' && typeof input.stepDown === 'function' ) {
-			if ( delta > 0 ) {
-				input.stepUp();
-			} else {
-				input.stepDown();
-			}
+		if ( delta > 0 ) {
+			input.stepUp();
 		} else {
-			var currentValue = parseInt( $input.val(), 10 );
-			if ( _.isNaN( currentValue ) ) {
-				currentValue = this.row && this.row.cells ? this.row.cells.length : 1;
-			}
-			$input.val( currentValue + delta );
+			input.stepDown();
 		}
-
-		var nextValue = parseInt( $input.val(), 10 );
-		if ( _.isNaN( nextValue ) ) {
-			nextValue = this.row && this.row.cells ? this.row.cells.length : 1;
-		}
-
-		if ( ! _.isNaN( minValue ) ) {
-			nextValue = Math.max( minValue, nextValue );
-		}
-
-		if ( ! _.isNaN( maxValue ) ) {
-			nextValue = Math.min( maxValue, nextValue );
-		}
-
-		$input.val( nextValue );
 
 		this.changeCellTotal();
 	},

--- a/js/siteorigin-panels/dialog/row.js
+++ b/js/siteorigin-panels/dialog/row.js
@@ -50,6 +50,7 @@ module.exports = panels.view.dialog.extend({
 		// Changing the row.
 		'click .row-set-form .so-row-field': 'changeCellTotal',
 		'change .row-set-form .so-row-field': 'changeCellTotal',
+		'click .row-set-form .so-row-count-step': 'adjustCellCount',
 		'click .cell-resize-sizing span': 'changeCellRatio',
 		'click .cell-resize-direction ': 'changeSizeDirection',
 
@@ -699,6 +700,25 @@ module.exports = panels.view.dialog.extend({
 
 	getCurrentCellCount: function() {
 		return parseInt( this.$('.row-set-form input[name="cells"]').val() );
+	},
+
+	adjustCellCount: function( e ) {
+		e.preventDefault();
+		var $input = this.$( '.row-set-form input[name="cells"].so-row-field' ).first();
+		if ( ! $input.length ) {
+			return;
+		}
+
+		var currentValue = parseInt( $input.val(), 10 );
+		if ( _.isNaN( currentValue ) ) {
+			currentValue = this.row && this.row.cells ? this.row.cells.length : 1;
+		}
+
+		var delta = $( e.currentTarget ).hasClass( 'so-row-count-step-up' ) ? 1 : -1;
+		var nextValue = Math.max( 1, Math.min( 12, currentValue + delta ) );
+		$input.val( nextValue );
+
+		this.changeCellTotal();
 	},
 
 	changeCellTotal: function ( cellRatio = 0 ) {

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -336,9 +336,9 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 					<div class="row-set-form" role="group" aria-label="<?php esc_attr_e( 'Column count controls', 'siteorigin-panels' ); ?>">
 						<div class="row-cell-column">
 							<?php
-							$column_count_input = apply_filters( 'siteorigin_panels_row_column_count_input', '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="2" />' );
+							$column_count_input = apply_filters( 'siteorigin_panels_row_column_count_input', '<input type="number" min="1" max="12" name="cells" id="so-row-count-input" class="so-row-field" value="2" />' );
 							?>
-							<span class="so-row-count-label"><?php esc_html_e( 'Column Count:', 'siteorigin-panels' ); ?></span>
+							<label class="so-row-count-label" for="so-row-count-input"><?php esc_html_e( 'Column Count:', 'siteorigin-panels' ); ?></label>
 							<div class="so-row-count-control">
 								<label class="so-row-count-input-label">
 									<span class="screen-reader-text">

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -333,20 +333,23 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 
 		<div class="content">
 
-				<div class="row-set-form">
-					<div class="row-cell-column">
-						<?php
-						esc_html_e( 'Column Count:', 'siteorigin-panels' );
-						$column_count_input = apply_filters( 'siteorigin_panels_row_column_count_input', '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="2" />' );
-						?>
-						<div class="so-row-count-control">
-							<?php echo $column_count_input; ?>
-							<div class="so-row-count-stepper">
-								<button type="button" class="so-row-count-step so-row-count-step-up" tabindex="-1">+</button>
-								<button type="button" class="so-row-count-step so-row-count-step-down" tabindex="-1">&minus;</button>
+					<div class="row-set-form" role="group" aria-label="<?php esc_attr_e( 'Column count controls', 'siteorigin-panels' ); ?>" aria-describedby="row-cell-description">
+						<div class="row-cell-column">
+							<?php
+							$column_count_input = apply_filters( 'siteorigin_panels_row_column_count_input', '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="2" id="so-row-cell-count" aria-live="polite" aria-describedby="row-cell-description" />' );
+							?>
+							<div class="so-row-count-control">
+								<label for="so-row-cell-count"><?php esc_html_e( 'Column Count:', 'siteorigin-panels' ); ?></label>
+								<?php echo $column_count_input; ?>
+								<span id="row-cell-description" class="screen-reader-text">
+									<?php esc_html_e( 'Use arrow keys or type a number between 1 and 12.', 'siteorigin-panels' ); ?>
+								</span>
+								<div class="so-row-count-stepper">
+									<button type="button" class="so-row-count-step so-row-count-step-up">+</button>
+									<button type="button" class="so-row-count-step so-row-count-step-down">&minus;</button>
+								</div>
 							</div>
 						</div>
-					</div>
 
 				<div class="cell-resize-container">
 					<span class="cell-resize-label">

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -333,13 +333,20 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 
 		<div class="content">
 
-			<div class="row-set-form">
-				<div class="row-cell-column">
-					<?php
-					esc_html_e( 'Column Count:', 'siteorigin-panels' );
-					echo apply_filters( 'siteorigin_panels_row_column_count_input', '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="2" />' );
-					?>
-				</div>
+				<div class="row-set-form">
+					<div class="row-cell-column">
+						<?php
+						esc_html_e( 'Column Count:', 'siteorigin-panels' );
+						$column_count_input = apply_filters( 'siteorigin_panels_row_column_count_input', '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="2" />' );
+						?>
+						<div class="so-row-count-control">
+							<?php echo $column_count_input; ?>
+							<div class="so-row-count-stepper">
+								<button type="button" class="so-row-count-step so-row-count-step-up" tabindex="-1">+</button>
+								<button type="button" class="so-row-count-step so-row-count-step-down" tabindex="-1">&minus;</button>
+							</div>
+						</div>
+					</div>
 
 				<div class="cell-resize-container">
 					<span class="cell-resize-label">

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -333,15 +333,17 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 
 		<div class="content">
 
-					<div class="row-set-form" role="group" aria-label="<?php esc_attr_e( 'Column count controls', 'siteorigin-panels' ); ?>" aria-describedby="row-cell-description">
+					<div class="row-set-form" role="group" aria-label="<?php esc_attr_e( 'Column count controls', 'siteorigin-panels' ); ?>">
 						<div class="row-cell-column">
 							<?php
-							$column_count_input = apply_filters( 'siteorigin_panels_row_column_count_input', '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="2" id="so-row-cell-count" aria-live="polite" aria-describedby="row-cell-description" />' );
+							$column_count_input = apply_filters( 'siteorigin_panels_row_column_count_input', '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="2" />' );
 							?>
 							<div class="so-row-count-control">
-								<label for="so-row-cell-count"><?php esc_html_e( 'Column Count:', 'siteorigin-panels' ); ?></label>
-								<?php echo $column_count_input; ?>
-								<span id="row-cell-description" class="screen-reader-text">
+								<label>
+									<?php esc_html_e( 'Column Count:', 'siteorigin-panels' ); ?>
+									<?php echo $column_count_input; ?>
+								</label>
+								<span class="screen-reader-text">
 									<?php esc_html_e( 'Use arrow keys or type a number between 1 and 12.', 'siteorigin-panels' ); ?>
 								</span>
 								<div class="so-row-count-stepper">

--- a/tpl/js-templates.php
+++ b/tpl/js-templates.php
@@ -338,9 +338,12 @@ $layouts = apply_filters( 'siteorigin_panels_prebuilt_layouts', array() );
 							<?php
 							$column_count_input = apply_filters( 'siteorigin_panels_row_column_count_input', '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="2" />' );
 							?>
+							<span class="so-row-count-label"><?php esc_html_e( 'Column Count:', 'siteorigin-panels' ); ?></span>
 							<div class="so-row-count-control">
-								<label>
-									<?php esc_html_e( 'Column Count:', 'siteorigin-panels' ); ?>
+								<label class="so-row-count-input-label">
+									<span class="screen-reader-text">
+										<?php esc_html_e( 'Column Count', 'siteorigin-panels' ); ?>
+									</span>
 									<?php echo $column_count_input; ?>
 								</label>
 								<span class="screen-reader-text">


### PR DESCRIPTION
## Summary
- Wrap the row column-count input in an integrated control container.
- Add plus/minus step buttons inside the control on the right.
- Style the control to match the row-width input stepper pattern.
- Hook step-button clicks into existing `changeCellTotal` behavior with `1..12` clamping.

## Validation
- `php -l tpl/js-templates.php`
- Parse check for `js/siteorigin-panels/dialog/row.js`
