### PR TITLE
Fix inflated row min-height in Gutenberg iframe (#1332)

### DIFF
--- a/compat/js/siteorigin-panels-layout-block.js
+++ b/compat/js/siteorigin-panels-layout-block.js
@@ -192,7 +192,39 @@ function SiteOriginPanelsLayoutBlock(props) {
     builderViewRef.current.render().attach({
       container: $panelsContainer
     }).setData(initialPanelsData);
-    builderViewRef.current.trigger('builder_resize');
+    builderViewRef.current.trigger('builder_resize'); // Re-fire builder_resize after iframe layout has actually settled so that
+    // resizeRow() measures cell heights against a stable layout instead of the
+    // natural unstyled stack height.
+
+    var settleResize = function settleResize() {
+      if (builderViewRef.current) {
+        builderViewRef.current.trigger('builder_resize');
+      }
+    }; // Re-fire once the iframe document is fully loaded.
+
+
+    if (iframeDoc.readyState === 'complete') {
+      requestAnimationFrame(function () {
+        return requestAnimationFrame(settleResize);
+      });
+    } else {
+      var onIframeReady = function onIframeReady() {
+        if (iframeDoc.readyState === 'complete') {
+          iframeDoc.removeEventListener('readystatechange', onIframeReady);
+          requestAnimationFrame(function () {
+            return requestAnimationFrame(settleResize);
+          });
+        }
+      };
+
+      iframeDoc.addEventListener('readystatechange', onIframeReady);
+    } // Re-fire once web fonts have loaded (font swaps change widget heights).
+
+
+    if (iframeDoc.fonts && iframeDoc.fonts.ready && typeof iframeDoc.fonts.ready.then === 'function') {
+      iframeDoc.fonts.ready.then(settleResize)["catch"](function () {});
+    }
+
     builderViewRef.current.on('content_change', function () {
       var newPanelsData = builderViewRef.current.getData();
 
@@ -212,7 +244,14 @@ function SiteOriginPanelsLayoutBlock(props) {
 
         setLoadingPreview(true);
         setPreviewHtml('');
-      }
+      } // Widget previews can re-render on content_change; re-measure after the next layout.
+
+
+      requestAnimationFrame(function () {
+        if (builderViewRef.current) {
+          builderViewRef.current.trigger('builder_resize');
+        }
+      });
     }); // Use iframeDoc so panels scripts inside the iframe receive the setup event.
 
     jQuery(iframeDoc).trigger('panels_setup', builderViewRef.current);

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -175,6 +175,33 @@ function SiteOriginPanelsLayoutBlock( props ) {
 
 		builderViewRef.current.trigger( 'builder_resize' );
 
+		// Re-fire builder_resize after iframe layout has actually settled so that
+		// resizeRow() measures cell heights against a stable layout instead of the
+		// natural unstyled stack height.
+		const settleResize = () => {
+			if ( builderViewRef.current ) {
+				builderViewRef.current.trigger( 'builder_resize' );
+			}
+		};
+
+		// Re-fire once the iframe document is fully loaded.
+		if ( iframeDoc.readyState === 'complete' ) {
+			requestAnimationFrame( () => requestAnimationFrame( settleResize ) );
+		} else {
+			const onIframeReady = () => {
+				if ( iframeDoc.readyState === 'complete' ) {
+					iframeDoc.removeEventListener( 'readystatechange', onIframeReady );
+					requestAnimationFrame( () => requestAnimationFrame( settleResize ) );
+				}
+			};
+			iframeDoc.addEventListener( 'readystatechange', onIframeReady );
+		}
+
+		// Re-fire once web fonts have loaded (font swaps change widget heights).
+		if ( iframeDoc.fonts && iframeDoc.fonts.ready && typeof iframeDoc.fonts.ready.then === 'function' ) {
+			iframeDoc.fonts.ready.then( settleResize ).catch( () => {} );
+		}
+
 			builderViewRef.current.on( 'content_change', () => {
 				const newPanelsData = builderViewRef.current.getData();
 

--- a/compat/js/siteorigin-panels-layout-block.jsx
+++ b/compat/js/siteorigin-panels-layout-block.jsx
@@ -226,6 +226,13 @@ function SiteOriginPanelsLayoutBlock( props ) {
 					setLoadingPreview( true );
 					setPreviewHtml( '' );
 				}
+
+				// Widget previews can re-render on content_change; re-measure after the next layout.
+				requestAnimationFrame( () => {
+					if ( builderViewRef.current ) {
+						builderViewRef.current.trigger( 'builder_resize' );
+					}
+				} );
 		} );
 
 		// Use iframeDoc so panels scripts inside the iframe receive the setup event.

--- a/js/siteorigin-panels/view/row.js
+++ b/js/siteorigin-panels/view/row.js
@@ -224,6 +224,7 @@ module.exports = Backbone.View.extend( {
 		var height = 0,
 			cellWidth = 0,
 			iconsShown = false,
+			measured = false,
 			cell;
 
 		this.$( '.so-cells .cell' ).each( function () {
@@ -235,6 +236,9 @@ module.exports = Backbone.View.extend( {
 			);
 
 			cellWidth = cell.width();
+			if ( cellWidth > 0 ) {
+				measured = true;
+			}
 			// Ensure this widget is large enough to allow for actions to appear.
 			if ( cellWidth < 215 ) {
 				cell.addClass( 'so-show-icon' );
@@ -256,7 +260,8 @@ module.exports = Backbone.View.extend( {
 		} );
 
 		// Resize all the grids and cell wrappers
-		this.$( '.so-cells .cell-wrapper' ).css( 'min-height', Math.max( height, 63 ) + 'px' );
+		var finalMinHeight = measured ? Math.max( height, 63 ) : 63;
+		this.$( '.so-cells .cell-wrapper' ).css( 'min-height', finalMinHeight + 'px' );
 		// If action icons are visible in any cell, give the container a special class.
 		if ( iconsShown ) {
 			this.$( '.so-cells' ).addClass( 'so-action-icons' );


### PR DESCRIPTION
## Summary
- Fixes #1332: rows in the Page Builder layout block render with very tall, incorrectly calculated `min-height` values when WP forces the Gutenberg-in-iframe editor.
- Root cause: `resizeRow()` measures `cell.height()` and pins it as `min-height`, but the layout block's initial `builder_resize` fires before the iframe's stylesheets, fonts, and widget previews have laid out, so an inflated value gets baked in and never recalculated.
- Fix: re-fire `builder_resize` once iframe layout has actually settled (readystate `complete` + `document.fonts.ready` + double-rAF), again on every `content_change`, and guard `resizeRow` from recording a measurement when no cell has positive width yet (falls back to the existing 63px CSS floor).

## Changes
- `js/siteorigin-panels/view/row.js` — `resizeRow` falls back to 63px when no cell reported a positive width during measurement (silent guard).
- `compat/js/siteorigin-panels-layout-block.jsx` — re-fires `builder_resize` on iframe readystate `complete`, on `document.fonts.ready`, and on every `content_change`.
- `compat/js/siteorigin-panels-layout-block.js` — regenerated Babel output.

Iframe path only — classic editor path is untouched.

## Test plan
- [x] In WP 6.3+ (iframed block editor), insert a SiteOrigin Layout block with a multi-cell row containing text/image widgets. Confirm `.so-cells .cell-wrapper` `min-height` settles at the genuine tallest-cell value (or 63px), not a multi-hundred-pixel inflated value.
- [x] Reload the editor several times to exercise font/image load races; `min-height` must stabilise within ~1s without manual interaction.
- [x] Add and remove widgets; confirm `min-height` recalculates and never sticks at an inflated value.
- [ ] Verify in a non-iframe context (older WP / classic post type) that there is no regression vs `develop`.