### PR TITLE
Exclude `vendor` Directory From Build

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -67,6 +67,7 @@ module.exports = {
             '!widgets/**/styles/*.css',                      // Don't copy any .css files compiled from runtime .less files
             '!{node_modules,node_modules/**}',               // Ignore node_modules/ and contents
             '!{tmp,tmp/**}',                                 // Ignore dist/ and contents
+            '!{vendor,vendor/**}',                           // Ignore composer files. We're not using any in release.
             '!siteorigin-panels.php',                        // Not the base plugin file. It is copied by the 'version' task.
             '!package.json',                                 // Ignore the package.json file..
             '!readme.txt',                                   // Not the readme.txt file. It is copied by the 'version' task.


### PR DESCRIPTION
Will prevent unexpected build bloat if `composer install` was run before a build was made.