### PR TITLE
Fix slug corruption during copy-content save

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -286,11 +286,22 @@ class SiteOrigin_Panels_Admin {
 				if ( $copy_content_update_method === 'direct_db' ) {
 					$this->copy_content_update_post_direct_db( $post );
 				} else {
+					// Prevent slug modification during content-only update.
+					// wp_update_post triggers the full wp_insert_post pipeline,
+					// where filters from other plugins (e.g. WPML) can corrupt
+					// the post slug. Lock it to the current value.
+					$slug_lock = static function( $override, $slug, $id ) use ( $post ) {
+						return $id === $post->ID ? $slug : $override;
+					};
+					add_filter( 'pre_wp_unique_post_slug', $slug_lock, 1, 3 );
+
 					$copy_content_update_args = array(
 						'ID'           => $post->ID,
 						'post_content' => $post->post_content,
 					);
 					wp_update_post( $copy_content_update_args, false, true );
+
+					remove_filter( 'pre_wp_unique_post_slug', $slug_lock, 1 );
 				}
 			}
 		} else {


### PR DESCRIPTION
## Problem

Saving a PB layout in the Classic Editor corrupts the page slug on sites running WPML (and likely other plugins that filter `wp_unique_post_slug`). The slug changes to that of an unrelated post, causing the page to 404.

Reproduced on demo.siteorigin.com with the Premium 404 Page addon active — editing a PB layout and saving would change the page slug to the first blog post's slug every time.

## Cause

Copy-content calls `wp_update_post()` just to sync rendered HTML to `post_content`. But `wp_update_post` runs the full `wp_insert_post` pipeline — including `wp_unique_post_slug` and all its filters. WPML hooks that filter at priority 100 end up corrupting the slug during this secondary save.

We already had a `direct_db` escape hatch for this (used by the Events Manager compat), but `direct_db` skips revisions and most hooks, so it's not a good default.

## Fix

Lock the slug via `pre_wp_unique_post_slug` for the duration of the `wp_update_post` call. Returns the existing slug unchanged for the post being saved. Removed immediately after.

This keeps revisions, cache invalidation, and third-party `save_post` hooks working — only the slug reprocessing is bypassed.

## Test plan

- Edit a PB page on a WPML site, change the layout, save — slug should stay correct
- Page should load normally (no 404)
- Rendered HTML should still appear in `post_content`