### PR TITLE
Fix: Re-scope dialog font-family rule to .so-panels-dialog only

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -947,6 +947,25 @@
 	padding: 2px;
 }
 
+// Force the WP system font on SO dialogs regardless of host chrome (Customizer,
+// block editor, classic editor). Scoped to .so-panels-dialog only so it does
+// not cross-product into unrelated host UI such as Customizer controls.
+.so-panels-dialog {
+	&,
+	label,
+	input,
+	select,
+	textarea,
+	button,
+	.button,
+	h3,
+	h4,
+	p,
+	a {
+		font-family: @wp_system_font_stack;
+	}
+}
+
 .so-panels-dialog,
 .block-editor-page,
 .wp-customizer {
@@ -961,20 +980,6 @@
 	@border_color: #d8d8d8;
 
 	-webkit-text-size-adjust: none;
-
-	&,
-	label,
-	input,
-	select,
-	textarea,
-	button,
-	.button,
-	h3,
-	h4,
-	p,
-	a {
-		font-family: @wp_system_font_stack;
-	}
 
 	.so-overlay, .so-content, .so-title-bar, .so-toolbar, .so-left-sidebar, .so-right-sidebar {
 		z-index: 100001;


### PR DESCRIPTION
## Summary
- Fixes a CSS regression in 2.34.1 where Dashicons on WordPress Customizer controls rendered as plain glyphs (reported on wordpress.org).
- Root cause: a LESS child-selector block added in `b97b23cb` was nested under the combined parent `.so-panels-dialog, .block-editor-page, .wp-customizer`, which cross-products into `.wp-customizer button`, `.wp-customizer a`, `.wp-customizer label`, `.block-editor-page button`, etc. — matching every button/link in the host chrome and overriding the `dashicons` font-family.
- Fix: extract the child-selector block into a standalone top-level rule scoped only to `.so-panels-dialog`. The dialog root element always carries that class (`tpl/js-templates.php:172`) and is appended to `<body>`, so the scoped rule still forces the WP system font inside dialogs rendered in the Customizer, block editor, and classic editor — without leaking into unrelated host UI.
- `-webkit-text-size-adjust: none` on the three parent roots is intentionally left alone: a single property, not a selector cross-product.

Only `css/admin.less` is touched. Compiled `css/admin.css` / `admin.min.css` are gitignored and regenerated at release.

## Test plan
- [ ] Open the WordPress Customizer on a site running this branch — confirm Dashicons render correctly on the close button, panel toggle arrows, and any other dashicon buttons.
- [ ] Open a Page Builder dialog from inside the Customizer (e.g. edit a widget/layout) — confirm dialog text still uses the WP system font.
- [ ] Repeat in the block editor (both via the SO Layout Block and via widget areas) — dialog font unchanged.
- [ ] Repeat in the classic editor — dialog font unchanged.
- [ ] Grep the regenerated `css/admin.css` — no `.wp-customizer button`, `.wp-customizer a`, `.wp-customizer label`, or `.block-editor-page button` rules; `.so-panels-dialog button` and `.so-panels-dialog a` are present.