### PR TITLE
Fix Layout Block column-resize crashes inside the widgets.php iframe

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -252,7 +252,7 @@ function SiteOriginPanelsLayoutBlock(props) {
 
       setTimeout(patchJQueryUIDocuments, 0); // Re-patch whenever a new row or widget is added (new instances are created).
 
-      builderViewRef.current.on('row_added widget_added', patchJQueryUIDocuments);
+      builderViewRef.current.on('row_added widget_added content_change', patchJQueryUIDocuments);
     }
 
     setPanelsInitialized(true);

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -234,7 +234,7 @@ function SiteOriginPanelsLayoutBlock( props ) {
 			// Patch initial instances after first render.
 			setTimeout( patchJQueryUIDocuments, 0 );
 			// Re-patch whenever a new row or widget is added (new instances are created).
-			builderViewRef.current.on( 'row_added widget_added', patchJQueryUIDocuments );
+			builderViewRef.current.on( 'row_added widget_added content_change', patchJQueryUIDocuments );
 		}
 
 		setPanelsInitialized( true );

--- a/js/siteorigin-panels/view/cell.js
+++ b/js/siteorigin-panels/view/cell.js
@@ -165,7 +165,7 @@ module.exports = Backbone.View.extend( {
 				// Set the containment to the cell parent
 				previousCell = cellView.$el.prev().data( 'view' );
 				if ( _.isUndefined( previousCell ) ) {
-					return;
+					return false;
 				}
 
 				// Create the clone for the current cell
@@ -194,6 +194,10 @@ module.exports = Backbone.View.extend( {
 				} );
 			},
 			drag: function ( e, ui ) {
+				var nClone = $( this ).data( 'newCellClone' );
+				var pClone = $( this ).data( 'prevCellClone' );
+				if ( ! previousCell || ! nClone || ! pClone ) { return; }
+
 				// Calculate the new cell and previous cell widths as a percent
 				var containerWidth = cellView.row.$el.width() + 10;
 				var ncw = cellView.model.get( 'weight' ) - (
@@ -207,16 +211,21 @@ module.exports = Backbone.View.extend( {
 					) / containerWidth
 					);
 
-				$( this ).data( 'newCellClone' ).css( 'width', containerWidth * ncw + 'px'  )
+				nClone.css( 'width', containerWidth * ncw + 'px'  )
 					.find( '.preview-cell-weight-input' ).val( Math.round( ncw * 1000 ) / 10 );
 
-				$( this ).data( 'prevCellClone' ).css( 'width', containerWidth * pcw + 'px' )
+				pClone.css( 'width', containerWidth * pcw + 'px' )
 					.find( '.preview-cell-weight-input' ).val( Math.round( pcw * 1000 ) / 10 );
 			},
 			stop: function ( e, ui ) {
+				var nClone = $( this ).data( 'newCellClone' );
+				var pClone = $( this ).data( 'prevCellClone' );
+				if ( ! previousCell || ! nClone || ! pClone ) { return; }
+
 				// Remove the clones
-				$( this ).data( 'newCellClone' ).remove();
-				$( this ).data( 'prevCellClone' ).remove();
+				nClone.remove();
+				pClone.remove();
+				$( this ).removeData( [ 'newCellClone', 'prevCellClone' ] );
 
 				var containerWidth = cellView.row.$el.width() + 10;
 				var ncw = cellView.model.get( 'weight' ) - (

--- a/js/siteorigin-panels/view/row.js
+++ b/js/siteorigin-panels/view/row.js
@@ -228,6 +228,7 @@ module.exports = Backbone.View.extend( {
 
 		this.$( '.so-cells .cell' ).each( function () {
 			cell = $( this );
+			if ( ! cell.data( 'view' ) ) { return; } // skip orphan/clone cells
 
 			$( this ).css(
 				'width',


### PR DESCRIPTION
## Summary
- Fix React error boundary crash when resizing columns in a SiteOrigin Layout Block inside `widgets.php` (iframed block editor in WP 6.5+).
- Three console errors (`t.data(...) is undefined` / `o(...).data(...) is undefined`) traced to `cell.js initResizable`, `row.js resizeRow`, and an incomplete iframe jQuery-UI re-patch in the layout-block React component.
- Reported by frafor.

## Changes
- `js/siteorigin-panels/view/cell.js` — `start` returns `false` to cancel the drag when there's no previous cell; `drag`/`stop` early-return when clone data is missing; `stop` clears its data keys.
- `js/siteorigin-panels/view/row.js` — `resizeRow` skips cells without a `view` data binding instead of throwing.
- `compat/js/siteorigin-panels-layout-block.jsx` — re-patch jQuery UI instances on `content_change` in addition to `row_added`/`widget_added`, so cell-count changes via the row dialog and undo/redo also get re-patched. Body and idempotent guard unchanged.
- `compat/js/siteorigin-panels-layout-block.js` — rebuilt to match the `.jsx` change (single-line diff).

## Test plan
- [x] WP 6.5+ `widgets.php`: SO Layout Block, 3-column row, drag dividers repeatedly — no console errors, no "block caused an error" boundary.
- [x] Open row dialog, change column count 3→4→2, drag again — no errors.
- [x] Standard post block editor: column resize still works.