### PR TITLE
WP 7: Restore admin control sizing

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -3415,8 +3415,10 @@
 				display: block;
 				width: 100%;
 				margin: 0;
+				min-height: 30px;
 				border: none;
-				padding: 5px 10px;
+				padding: 0 8px;
+				line-height: 2;
 				background: #fbfbfb;
 
 				&:focus,

--- a/settings/admin-settings.less
+++ b/settings/admin-settings.less
@@ -2,6 +2,41 @@
 
 	margin: 0 0 0 -20px;
 
+	input[type="text"],
+	input[type="password"],
+	input[type="number"],
+	input[type="search"],
+	textarea {
+		box-shadow: 0 0 0 transparent;
+		border-radius: 4px;
+		border: 1px solid #8c8f94;
+		background-color: #fff;
+		color: #2c3338;
+		padding: 0 8px;
+		line-height: 2;
+		min-height: 30px;
+	}
+
+	select {
+		box-shadow: 0 0 0 transparent;
+		border-radius: 3px;
+		border: 1px solid #8c8f94;
+		background-color: #fff;
+		color: #2c3338;
+		padding: 0 24px 0 8px;
+		line-height: 2;
+		min-height: 30px;
+	}
+
+	.button,
+	.button-primary {
+		border-radius: 3px;
+		font-size: 13px;
+		line-height: 2.15384615;
+		padding: 0 10px;
+		min-height: 30px;
+	}
+
 	.settings-banner {
 		display: block;
 		padding: 15px 30px 5px 30px;


### PR DESCRIPTION
## Summary
- restore WP 6-sized context menu search input in Page Builder admin UI
- restore WP 6-sized settings page inputs, selects, textareas, and buttons

## Root Cause
The earlier WP 7 styling rollback covered the main dialog and Layout Block surfaces, but a few plugin admin controls were still outside that normalization layer and continued inheriting larger WP 7 control sizing.

The two remaining shared misses in this pass were:
- the right-click context menu search field
- the plugin settings page form controls

## Changes
- apply WP 6 input sizing to the context menu search field
- apply WP 6 form control sizing to the settings page search/input/select/textarea/button controls

## Testing
- verified right-click context menu search field sizing
- verified plugin settings page search field sizing
- verified plugin settings page input/select/save button sizing
- confirmed the earlier Design-panel examples still looked correct
