### PR TITLE
Fix Layout Block Top Toolbar Focus Rendering

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -421,16 +421,14 @@ wp.blocks.registerBlockType('siteorigin-panels/layout-block', {
     var enableSelection = wp.element.useCallback(function () {
       toggleSelection(true);
     }, [toggleSelection]);
-    return React.createElement(wp.element.Fragment, null, React.createElement(wp.blockEditor.BlockControls, null, React.createElement(wp.components.Toolbar, {
-      label: wp.i18n.__('Page Builder Mode.', 'siteorigin-panels')
+    return React.createElement(wp.element.Fragment, null, React.createElement(wp.blockEditor.BlockControls, null, React.createElement(wp.components.ToolbarGroup, {
+      label: wp.i18n.__('Page Builder Mode Controls', 'siteorigin-panels')
     }, editing ? React.createElement(wp.components.ToolbarButton, {
       icon: "visibility",
-      className: "components-icon-button components-toolbar__control",
       label: wp.i18n.__('Preview layout.', 'siteorigin-panels'),
       onClick: switchToPreview
     }) : React.createElement(wp.components.ToolbarButton, {
       icon: "edit",
-      className: "components-icon-button components-toolbar__control",
       label: wp.i18n.__('Edit layout.', 'siteorigin-panels'),
       onClick: switchToEditing
     }))), React.createElement("div", blockProps, React.createElement(SiteOriginPanelsLayoutBlock, {

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -434,23 +434,21 @@ wp.blocks.registerBlockType( 'siteorigin-panels/layout-block', {
 		return (
 			<wp.element.Fragment>
 				<wp.blockEditor.BlockControls>
-				<wp.components.Toolbar label={ wp.i18n.__( 'Page Builder Mode.', 'siteorigin-panels' ) }>
+				<wp.components.ToolbarGroup label={ wp.i18n.__( 'Page Builder Mode Controls', 'siteorigin-panels' ) }>
 					{ editing ? (
-					<wp.components.ToolbarButton
-						icon="visibility"
-						className="components-icon-button components-toolbar__control"
-						label={ wp.i18n.__( 'Preview layout.', 'siteorigin-panels' ) }
-						onClick={ switchToPreview }
-					/>
+						<wp.components.ToolbarButton
+							icon="visibility"
+							label={ wp.i18n.__( 'Preview layout.', 'siteorigin-panels' ) }
+							onClick={ switchToPreview }
+						/>
 					) : (
-					<wp.components.ToolbarButton
-						icon="edit"
-						className="components-icon-button components-toolbar__control"
-						label={ wp.i18n.__( 'Edit layout.', 'siteorigin-panels' ) }
-						onClick={ switchToEditing }
-					/>
+						<wp.components.ToolbarButton
+							icon="edit"
+							label={ wp.i18n.__( 'Edit layout.', 'siteorigin-panels' ) }
+							onClick={ switchToEditing }
+						/>
 					) }
-				</wp.components.Toolbar>
+				</wp.components.ToolbarGroup>
 				</wp.blockEditor.BlockControls>
 				<div { ...blockProps }>
 					<SiteOriginPanelsLayoutBlock

--- a/css/admin.less
+++ b/css/admin.less
@@ -925,6 +925,13 @@
 			}
 		}
 	}
+
+}
+
+// Reserve space for Gutenberg's selected ring so selection state changes don't shift toolbar layout.
+.block-editor-block-list__block.wp-block-siteorigin-panels-layout-block .siteorigin-panels-layout-block-container {
+	box-sizing: border-box;
+	padding: 2px;
 }
 
 .so-panels-dialog,


### PR DESCRIPTION
## Summary
- Switch the Layout Block mode control to ToolbarGroup so Gutenberg renders the top toolbar control using the expected structure.
- Reserve 2px inside the Layout Block container so Gutenberg's selected ring does not overlap the control when the block toolbar is in topbar mode.

## Included Commits
- 92f91446 Fix Layout Block selection ring overlap without layout shift.
- 9f61ffe1 Use ToolbarGroup for Layout Block mode controls.

## Testing
- Verified locally against the block editor top toolbar path.
- Removed the previous incorrect PR and rebuilt this branch from current origin/develop.