### PR TITLE
Fix Code tab font regression in widget dialogs

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -966,7 +966,6 @@
 	label,
 	input,
 	select,
-	textarea,
 	button,
 	.button,
 	h3,


### PR DESCRIPTION
## Summary
- Removes `textarea` from the `.so-panels-dialog, .block-editor-page, .wp-customizer` font-family selector list in `css/admin.less`.
- Fixes a regression introduced in 2.34.1 where the Custom HTML widget's Code tab textarea picked up the WP system UI font stack instead of WordPress core's `Consolas, Monaco, monospace`.
- Reported by a user after the 2.34.1 update; the dialog/modal font rule added in `b97b23cb` was inadvertently overriding core's monospace styling for code textareas.

## Root cause
Commit `b97b23cb` added `font-family: @wp_system_font_stack` to a child-selector list that included `textarea`. Inside widget dialogs, the Custom HTML widget's `.so-field-code` textarea relies on core's monospace defaults — the new rule clobbered them. Dropping `textarea` from the list lets core's code-editor font styling pass through while keeping all other form controls (inputs, selects, buttons, labels, headings, links) on the WP system font stack to fend off WP 7 block CSS resets.

## Test plan
- [x] Edit a page in the Classic editor → add a Custom HTML widget → open the Code tab → confirm the textarea uses a monospace font (Consolas / Monaco / monospace).
- [x] Verify other widget form controls in the same dialog (labels, inputs, selects, buttons) still render with the WP system UI font.
- [x] Repeat the above in the block editor (Layout Block) and in the Customizer context.
- [x] Confirm no visual regression on dialog chrome (title bar, toolbar, sidebars).