### PR TITLE
WP 7: Resolve Inline Saving Issues

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -198,7 +198,16 @@ function SiteOriginPanelsLayoutBlock(props) {
 
       if (!SiteOriginIsPanelsEqual(initialPanelsData, newPanelsData)) {
         if (typeof onContentChangeRef.current === 'function') {
-          onContentChangeRef.current(newPanelsData);
+          var pendingContentChange = onContentChangeRef.current(newPanelsData);
+
+          if (pendingContentChange && typeof pendingContentChange.then === 'function') {
+            builderViewRef.current.pendingContentChange = pendingContentChange;
+            pendingContentChange["finally"](function () {
+              if (builderViewRef.current && builderViewRef.current.pendingContentChange === pendingContentChange) {
+                builderViewRef.current.pendingContentChange = null;
+              }
+            });
+          }
         }
 
         setLoadingPreview(true);
@@ -383,37 +392,49 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
           wp.data.dispatch('core/editor').lockPostSaving();
         }
 
-        jQuery.post(panelsOptions.ajaxurl, {
-          action: 'so_panels_builder_content_json',
-          panels_data: JSON.stringify(newPanelsData),
-          post_id: !isNewWPBlockEditor ? wp.data.select("core/editor").getCurrentPostId() : ''
-        }, function (content) {
-          var panelsAttributes = {};
+        return new Promise(function (resolve, reject) {
+          jQuery.post(panelsOptions.ajaxurl, {
+            action: 'so_panels_builder_content_json',
+            panels_data: JSON.stringify(newPanelsData),
+            post_id: !isNewWPBlockEditor ? wp.data.select("core/editor").getCurrentPostId() : ''
+          }).done(function (content) {
+            var panelsAttributes = {};
 
-          if (content.sanitized_panels_data !== '') {
-            panelsAttributes.panelsData = content.sanitized_panels_data;
-          }
+            if (content.sanitized_panels_data !== '') {
+              panelsAttributes.panelsData = content.sanitized_panels_data;
+            }
 
-          if (content.preview !== '') {
-            panelsAttributes.contentPreview = content.preview;
-          }
+            if (content.preview !== '') {
+              panelsAttributes.contentPreview = content.preview;
+            }
 
-          setAttributes({
-            contentPreview: panelsAttributes.contentPreview,
-            panelsData: panelsAttributes.panelsData,
-            previewInitialized: false
+            setAttributes({
+              contentPreview: panelsAttributes.contentPreview,
+              panelsData: panelsAttributes.panelsData,
+              previewInitialized: false
+            });
+            setTimeout(function () {
+              if (!isNewWPBlockEditor) {
+                wp.data.dispatch('core/editor').unlockPostSaving();
+              }
+
+              resolve(content);
+            }, 0);
+          }).fail(function (jqXHR, textStatus, errorThrown) {
+            if (!isNewWPBlockEditor) {
+              wp.data.dispatch('core/editor').unlockPostSaving();
+            }
+
+            reject(errorThrown || textStatus);
           });
-
-          if (!isNewWPBlockEditor) {
-            wp.data.dispatch('core/editor').unlockPostSaving();
-          }
-        });
-      } else {
-        setAttributes({
-          panelsData: null,
-          contentPreview: null
         });
       }
+
+      setAttributes({
+        panelsData: null,
+        contentPreview: null
+      });
+      return Promise.resolve();
     }, [setAttributes]);
     var disableSelection = wp.element.useCallback(function () {
       toggleSelection(false);

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -175,16 +175,30 @@ function SiteOriginPanelsLayoutBlock( props ) {
 
 		builderViewRef.current.trigger( 'builder_resize' );
 
-		builderViewRef.current.on( 'content_change', () => {
-			const newPanelsData = builderViewRef.current.getData();
+			builderViewRef.current.on( 'content_change', () => {
+				const newPanelsData = builderViewRef.current.getData();
 
-			if ( ! SiteOriginIsPanelsEqual( initialPanelsData, newPanelsData ) ) {
-				if ( typeof onContentChangeRef.current === 'function' ) {
-					onContentChangeRef.current( newPanelsData );
+				if ( ! SiteOriginIsPanelsEqual( initialPanelsData, newPanelsData ) ) {
+					if ( typeof onContentChangeRef.current === 'function' ) {
+						const pendingContentChange = onContentChangeRef.current( newPanelsData );
+						if (
+							pendingContentChange &&
+							typeof pendingContentChange.then === 'function'
+						) {
+							builderViewRef.current.pendingContentChange = pendingContentChange;
+							pendingContentChange.finally( () => {
+								if (
+									builderViewRef.current &&
+									builderViewRef.current.pendingContentChange === pendingContentChange
+								) {
+									builderViewRef.current.pendingContentChange = null;
+								}
+							} );
+						}
+					}
+					setLoadingPreview( true );
+					setPreviewHtml( '' );
 				}
-				setLoadingPreview( true );
-				setPreviewHtml( '' );
-			}
 		} );
 
 		// Use iframeDoc so panels scripts inside the iframe receive the setup event.
@@ -375,53 +389,65 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 			}
 		}, [ attributes.panelsData ] );
 
-		const onLayoutBlockContentChange = wp.element.useCallback( ( newPanelsData ) => {
+			const onLayoutBlockContentChange = wp.element.useCallback( ( newPanelsData ) => {
+				if (
+					newPanelsData.widgets !== null &&
+				    typeof newPanelsData.widgets === 'object' &&
+				    Object.keys( newPanelsData.widgets ).length > 0
+				) {
+					// Send panelsData to server for sanitization.
+					var isNewWPBlockEditor = jQuery( '.widgets-php' ).length;
+					if ( ! isNewWPBlockEditor ) {
+						wp.data.dispatch( 'core/editor' ).lockPostSaving();
+					}
 
-			if (
-				newPanelsData.widgets !== null &&
-			    typeof newPanelsData.widgets === 'object' &&
-			    Object.keys( newPanelsData.widgets ).length > 0
-			) {
-				// Send panelsData to server for sanitization.
-				var isNewWPBlockEditor = jQuery( '.widgets-php' ).length;
-				if ( ! isNewWPBlockEditor ) {
-					wp.data.dispatch( 'core/editor' ).lockPostSaving();
+					return new Promise( ( resolve, reject ) => {
+						jQuery.post(
+							panelsOptions.ajaxurl,
+							{
+								action: 'so_panels_builder_content_json',
+								panels_data: JSON.stringify( newPanelsData ),
+								post_id: ! isNewWPBlockEditor ? wp.data.select("core/editor").getCurrentPostId() : ''
+							}
+						)
+						.done( function( content ) {
+							let panelsAttributes = {};
+							if ( content.sanitized_panels_data !== '' ) {
+								panelsAttributes.panelsData = content.sanitized_panels_data;
+							}
+							if ( content.preview !== '' ) {
+								panelsAttributes.contentPreview = content.preview;
+							}
+
+							setAttributes( {
+								contentPreview: panelsAttributes.contentPreview,
+								panelsData: panelsAttributes.panelsData,
+								previewInitialized: false,
+							} );
+
+							setTimeout( function() {
+								if ( ! isNewWPBlockEditor ) {
+									wp.data.dispatch( 'core/editor' ).unlockPostSaving();
+								}
+								resolve( content );
+							}, 0 );
+						} )
+						.fail( function( jqXHR, textStatus, errorThrown ) {
+							if ( ! isNewWPBlockEditor ) {
+								wp.data.dispatch( 'core/editor' ).unlockPostSaving();
+							}
+							reject( errorThrown || textStatus );
+						} );
+					} );
 				}
 
-				jQuery.post(
-					panelsOptions.ajaxurl,
-					{
-						action: 'so_panels_builder_content_json',
-						panels_data: JSON.stringify( newPanelsData ),
-						post_id: ! isNewWPBlockEditor ? wp.data.select("core/editor").getCurrentPostId() : ''
-					},
-					function( content ) {
-						let panelsAttributes = {};
-						if ( content.sanitized_panels_data !== '' ) {
-							panelsAttributes.panelsData = content.sanitized_panels_data;
-						}
-						if ( content.preview !== '' ) {
-							panelsAttributes.contentPreview = content.preview;
-						}
-
-						setAttributes( {
-							contentPreview: panelsAttributes.contentPreview,
-							panelsData: panelsAttributes.panelsData,
-							previewInitialized: false,
-						} );
-
-						if ( ! isNewWPBlockEditor ) {
-							wp.data.dispatch( 'core/editor' ).unlockPostSaving();
-						}
-					}
-				);
-			} else {
 				setAttributes( {
 					panelsData: null,
 					contentPreview: null,
 				} );
-			}
-		}, [ setAttributes ] );
+
+				return Promise.resolve();
+			}, [ setAttributes ] );
 
 		const disableSelection = wp.element.useCallback( () => {
 			toggleSelection( false );

--- a/js/siteorigin-panels/helpers/utils.js
+++ b/js/siteorigin-panels/helpers/utils.js
@@ -33,7 +33,17 @@ module.exports = {
 	},
 
 	saveHeartbeat: function( thisDialog ) {
+		var resetButton = function() {
+			jQuery( '.so-saveinline' ).removeAttr( 'disabled' );
+		};
+
 		jQuery( '.so-saveinline' ).attr( 'disabled', 'disabled' )
+
+		if ( this.shouldUseBlockEditorSave( thisDialog ) ) {
+			this.saveBlockEditor( thisDialog, resetButton );
+			return;
+		}
+
 		jQuery( document ).one( 'heartbeat-send', function( event, data ) {
 			data.panels = JSON.stringify( {
 				data: thisDialog.builder.model.getPanelsData(),
@@ -42,39 +52,150 @@ module.exports = {
 			} );
 		} );
 		jQuery( document ).one( 'heartbeat-tick', function( event, data ) {
-			jQuery( '.so-saveinline' ).removeAttr( 'disabled' )
+			resetButton();
 		} );
 
-		if ( ! this.attemptToSave() ) {
+		if (
+			typeof wp !== 'undefined' &&
+			wp.heartbeat &&
+			wp.heartbeat.connectNow
+		) {
+			wp.heartbeat.connectNow();
+			return;
+		}
+
+		if (
+			typeof wp !== 'undefined' &&
+			wp.autosave &&
+			wp.autosave.server
+		) {
+			wp.autosave.server.triggerSave();
+			return;
+		}
+
+		resetButton();
+		if ( window.console && console.warn ) {
 			console.warn( 'Unable to save post.' );
 		}
 	},
 
-	/**
-	 * Attempt to save the current post using the best available mechanism.
-	 *
-	 * @return {boolean} True if a save was dispatched, false if no save mechanism was found.
-	 */
-	attemptToSave: function() {
-		if ( typeof wp === 'undefined' ) {
-			return false;
+	shouldUseBlockEditorSave: function( thisDialog ) {
+		return (
+			typeof wp !== 'undefined' &&
+			wp.data &&
+			wp.data.select &&
+			wp.data.dispatch &&
+			wp.data.select( 'core/editor' ) &&
+			thisDialog &&
+			thisDialog.builder &&
+			thisDialog.builder.config &&
+			thisDialog.builder.config.editorType === 'standalone'
+		);
+	},
+
+	saveBlockEditor: function( thisDialog, resetButton ) {
+		var self = this;
+		var pendingContentChange = thisDialog &&
+			thisDialog.builder &&
+			thisDialog.builder.pendingContentChange;
+
+		Promise.resolve( pendingContentChange )
+			.catch( function() {} )
+			.then( function() {
+				return self.waitForPostSavingUnlock();
+			} )
+			.then( function() {
+				return self.dispatchBlockEditorSave();
+			} )
+			.then( resetButton )
+			.catch( function() {
+				resetButton();
+				if ( window.console && console.warn ) {
+					console.warn( 'Unable to save post.' );
+				}
+			} );
+	},
+
+	dispatchBlockEditorSave: function() {
+		var self = this;
+		var editorSelect = wp.data.select( 'core/editor' );
+		var editorDispatch = wp.data.dispatch( 'core/editor' );
+
+		if ( editorSelect.isSavingPost() ) {
+			return this.waitForPostSaveCompletion( false )
+				.then( function() {
+					return self.dispatchBlockEditorSave();
+				} );
 		}
 
-		// Block Editor.
-		if ( wp.data && wp.data.select( 'core/editor' ) ) {
-			if ( ! wp.data.select( 'core/editor' ).isSavingPost() ) {
-				wp.data.dispatch( 'core/editor' ).savePost();
-			}
-			return true;
+		if (
+			editorSelect.isEditedPostDirty &&
+			! editorSelect.isEditedPostDirty()
+		) {
+			return Promise.resolve();
 		}
 
-		// Classic Editor, and older versions of the Block Editor.
-		if ( wp.autosave && wp.autosave.server ) {
-			wp.autosave.server.triggerSave();
-			return true;
+		editorDispatch.savePost();
+		return this.waitForPostSaveCompletion( true );
+	},
+
+	waitForPostSavingUnlock: function() {
+		var editorSelect = wp.data.select( 'core/editor' );
+		if (
+			! editorSelect.isPostSavingLocked ||
+			! editorSelect.isPostSavingLocked()
+		) {
+			return Promise.resolve();
 		}
 
-		return false;
-	}
+		return new Promise( function( resolve ) {
+			var unsubscribe = wp.data.subscribe( function() {
+				editorSelect = wp.data.select( 'core/editor' );
+				if (
+					! editorSelect.isPostSavingLocked ||
+					! editorSelect.isPostSavingLocked()
+				) {
+					unsubscribe();
+					setTimeout( resolve, 0 );
+				}
+			} );
+		} );
+	},
+
+	waitForPostSaveCompletion: function( requireStart ) {
+		var editorSelect = wp.data.select( 'core/editor' );
+		var isSaving = editorSelect.isSavingPost() ||
+			( editorSelect.isAutosavingPost && editorSelect.isAutosavingPost() );
+
+		if ( ! requireStart && ! isSaving ) {
+			return Promise.resolve();
+		}
+
+		return new Promise( function( resolve ) {
+			var saveStarted = isSaving;
+			var checks = 0;
+			var unsubscribe = wp.data.subscribe( function() {
+				editorSelect = wp.data.select( 'core/editor' );
+				isSaving = editorSelect.isSavingPost() ||
+					( editorSelect.isAutosavingPost && editorSelect.isAutosavingPost() );
+
+				if ( isSaving ) {
+					saveStarted = true;
+				}
+
+				if ( saveStarted && ! isSaving ) {
+					unsubscribe();
+					setTimeout( resolve, 0 );
+					return;
+				}
+
+				checks++;
+				if ( checks >= 120 ) {
+					unsubscribe();
+					resolve();
+				}
+			} );
+		} );
+	},
 
 }

--- a/js/siteorigin-panels/helpers/utils.js
+++ b/js/siteorigin-panels/helpers/utils.js
@@ -44,7 +44,37 @@ module.exports = {
 		jQuery( document ).one( 'heartbeat-tick', function( event, data ) {
 			jQuery( '.so-saveinline' ).removeAttr( 'disabled' )
 		} );
-		wp.autosave.server.triggerSave()
+
+		if ( ! this.attemptToSave() ) {
+			console.warn( 'Unable to save post.' );
+		}
 	},
+
+	/**
+	 * Attempt to save the current post using the best available mechanism.
+	 *
+	 * @return {boolean} True if a save was dispatched, false if no save mechanism was found.
+	 */
+	attemptToSave: function() {
+		if ( typeof wp === 'undefined' ) {
+			return false;
+		}
+
+		// Block Editor.
+		if ( wp.data && wp.data.select( 'core/editor' ) ) {
+			if ( ! wp.data.select( 'core/editor' ).isSavingPost() ) {
+				wp.data.dispatch( 'core/editor' ).savePost();
+			}
+			return true;
+		}
+
+		// Classic Editor, and older versions of the Block Editor.
+		if ( wp.autosave && wp.autosave.server ) {
+			wp.autosave.server.triggerSave();
+			return true;
+		}
+
+		return false;
+	}
 
 }

--- a/js/siteorigin-panels/view/live-editor.js
+++ b/js/siteorigin-panels/view/live-editor.js
@@ -43,7 +43,7 @@ module.exports = Backbone.View.extend( {
 	render: function () {
 		this.setElement( this.template() );
 		this.$el.hide();
-		
+
 		if ( $( '#submitdiv #save-post' ).length > 0 ) {
 			var $saveButton = this.$el.find( '.live-editor-save' );
 			$saveButton.text( $saveButton.data( 'save' ) );
@@ -124,18 +124,16 @@ module.exports = Backbone.View.extend( {
 			// The live editor requires a saved draft post, so we'll create one for auto-draft posts
 			var thisView = this;
 
-			if ( wp.autosave ) {
-				// Set a temporary post title so the autosave triggers properly
-				if( $('#title[name="post_title"]' ).val() === '' ) {
-					$('#title[name="post_title"]' ).val( panelsOptions.loc.draft ).trigger('keydown');
-				}
-
-				$( document ).one( 'heartbeat-tick.autosave', function(){
-					thisView.autoSaved = true;
-					thisView.refreshPreview( thisView.builder.model.getPanelsData() );
-				} );
-				wp.autosave.server.triggerSave();
+			// Set a temporary post title so the autosave triggers properly
+			if( $('#title[name="post_title"]' ).val() === '' ) {
+				$('#title[name="post_title"]' ).val( panelsOptions.loc.draft ).trigger('keydown');
 			}
+
+			$( document ).one( 'heartbeat-tick.autosave', function(){
+				thisView.autoSaved = true;
+				thisView.refreshPreview( thisView.builder.model.getPanelsData() );
+			} );
+			panels.helpers.utils.saveHeartbeat( thisView );
 		}
 	},
 
@@ -169,8 +167,7 @@ module.exports = Backbone.View.extend( {
 	 */
 	closeAndSave: function(){
 		this.close( false );
-		// Finds the submit input for saving without publishing draft posts.
-		$( '#submitdiv input[type="submit"][name="save"], .editor-post-publish-button, .edit-widgets-header__actions .is-primary' )[0].click();
+		panels.helpers.utils.saveHeartbeat( this );
 	},
 
 	/**

--- a/js/siteorigin-panels/view/live-editor.js
+++ b/js/siteorigin-panels/view/live-editor.js
@@ -124,16 +124,18 @@ module.exports = Backbone.View.extend( {
 			// The live editor requires a saved draft post, so we'll create one for auto-draft posts
 			var thisView = this;
 
-			// Set a temporary post title so the autosave triggers properly
-			if( $('#title[name="post_title"]' ).val() === '' ) {
-				$('#title[name="post_title"]' ).val( panelsOptions.loc.draft ).trigger('keydown');
-			}
+			if ( wp.autosave ) {
+				// Set a temporary post title so the autosave triggers properly
+				if( $('#title[name="post_title"]' ).val() === '' ) {
+					$('#title[name="post_title"]' ).val( panelsOptions.loc.draft ).trigger('keydown');
+				}
 
-			$( document ).one( 'heartbeat-tick.autosave', function(){
-				thisView.autoSaved = true;
-				thisView.refreshPreview( thisView.builder.model.getPanelsData() );
-			} );
-			panels.helpers.utils.saveHeartbeat( thisView );
+				$( document ).one( 'heartbeat-tick.autosave', function(){
+					thisView.autoSaved = true;
+					thisView.refreshPreview( thisView.builder.model.getPanelsData() );
+				} );
+				wp.autosave.server.triggerSave();
+			}
 		}
 	},
 
@@ -167,7 +169,8 @@ module.exports = Backbone.View.extend( {
 	 */
 	closeAndSave: function(){
 		this.close( false );
-		panels.helpers.utils.saveHeartbeat( this );
+		// Finds the submit input for saving without publishing draft posts.
+		$( '#submitdiv input[type="submit"][name="save"], .editor-post-publish-button, .edit-widgets-header__actions .is-primary' )[0].click();
 	},
 
 	/**

--- a/js/siteorigin-panels/view/live-editor.js
+++ b/js/siteorigin-panels/view/live-editor.js
@@ -169,8 +169,17 @@ module.exports = Backbone.View.extend( {
 	 */
 	closeAndSave: function(){
 		this.close( false );
+
+		if ( panels.helpers.utils.shouldUseBlockEditorSave( this ) ) {
+			panels.helpers.utils.saveBlockEditor( this, function() {} );
+			return;
+		}
+
 		// Finds the submit input for saving without publishing draft posts.
-		$( '#submitdiv input[type="submit"][name="save"], .editor-post-publish-button, .edit-widgets-header__actions .is-primary' )[0].click();
+		var saveButton = $( '#submitdiv input[type="submit"][name="save"], .editor-post-publish-button, .edit-widgets-header__actions .is-primary' )[0];
+		if ( saveButton ) {
+			saveButton.click();
+		}
 	},
 
 	/**


### PR DESCRIPTION
## Summary
- Resolve the WP 7 Block Editor inline row/widget save regression.
- Keep the normal Live Editor save flow on the standard post save path.
- Include the stacked Layout Block inline-save persistence fix from `#1323`.

## Included Work
This PR now includes the original `WP 7: Resolve Inline Saving Issues` change plus the follow-up fix from `#1323`:
- `e4671f2f` `Fix inline save persistence in layout block`
- `f145b2bb` `Live Editor: Use block editor save path`
- merge commit `076e1ba1` bringing `#1323` into this branch

## Root Cause
WP 7 changed the Block Editor save flow enough that the existing inline row/widget save behavior was no longer reliable in the Block Editor path. The follow-up work in `#1323` also addressed Layout Block inline-save persistence and ensured Live Editor uses the correct Block Editor save route when needed.

## Testing
Please verify in WP 7:
- Row inline save persists after saving and immediately refreshing.
- Widget inline save persists after saving and immediately refreshing.
- Layout Block inline save persists.
- Live Editor save follows the correct post-save path.

## Notes
- `#1323` was merged into this branch first, so `#1319` is the PR that should now merge to `develop`.
