### PR TITLE
Use overflow-x: clip for iOS scroll fix

### DIFF
--- a/css/front-flex.less
+++ b/css/front-flex.less
@@ -96,7 +96,7 @@
 }
 
 body.siteorigin-panels-before-js:not(.siteorigin-panels-css-container) {
-	overflow-x: hidden;
+	overflow-x: clip;
 
 	.siteorigin-panels-stretch {
 		margin-right: -1000px !important;


### PR DESCRIPTION
## Summary
- Changes `overflow-x: hidden` to `overflow-x: clip` on the body element in the pre-JS fallback CSS
- Fixes an issue where `overflow-x: hidden` creates a nested scroll context on iOS WebKit, making it difficult to scroll to the footer when Full Width rows are present
- `overflow-x: clip` prevents horizontal overflow without affecting vertical scrolling behavior

## Test plan
- [ ] Create a page with Full Width (not stretched) rows using the Vantage theme (full layout)
- [ ] Test on Chrome iOS — scroll to bottom, verify footer is easily reachable
- [ ] Verify no horizontal scrollbar appears on desktop browsers
- [ ] Test with Full Width Stretched rows
- [ ] Test without any Full Width rows to ensure no regression