### PR TITLE
Fix Layout Block and Dialog Styling for WP 7

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -892,44 +892,43 @@
 	}
 }
 
-.wp-customizer,
-.block-editor-page {
-	// Styles for PB in block editor.
-	.siteorigin-panels-layout-block-container {
-		font-size: 13px;
-		line-height: 1.4em;
+// Styles for PB in block editor.
+// Not nested under .block-editor-page because the Layout Block renders
+// inside an iframe whose body may not carry that class.
+.siteorigin-panels-layout-block-container {
+	font-size: 13px;
+	line-height: 1.4em;
 
-		&,
-		h4,
-		ul,
-		label,
-		input,
-		select,
-		textarea,
-		button,
-		a {
-			font-family: @wp_system_font_stack;
+	&,
+	h4,
+	ul,
+	label,
+	input,
+	select,
+	textarea,
+	button,
+	a {
+		font-family: @wp_system_font_stack;
+	}
+
+	ul {
+		list-style: none;
+	}
+
+	// Prevent display issues when the editor has a darker background.
+	.so-builder-container {
+		background: #fff;
+
+		.so-row-container {
+			padding: 0 15px 20px;
 		}
 
-		ul {
-			list-style: none;
-		}
+		a:not(.so-tool-button):not([class^="so-row-"]) {
+			color: #2271b1;
 
-		// Prevent display issues when the editor has a darker background.
-		.so-builder-container {
-			background: #fff;
-
-			.so-row-container {
-				padding: 0 15px 20px;
-			}
-
-			a:not(.so-tool-button):not([class^="so-row-"]) {
-				color: #2271b1;
-
-				&:hover,
-				&:focus {
-					color: #1e1e1e;
-				}
+			&:hover,
+			&:focus {
+				color: #1e1e1e;
 			}
 		}
 	}

--- a/css/admin.less
+++ b/css/admin.less
@@ -1043,6 +1043,25 @@
 			border: 1px solid #8c8f94;
 			border-radius: 3px;
 			vertical-align: middle;
+			background: #fff;
+
+			&:checked {
+				background: #fff;
+				border-color: #8c8f94;
+			}
+
+			&:checked::before {
+				content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27%233582c4%27%2F%3E%3C%2Fsvg%3E");
+				margin: -3px 0 0 -4px;
+				width: 1.3125rem;
+				height: 1.3125rem;
+			}
+
+			&:focus {
+				border-color: #2271b1;
+				box-shadow: 0 0 0 1px #2271b1;
+				outline: 2px solid transparent;
+			}
 		}
 
 	}

--- a/css/admin.less
+++ b/css/admin.less
@@ -1168,7 +1168,6 @@
 			}
 
 			&:focus {
-				box-shadow: inset 0 0 0 2px #2271b1;
 				outline: none;
 			}
 

--- a/css/admin.less
+++ b/css/admin.less
@@ -1168,7 +1168,7 @@
 			}
 
 			&:focus {
-				box-shadow: inset 0 0 0 1px #2271b1;
+				box-shadow: inset 0 0 0 2px #2271b1;
 				outline: none;
 			}
 

--- a/css/admin.less
+++ b/css/admin.less
@@ -1021,6 +1021,31 @@
 			margin: 1em 0;
 		}
 
+		input[type="text"],
+		input[type="number"],
+		input[type="email"],
+		input[type="url"],
+		input[type="search"],
+		input[type="password"],
+		select,
+		textarea {
+			min-height: 30px;
+			padding: 0 8px;
+			line-height: 2;
+			border: 1px solid #8c8f94;
+			border-radius: 3px;
+			font-size: 13px;
+		}
+
+		input[type="checkbox"] {
+			width: 16px;
+			height: 16px;
+			min-height: 16px;
+			border: 1px solid #8c8f94;
+			border-radius: 3px;
+			vertical-align: middle;
+		}
+
 	}
 
 	.so-title-bar {

--- a/css/admin.less
+++ b/css/admin.less
@@ -1307,6 +1307,7 @@
 			margin-right: 5px;
 
 			.button-primary {
+				min-height: 30px;
 				height: 30px;
 				line-height: 2.15384615;
 				padding: 0 10px;

--- a/css/admin.less
+++ b/css/admin.less
@@ -3035,11 +3035,21 @@
 		}
 
 		.live-editor-save{
+			min-height: 30px;
+			height: 30px;
+			line-height: 2.15384615;
+			padding: 0 10px;
+			font-size: 13px;
 			margin: 9px 10px 0 5px;
 			float: right;
 		}
 
 		.live-editor-close {
+			min-height: 30px;
+			height: 30px;
+			line-height: 2.15384615;
+			padding: 0 10px;
+			font-size: 13px;
 			margin: 9px 5px 0 15px;
 			float: right;
 		}

--- a/css/admin.less
+++ b/css/admin.less
@@ -1167,6 +1167,11 @@
 				}
 			}
 
+			&:focus {
+				box-shadow: inset 0 0 0 1px #2271b1;
+				outline: none;
+			}
+
 			.so-dialog-icon {
 				position: absolute;
 				top: 50%;

--- a/css/admin.less
+++ b/css/admin.less
@@ -1304,7 +1304,6 @@
 
 		.so-buttons {
 			float: right;
-			margin-right: 5px;
 
 			.button-primary {
 				min-height: 30px;

--- a/css/admin.less
+++ b/css/admin.less
@@ -1169,6 +1169,7 @@
 
 			&:focus {
 				outline: none;
+				box-shadow: none;
 			}
 
 			.so-dialog-icon {

--- a/css/admin.less
+++ b/css/admin.less
@@ -1306,6 +1306,13 @@
 			float: right;
 			margin-right: 5px;
 
+			.button-primary {
+				height: 30px;
+				line-height: 2.15384615;
+				padding: 0 10px;
+				font-size: 13px;
+			}
+
 			.action-buttons {
 
 				position: absolute;

--- a/css/admin.less
+++ b/css/admin.less
@@ -2929,6 +2929,19 @@
 	}
 }
 
+// Ensure widget forms inside dialogs use the WP system font stack.
+.so-panels-dialog .so-content .siteorigin-widget-content {
+	&,
+	label,
+	input,
+	select,
+	.siteorigin-widget-field,
+	.button,
+	a {
+		font-family: @wp_system_font_stack;
+	}
+}
+
 .so-panels-live-editor {
 	@live_editor_width: 360px;
 

--- a/css/admin.less
+++ b/css/admin.less
@@ -950,6 +950,20 @@
 
 	-webkit-text-size-adjust: none;
 
+	&,
+	label,
+	input,
+	select,
+	textarea,
+	button,
+	.button,
+	h3,
+	h4,
+	p,
+	a {
+		font-family: @wp_system_font_stack;
+	}
+
 	.so-overlay, .so-content, .so-title-bar, .so-toolbar, .so-left-sidebar, .so-right-sidebar {
 		z-index: 100001;
 		position: fixed;

--- a/css/admin.less
+++ b/css/admin.less
@@ -899,6 +899,11 @@
 	font-size: 13px;
 	line-height: 1.4em;
 
+	.siteorigin-panels-builder {
+		padding: 6px;
+		background: #fff;
+	}
+
 	&,
 	h4,
 	ul,

--- a/css/admin.less
+++ b/css/admin.less
@@ -1305,6 +1305,7 @@
 
 		.so-buttons {
 			float: right;
+			margin-right: 5px;
 
 			.action-buttons {
 

--- a/css/admin.less
+++ b/css/admin.less
@@ -901,7 +901,13 @@
 
 		&,
 		h4,
-		ul {
+		ul,
+		label,
+		input,
+		select,
+		textarea,
+		button,
+		a {
 			font-family: @wp_system_font_stack;
 		}
 

--- a/css/admin.less
+++ b/css/admin.less
@@ -1,5 +1,7 @@
 @import "mixins";
 
+@wp_system_font_stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+
 @font-face {
 	font-family: 'siteorigin-panels-icons';
 	src: url('icons/panels-icons.eot');
@@ -900,7 +902,7 @@
 		&,
 		h4,
 		ul {
-			font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;
+			font-family: @wp_system_font_stack;
 		}
 
 		ul {
@@ -3435,7 +3437,7 @@
 		input,
 		a {
 			color: #3c434a;
-			font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+			font-family: @wp_system_font_stack;
 			font-size: 13px;
 			line-height: 1.4;
 		}
@@ -3460,7 +3462,7 @@
 			box-shadow: none;
 			color: #2c3338;
 			cursor: pointer;
-			font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+			font-family: @wp_system_font_stack;
 			font-size: 14px;
 			line-height: 2;
 			min-height: 30px;


### PR DESCRIPTION
## Summary

- Fix font-family inheritance broken by WP 7 block CSS resets across the Layout Block container, dialog/modal system, and widget forms
- Normalize input, checkbox, and button sizing against WP 7's inflated dimensions
- Restore WP 6-style checkbox appearance in dialog content
- Suppress WP 7 focus ring clipping on title bar nav buttons

## Changes

- **Font stack:** Introduce `@wp_system_font_stack` LESS variable, replace hardcoded font stacks, and apply to Layout Block container, dialog system, and widget forms inside dialogs
- **Layout Block container:** Move out of `.block-editor-page` nesting so selectors work inside the block editor iframe where the body lacks that class
- **Input normalization:** Pin WP 5.7.2 admin input styling (min-height, padding, line-height, border, font-size) on text inputs, selects, and textareas in `.so-content`
- **Checkbox normalization:** Override WP 7's filled-background checked state with WP 6 values (white background, blue `#3582c4` checkmark, simple border focus)
- **Button normalization:** Pin WP 5.7.2 `.button-primary` dimensions with `min-height: 30px` on toolbar save/close buttons
- **Title bar focus:** Suppress WP 7's outset focus box-shadow on nav buttons to prevent clipping

## Test Plan

- [ ] WP 7 Block Editor: Insert Layout Block, verify toolbar buttons use correct font
- [ ] WP 7 Block Editor: Open Add Widget / Edit Widget / Row Edit / Prebuilt dialogs — verify fonts, input heights, checkbox appearance, and button sizing
- [ ] WP 7 Block Editor: Tab through title bar nav buttons — verify no clipped focus border
- [ ] WP 7 Widgets Page: Verify existing `.widgets-php.block-editor-page` styles still work
- [ ] WP 7 Customizer: Test Layout widget in customizer context
- [ ] WP 6 / Classic Editor: Verify no visual regressions

Closes #1315

🤖 Generated with [Claude Code](https://claude.com/claude-code)