### PR TITLE
Fix Layout Block Context Menu in the Block Editor Iframe

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -303,6 +303,9 @@ function SiteOriginPanelsLayoutBlock(props) {
 
   wp.element.useEffect(function () {
     if (editing && builderViewRef.current) {
+      builderViewRef.current.menu.setContext({
+        container: jQuery(panelsContainer.current)
+      });
       setTimeout(function () {
         if (builderViewRef.current) {
           builderViewRef.current.trigger('builder_resize');

--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -262,6 +262,7 @@ function SiteOriginPanelsLayoutBlock(props) {
           });
         }
 
+        builderViewRef.current.remove();
         builderViewRef.current = null;
       }
 

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -239,6 +239,7 @@ function SiteOriginPanelsLayoutBlock( props ) {
 						view => view !== builderViewRef.current
 					);
 				}
+				builderViewRef.current.remove();
 				builderViewRef.current = null;
 			}
 

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -285,6 +285,10 @@ function SiteOriginPanelsLayoutBlock( props ) {
 	// Trigger a layout recalculation whenever we switch back into edit mode.
 	wp.element.useEffect( () => {
 		if ( editing && builderViewRef.current ) {
+			builderViewRef.current.menu.setContext( {
+				container: jQuery( panelsContainer.current )
+			} );
+
 			setTimeout( () => {
 				if ( builderViewRef.current ) {
 					builderViewRef.current.trigger( 'builder_resize' );

--- a/js/siteorigin-panels/utils/menu.js
+++ b/js/siteorigin-panels/utils/menu.js
@@ -35,14 +35,111 @@ module.exports = Backbone.View.extend( {
 		return this.contextWindow || contextDocument.defaultView || window;
 	},
 
-	getOutsideClickWindows: function () {
-		var interactionWindows = [ this.getContextWindow() ];
+	getRenderWindow: function () {
+		var renderWindow = this.getContextWindow();
 
-		if ( window !== interactionWindows[ 0 ] ) {
-			interactionWindows.push( window );
+		try {
+			if ( renderWindow.top && renderWindow.top.document ) {
+				renderWindow = renderWindow.top;
+			}
+		}
+		catch ( err ) {}
+
+		return renderWindow;
+	},
+
+	getRenderDocument: function () {
+		var renderWindow = this.getRenderWindow();
+		return renderWindow.document || document;
+	},
+
+	getUniqueWindows: function( windows ) {
+		var uniqueWindows = [];
+
+		_.each( windows, function( candidateWindow ) {
+			if ( candidateWindow && uniqueWindows.indexOf( candidateWindow ) === -1 ) {
+				uniqueWindows.push( candidateWindow );
+			}
+		} );
+
+		return uniqueWindows;
+	},
+
+	getOutsideClickWindows: function () {
+		return this.getUniqueWindows( [
+			this.getContextWindow(),
+			this.getRenderWindow(),
+			window
+		] );
+	},
+
+	getKeyupWindows: function () {
+		return this.getUniqueWindows( [
+			this.getContextWindow(),
+			this.getRenderWindow()
+		] );
+	},
+
+	getPositionForRenderWindow: function( position ) {
+		var renderWindow = this.getRenderWindow();
+		var contextWindow = this.getContextWindow();
+		var translatedPosition = {
+			left: position.left,
+			top: position.top
+		};
+
+		if ( renderWindow === contextWindow ) {
+			return translatedPosition;
 		}
 
-		return interactionWindows;
+		if ( contextWindow.frameElement ) {
+			var frameRect = contextWindow.frameElement.getBoundingClientRect();
+			var renderScrollLeft = $( renderWindow ).scrollLeft();
+			var renderScrollTop = $( renderWindow ).scrollTop();
+			var contextScrollLeft = $( contextWindow ).scrollLeft();
+			var contextScrollTop = $( contextWindow ).scrollTop();
+			var clientLeft = _.isNumber( position.clientX ) ? position.clientX : position.left - contextScrollLeft;
+			var clientTop = _.isNumber( position.clientY ) ? position.clientY : position.top - contextScrollTop;
+
+			translatedPosition.left = frameRect.left + renderScrollLeft + clientLeft;
+			translatedPosition.top = frameRect.top + renderScrollTop + clientTop;
+		}
+
+		return translatedPosition;
+	},
+
+	getEventPositionForElement: function( el, event ) {
+		var element = el && el[ 0 ] ? el[ 0 ] : null;
+		var targetDocument = element && element.ownerDocument ? element.ownerDocument : document;
+		var targetWindow = targetDocument.defaultView || window;
+		var eventDocument = event && event.target && event.target.ownerDocument ? event.target.ownerDocument : targetDocument;
+		var eventWindow = eventDocument.defaultView || window;
+		var position = {
+			left: event.pageX,
+			top: event.pageY
+		};
+
+		if ( eventWindow === targetWindow ) {
+			return position;
+		}
+
+		if ( eventWindow.frameElement && targetWindow === this.getRenderWindow() ) {
+			return this.getPositionForRenderWindow( {
+				left: event.pageX,
+				top: event.pageY,
+				clientX: event.clientX,
+				clientY: event.clientY
+			} );
+		}
+
+		if ( targetWindow.frameElement && eventWindow === this.getRenderWindow() ) {
+			var frameRect = targetWindow.frameElement.getBoundingClientRect();
+
+			position.left = event.clientX - frameRect.left + $( targetWindow ).scrollLeft();
+			position.top = event.clientY - frameRect.top + $( targetWindow ).scrollTop();
+		}
+
+		return position;
 	},
 
 	setContext: function( options ) {
@@ -113,7 +210,9 @@ module.exports = Backbone.View.extend( {
 
 				thisView.openMenu( {
 					left: e.pageX,
-					top: e.pageY
+					top: e.pageY,
+					clientX: e.clientX,
+					clientY: e.clientY
 				} );
 			}
 		} );
@@ -135,7 +234,7 @@ module.exports = Backbone.View.extend( {
 	},
 
 	attach: function () {
-		this.$el.appendTo( this.getContextDocument().body );
+		this.$el.appendTo( this.getRenderDocument().body );
 	},
 
 	/**
@@ -144,33 +243,37 @@ module.exports = Backbone.View.extend( {
 	 * @param position
 	 */
 	openMenu: function ( position ) {
-		var $contextWindow = $( this.getContextWindow() ),
+		var $renderWindow = $( this.getRenderWindow() ),
 			eventNamespace = this.getEventNamespace(),
 			thisView = this;
+
+		position = this.getPositionForRenderWindow( position );
 
 		this.trigger( 'open_menu' );
 
 		// Start listening for situations when we should close the menu
-		$( this.getContextWindow() ).on( 'keyup' + eventNamespace, {menu: thisView}, thisView.keyboardListen );
+		_.each( this.getKeyupWindows(), function( interactionWindow ) {
+			$( interactionWindow ).on( 'keyup' + eventNamespace, {menu: thisView}, thisView.keyboardListen );
+		} );
 
 		_.each( this.getOutsideClickWindows(), function( interactionWindow ) {
 			$( interactionWindow ).on( 'click' + eventNamespace, {menu: thisView}, thisView.clickOutsideListen );
 		} );
 
 		// Set the maximum height of the menu
-		this.$el.css( 'max-height', $contextWindow.height() - 20 );
+		this.$el.css( 'max-height', $renderWindow.height() - 20 );
 
 		// Correct the left position
-		if ( position.left + this.$el.outerWidth() + 10 >= $contextWindow.width() ) {
-			position.left = $contextWindow.width() - this.$el.outerWidth() - 10;
+		if ( position.left + this.$el.outerWidth() + 10 >= $renderWindow.width() + $renderWindow.scrollLeft() ) {
+			position.left = $renderWindow.width() + $renderWindow.scrollLeft() - this.$el.outerWidth() - 10;
 		}
 		if ( position.left <= 0 ) {
 			position.left = 10;
 		}
 
 		// Check top position
-		if ( position.top + this.$el.outerHeight() - $contextWindow.scrollTop() + 10 >= $contextWindow.height() ) {
-			position.top = $contextWindow.height() + $contextWindow.scrollTop() - this.$el.outerHeight() - 10;
+		if ( position.top + this.$el.outerHeight() + 10 >= $renderWindow.height() + $renderWindow.scrollTop() ) {
+			position.top = $renderWindow.height() + $renderWindow.scrollTop() - this.$el.outerHeight() - 10;
 		}
 		if ( position.left <= 0 ) {
 			position.left = 10;
@@ -185,13 +288,14 @@ module.exports = Backbone.View.extend( {
 	},
 
 	closeMenu: function () {
-		var eventNamespace = this.getEventNamespace(),
-			contextWindow = this.getContextWindow();
+		var eventNamespace = this.getEventNamespace();
 
 		this.trigger( 'close_menu' );
 
 		// Stop listening for situations when we should close the menu
-		$( contextWindow ).off( 'keyup' + eventNamespace, this.keyboardListen );
+		_.each( this.getKeyupWindows(), function( interactionWindow ) {
+			$( interactionWindow ).off( 'keyup' + eventNamespace, this.keyboardListen );
+		}, this );
 
 		_.each( this.getOutsideClickWindows(), function( interactionWindow ) {
 			$( interactionWindow ).off( 'click' + eventNamespace, this.clickOutsideListen );
@@ -199,6 +303,13 @@ module.exports = Backbone.View.extend( {
 
 		this.active = false;
 		this.$el.empty().hide();
+	},
+
+	remove: function() {
+		this.closeMenu();
+		this.unlistenContextMenu();
+
+		return Backbone.View.prototype.remove.call( this );
 	},
 
 	/**
@@ -392,6 +503,7 @@ module.exports = Backbone.View.extend( {
 	 * @param event
 	 */
 	isOverEl: function ( el, event ) {
+		var eventPosition = this.getEventPositionForElement( el, event );
 		var elPos = [
 			[el.offset().left, el.offset().top],
 			[el.offset().left + el.outerWidth(), el.offset().top + el.outerHeight()]
@@ -399,8 +511,8 @@ module.exports = Backbone.View.extend( {
 
 		// Return if this event is over the given element
 		return (
-			event.pageX >= elPos[0][0] && event.pageX <= elPos[1][0] &&
-			event.pageY >= elPos[0][1] && event.pageY <= elPos[1][1]
+			eventPosition.left >= elPos[0][0] && eventPosition.left <= elPos[1][0] &&
+			eventPosition.top >= elPos[0][1] && eventPosition.top <= elPos[1][1]
 		);
 	}
 

--- a/js/siteorigin-panels/utils/menu.js
+++ b/js/siteorigin-panels/utils/menu.js
@@ -15,18 +15,82 @@ module.exports = Backbone.View.extend( {
 	 * Intialize the context menu
 	 */
 	initialize: function () {
+		this.contextDocument = document;
+		this.contextWindow = window;
 		this.listenContextMenu();
 		this.render();
 		this.attach();
+	},
+
+	getEventNamespace: function () {
+		return '.siteoriginPanelsMenu' + this.cid;
+	},
+
+	getContextDocument: function () {
+		return this.contextDocument || document;
+	},
+
+	getContextWindow: function () {
+		var contextDocument = this.getContextDocument();
+		return this.contextWindow || contextDocument.defaultView || window;
+	},
+
+	getInteractionWindows: function () {
+		var interactionWindows = [ this.getContextWindow() ];
+
+		if ( window !== interactionWindows[ 0 ] ) {
+			interactionWindows.push( window );
+		}
+
+		return interactionWindows;
+	},
+
+	setContext: function( options ) {
+		options = options || {};
+
+		var contextDocument = options.document;
+		if (
+			! contextDocument &&
+			options.container &&
+			options.container.length &&
+			options.container[ 0 ]
+		) {
+			contextDocument = options.container[ 0 ].ownerDocument;
+		}
+
+		if ( ! contextDocument ) {
+			contextDocument = this.getContextDocument();
+		}
+
+		var contextWindow = options.window || contextDocument.defaultView || window;
+
+		if (
+			this.contextDocument === contextDocument &&
+			this.contextWindow === contextWindow
+		) {
+			return this;
+		}
+
+		this.closeMenu();
+		this.unlistenContextMenu();
+
+		this.contextDocument = contextDocument;
+		this.contextWindow = contextWindow;
+
+		this.attach();
+		this.listenContextMenu();
+
+		return this;
 	},
 
 	/**
 	 * Listen for the right click context menu
 	 */
 	listenContextMenu: function () {
-		var thisView = this;
+		var thisView = this,
+			eventNamespace = 'contextmenu' + this.getEventNamespace();
 
-		$( window ).on( 'contextmenu', function ( e ) {
+		$( this.getContextDocument() ).on( eventNamespace, function ( e ) {
 			if ( thisView.active && ! thisView.isOverEl( thisView.$el, e ) ) {
 				thisView.closeMenu();
 				thisView.active = false;
@@ -55,12 +119,22 @@ module.exports = Backbone.View.extend( {
 		} );
 	},
 
+	unlistenContextMenu: function() {
+		var eventNamespace = this.getEventNamespace();
+		$( this.getContextDocument() ).off( 'contextmenu' + eventNamespace );
+
+		_.each( this.getInteractionWindows(), function( interactionWindow ) {
+			$( interactionWindow ).off( 'keyup' + eventNamespace );
+			$( interactionWindow ).off( 'click' + eventNamespace );
+		} );
+	},
+
 	render: function () {
 		this.setElement( this.wrapperTemplate() );
 	},
 
 	attach: function () {
-		this.$el.appendTo( 'body' );
+		this.$el.appendTo( this.getContextDocument().body );
 	},
 
 	/**
@@ -69,26 +143,32 @@ module.exports = Backbone.View.extend( {
 	 * @param position
 	 */
 	openMenu: function ( position ) {
+		var $contextWindow = $( this.getContextWindow() ),
+			eventNamespace = this.getEventNamespace(),
+			thisView = this;
+
 		this.trigger( 'open_menu' );
 
 		// Start listening for situations when we should close the menu
-		$( window ).on( 'keyup', {menu: this}, this.keyboardListen );
-		$( window ).on( 'click', {menu: this}, this.clickOutsideListen );
+		_.each( this.getInteractionWindows(), function( interactionWindow ) {
+			$( interactionWindow ).on( 'keyup' + eventNamespace, {menu: thisView}, thisView.keyboardListen );
+			$( interactionWindow ).on( 'click' + eventNamespace, {menu: thisView}, thisView.clickOutsideListen );
+		} );
 
 		// Set the maximum height of the menu
-		this.$el.css( 'max-height', $( window ).height() - 20 );
+		this.$el.css( 'max-height', $contextWindow.height() - 20 );
 
 		// Correct the left position
-		if ( position.left + this.$el.outerWidth() + 10 >= $( window ).width() ) {
-			position.left = $( window ).width() - this.$el.outerWidth() - 10;
+		if ( position.left + this.$el.outerWidth() + 10 >= $contextWindow.width() ) {
+			position.left = $contextWindow.width() - this.$el.outerWidth() - 10;
 		}
 		if ( position.left <= 0 ) {
 			position.left = 10;
 		}
 
 		// Check top position
-		if ( position.top + this.$el.outerHeight() - $( window ).scrollTop() + 10 >= $( window ).height() ) {
-			position.top = $( window ).height() + $( window ).scrollTop() - this.$el.outerHeight() - 10;
+		if ( position.top + this.$el.outerHeight() - $contextWindow.scrollTop() + 10 >= $contextWindow.height() ) {
+			position.top = $contextWindow.height() + $contextWindow.scrollTop() - this.$el.outerHeight() - 10;
 		}
 		if ( position.left <= 0 ) {
 			position.left = 10;
@@ -103,11 +183,15 @@ module.exports = Backbone.View.extend( {
 	},
 
 	closeMenu: function () {
+		var eventNamespace = this.getEventNamespace();
+
 		this.trigger( 'close_menu' );
 
 		// Stop listening for situations when we should close the menu
-		$( window ).off( 'keyup', this.keyboardListen );
-		$( window ).off( 'click', this.clickOutsideListen );
+		_.each( this.getInteractionWindows(), function( interactionWindow ) {
+			$( interactionWindow ).off( 'keyup' + eventNamespace, this.keyboardListen );
+			$( interactionWindow ).off( 'click' + eventNamespace, this.clickOutsideListen );
+		}, this );
 
 		this.active = false;
 		this.$el.empty().hide();

--- a/js/siteorigin-panels/utils/menu.js
+++ b/js/siteorigin-panels/utils/menu.js
@@ -35,7 +35,7 @@ module.exports = Backbone.View.extend( {
 		return this.contextWindow || contextDocument.defaultView || window;
 	},
 
-	getInteractionWindows: function () {
+	getOutsideClickWindows: function () {
 		var interactionWindows = [ this.getContextWindow() ];
 
 		if ( window !== interactionWindows[ 0 ] ) {
@@ -120,11 +120,12 @@ module.exports = Backbone.View.extend( {
 	},
 
 	unlistenContextMenu: function() {
-		var eventNamespace = this.getEventNamespace();
+		var eventNamespace = this.getEventNamespace(),
+			contextWindow = this.getContextWindow();
 		$( this.getContextDocument() ).off( 'contextmenu' + eventNamespace );
+		$( contextWindow ).off( 'keyup' + eventNamespace );
 
-		_.each( this.getInteractionWindows(), function( interactionWindow ) {
-			$( interactionWindow ).off( 'keyup' + eventNamespace );
+		_.each( this.getOutsideClickWindows(), function( interactionWindow ) {
 			$( interactionWindow ).off( 'click' + eventNamespace );
 		} );
 	},
@@ -150,8 +151,9 @@ module.exports = Backbone.View.extend( {
 		this.trigger( 'open_menu' );
 
 		// Start listening for situations when we should close the menu
-		_.each( this.getInteractionWindows(), function( interactionWindow ) {
-			$( interactionWindow ).on( 'keyup' + eventNamespace, {menu: thisView}, thisView.keyboardListen );
+		$( this.getContextWindow() ).on( 'keyup' + eventNamespace, {menu: thisView}, thisView.keyboardListen );
+
+		_.each( this.getOutsideClickWindows(), function( interactionWindow ) {
 			$( interactionWindow ).on( 'click' + eventNamespace, {menu: thisView}, thisView.clickOutsideListen );
 		} );
 
@@ -183,13 +185,15 @@ module.exports = Backbone.View.extend( {
 	},
 
 	closeMenu: function () {
-		var eventNamespace = this.getEventNamespace();
+		var eventNamespace = this.getEventNamespace(),
+			contextWindow = this.getContextWindow();
 
 		this.trigger( 'close_menu' );
 
 		// Stop listening for situations when we should close the menu
-		_.each( this.getInteractionWindows(), function( interactionWindow ) {
-			$( interactionWindow ).off( 'keyup' + eventNamespace, this.keyboardListen );
+		$( contextWindow ).off( 'keyup' + eventNamespace, this.keyboardListen );
+
+		_.each( this.getOutsideClickWindows(), function( interactionWindow ) {
 			$( interactionWindow ).off( 'click' + eventNamespace, this.clickOutsideListen );
 		}, this );
 

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -37,6 +37,10 @@ module.exports = Backbone.View.extend( {
 	/**
 	 * Initialize the builder
 	 */
+	getEventNamespace: function () {
+		return '.siteoriginPanelsBuilder' + this.cid;
+	},
+
 	initialize: function ( options ) {
 		var builder = this;
 
@@ -94,11 +98,12 @@ module.exports = Backbone.View.extend( {
 		this.listenTo( this.model.get( 'rows' ), 'add', this.onAddRow );
 
 		// Reflow the entire builder when ever the
-		$( window ).on( 'resize', function( e ) {
+		this._onWindowResize = function( e ) {
 			if ( e.target === window ) {
 				builder.trigger( 'builder_resize' );
 			}
-		} );
+		};
+		$( window ).on( 'resize' + this.getEventNamespace(), this._onWindowResize );
 
 		// When the data changes in the model, store it in the field
 		this.listenTo( this.model, 'change:data load_panels_data', this.storeModelData );
@@ -115,7 +120,7 @@ module.exports = Backbone.View.extend( {
 
 		// Create the context menu for this builder
 		this.menu = new panels.utils.menu( {} );
-		this.listenTo( this.menu, 'activate_context', this.activateContextMenu )
+		this.listenTo( this.menu, 'activate_context', this.activateContextMenu );
 
 		if ( this.config.loadOnAttach ) {
 			this.on( 'builder_attached_to_editor', function () {
@@ -221,6 +226,28 @@ module.exports = Backbone.View.extend( {
 		welcomeMessageContainer.find( '.so-message-wrapper' ).html( msgHTML );
 
 		return this;
+	},
+
+	remove: function() {
+		if ( this.menu ) {
+			this.menu.remove();
+			this.menu = null;
+		}
+
+		if ( this._onWindowResize ) {
+			$( window ).off( 'resize' + this.getEventNamespace(), this._onWindowResize );
+			this._onWindowResize = null;
+		}
+
+		if ( !_.isNull( this.rowsSortable ) ) {
+			try {
+				this.rowsSortable.sortable( 'destroy' );
+			}
+			catch ( err ) {}
+			this.rowsSortable = null;
+		}
+
+		return Backbone.View.prototype.remove.call( this );
 	},
 
 	/**
@@ -957,9 +984,10 @@ module.exports = Backbone.View.extend( {
 	 */
 	activateContextMenu: function ( e, menu ) {
 		var builder = this;
+		var containsTarget = $.contains( builder.$el.get( 0 ), e.target );
 
 		// Only run this if the event target is a descendant of this builder's DOM element.
-		if ( $.contains( builder.$el.get( 0 ), e.target ) ) {
+		if ( containsTarget ) {
 			// Get the element we're currently hovering over
 			var over = $( [] )
 			.add( builder.$( '.so-panels-welcome-message:visible' ) )

--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -160,6 +160,10 @@ module.exports = Backbone.View.extend( {
 			this.dialog = new panels.dialog.builder();
 			this.dialog.builder = this;
 		} else {
+			this.menu.setContext( {
+				container: options.container
+			} );
+
 			// Attach this in the standard way
 			this.$el.appendTo( options.container );
 			this.metabox = options.container.closest( '.postbox' );

--- a/js/siteorigin-panels/view/live-editor.js
+++ b/js/siteorigin-panels/view/live-editor.js
@@ -116,6 +116,9 @@ module.exports = Backbone.View.extend( {
 		// Move the builder view into the Live Editor
 		this.originalContainer = this.builder.$el.parent();
 		this.builder.$el.appendTo( this.$( '.so-live-editor-builder' ) );
+		this.builder.menu.setContext( {
+			container: this.$( '.so-live-editor-builder' )
+		} );
 		this.builder.$( '.so-tool-button.so-live-editor' ).hide();
 		this.builder.trigger( 'builder_resize' );
 
@@ -160,6 +163,9 @@ module.exports = Backbone.View.extend( {
 
 		// Move the builder back to its original container
 		this.builder.$el.appendTo( this.originalContainer );
+		this.builder.menu.setContext( {
+			container: this.originalContainer
+		} );
 		this.builder.$( '.so-tool-button.so-live-editor' ).show();
 		this.builder.trigger( 'builder_resize' );
 	},


### PR DESCRIPTION
## Summary
- Keep the context menu activation listeners bound to the Block Editor iframe document where the Layout Block builder lives.
- Render the visible context menu in the top admin document and translate iframe click coordinates into top-window coordinates before opening it.
- Tear down builder and menu instances on Layout Block unmount so stale listeners do not survive editor remounts.

## Root Cause
This turned out to be two separate problems in the iframe editor path:

1. Stale builder/menu instances were surviving Layout Block remounts after refresh, leaving old document-level listeners behind.
2. Even once the active menu instance was correct, rendering the visible menu inside the iframe document was unreliable after reload. The menu activated and populated, but its rendered box collapsed instead of displaying.

The final fix keeps right-click detection in the iframe, but renders the actual menu in the top admin document where the menu styles and layout behave consistently.

## Testing
- `node --check js/siteorigin-panels/utils/menu.js`
- `node --check js/siteorigin-panels/view/builder.js`
- `node --check compat/js/siteorigin-panels-layout-block.js`
- `node --check js/siteorigin-panels.js`
- Rebuilt `compat/js/siteorigin-panels-layout-block.js` with Babel and `js/siteorigin-panels.js` with Browserify locally
- Current manual browser checks look good, but more browser verification is still useful before merge

## Notes
- `gulp` build tasks are blocked locally by the repo's legacy `node-sass` dependency under Node `v24.7.0`, so the JS assets were rebuilt directly with the installed Babel/Browserify tooling instead.
