### PR TITLE
Restore post globals after admin renders

### DIFF
--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -151,7 +151,11 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 			SiteOrigin_Panels_Post_Content_Filters::add_filters( true );
 		}
 
-		$rendered_layout = SiteOrigin_Panels::renderer()->render( $builder_id, ! $is_editing, $panels_data );
+		if ( $is_editing || ! $this->return_layout ) {
+			$rendered_layout = SiteOrigin_Panels_Admin::render_and_restore_post_globals( $builder_id, ! $is_editing, $panels_data );
+		} else {
+			$rendered_layout = SiteOrigin_Panels::renderer()->render( $builder_id, true, $panels_data );
+		}
 
 		if ( $is_editing ) {
 			SiteOrigin_Panels_Post_Content_Filters::remove_filters( true );

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -260,7 +260,7 @@ class SiteOrigin_Panels_Admin {
 
 				SiteOrigin_Panels_Post_Content_Filters::add_filters();
 				$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-				$post_content = $this->render_and_restore_post_globals( $layout_id, false, $panels_data );
+				$post_content = self::render_and_restore_post_globals( $layout_id, false, $panels_data );
 				$post_css = SiteOrigin_Panels::renderer()->generate_css( $layout_id, $panels_data );
 				SiteOrigin_Panels_Post_Content_Filters::remove_filters();
 				unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
@@ -1359,15 +1359,16 @@ class SiteOrigin_Panels_Admin {
 
 	public function generate_panels_preview( $post_id, $panels_data ) {
 		$GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] = true;
-		$return = $this->render_and_restore_post_globals( (int) $post_id, false, $panels_data );
+		$return = self::render_and_restore_post_globals( (int) $post_id, false, $panels_data );
 
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] );
 
 		return $return;
 	}
 
-	private function render_and_restore_post_globals( $post_id = false, $enqueue_css = true, $panels_data = false, & $layout_data = array(), $is_preview = false ) {
+	public static function render_and_restore_post_globals( $post_id = false, $enqueue_css = true, $panels_data = false, & $layout_data = array(), $is_preview = false ) {
 		$post_globals = array(
+			'siteorigin_panels_current_post',
 			'post',
 			'id',
 			'authordata',
@@ -1435,7 +1436,7 @@ class SiteOrigin_Panels_Admin {
 		// Create a version of the builder data for post content.
 		SiteOrigin_Panels_Post_Content_Filters::add_filters();
 		$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-		echo $this->render_and_restore_post_globals( (int) $_POST['post_id'], false, $panels_data );
+		echo self::render_and_restore_post_globals( (int) $_POST['post_id'], false, $panels_data );
 		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 
@@ -1487,7 +1488,7 @@ class SiteOrigin_Panels_Admin {
 		// Create a version of the builder data for post content.
 		SiteOrigin_Panels_Post_Content_Filters::add_filters();
 		$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-		$return['post_content'] = $this->render_and_restore_post_globals( (int) $_POST['post_id'], false, $panels_data );
+		$return['post_content'] = self::render_and_restore_post_globals( (int) $_POST['post_id'], false, $panels_data );
 		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 
@@ -1565,7 +1566,7 @@ class SiteOrigin_Panels_Admin {
 			// We need this to get our widgets bundle to add it's styles inline for previews.
 			add_filter( 'siteorigin_widgets_is_preview', '__return_true' );
 		}
-		$rendered_layout = $this->render_and_restore_post_globals( $builder_id, true, $panels_data, $layout_data );
+		$rendered_layout = self::render_and_restore_post_globals( $builder_id, true, $panels_data, $layout_data );
 		ob_start();
 
 		// Need to explicitly call `siteorigin_widget_print_styles` because Gutenberg previews don't render a full version of the front end,

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -260,7 +260,7 @@ class SiteOrigin_Panels_Admin {
 
 				SiteOrigin_Panels_Post_Content_Filters::add_filters();
 				$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-				$post_content = SiteOrigin_Panels::renderer()->render( $layout_id, false, $panels_data );
+				$post_content = $this->render_and_restore_post_globals( $layout_id, false, $panels_data );
 				$post_css = SiteOrigin_Panels::renderer()->generate_css( $layout_id, $panels_data );
 				SiteOrigin_Panels_Post_Content_Filters::remove_filters();
 				unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
@@ -1359,11 +1359,46 @@ class SiteOrigin_Panels_Admin {
 
 	public function generate_panels_preview( $post_id, $panels_data ) {
 		$GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] = true;
-		$return = SiteOrigin_Panels::renderer()->render( (int) $post_id, false, $panels_data );
+		$return = $this->render_and_restore_post_globals( (int) $post_id, false, $panels_data );
 
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_PREVIEW_RENDER' ] );
 
 		return $return;
+	}
+
+	private function render_and_restore_post_globals( $post_id = false, $enqueue_css = true, $panels_data = false, & $layout_data = array(), $is_preview = false ) {
+		$post_globals = array(
+			'post',
+			'id',
+			'authordata',
+			'currentday',
+			'currentmonth',
+			'page',
+			'pages',
+			'multipage',
+			'more',
+			'numpages',
+		);
+		$original_globals = array();
+
+		foreach ( $post_globals as $global_name ) {
+			$original_globals[ $global_name ] = array(
+				'exists' => array_key_exists( $global_name, $GLOBALS ),
+				'value' => array_key_exists( $global_name, $GLOBALS ) ? $GLOBALS[ $global_name ] : null,
+			);
+		}
+
+		try {
+			return SiteOrigin_Panels::renderer()->render( $post_id, $enqueue_css, $panels_data, $layout_data, $is_preview );
+		} finally {
+			foreach ( $original_globals as $global_name => $global_value ) {
+				if ( $global_value['exists'] ) {
+					$GLOBALS[ $global_name ] = $global_value['value'];
+				} else {
+					unset( $GLOBALS[ $global_name ] );
+				}
+			}
+		}
 	}
 
 	/**
@@ -1400,7 +1435,7 @@ class SiteOrigin_Panels_Admin {
 		// Create a version of the builder data for post content.
 		SiteOrigin_Panels_Post_Content_Filters::add_filters();
 		$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-		echo SiteOrigin_Panels::renderer()->render( (int) $_POST['post_id'], false, $panels_data );
+		echo $this->render_and_restore_post_globals( (int) $_POST['post_id'], false, $panels_data );
 		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 
@@ -1452,7 +1487,7 @@ class SiteOrigin_Panels_Admin {
 		// Create a version of the builder data for post content.
 		SiteOrigin_Panels_Post_Content_Filters::add_filters();
 		$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-		$return['post_content'] = SiteOrigin_Panels::renderer()->render( (int) $_POST['post_id'], false, $panels_data );
+		$return['post_content'] = $this->render_and_restore_post_globals( (int) $_POST['post_id'], false, $panels_data );
 		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
 		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
 
@@ -1530,7 +1565,7 @@ class SiteOrigin_Panels_Admin {
 			// We need this to get our widgets bundle to add it's styles inline for previews.
 			add_filter( 'siteorigin_widgets_is_preview', '__return_true' );
 		}
-		$rendered_layout = SiteOrigin_Panels::renderer()->render( $builder_id, true, $panels_data, $layout_data );
+		$rendered_layout = $this->render_and_restore_post_globals( $builder_id, true, $panels_data, $layout_data );
 		ob_start();
 
 		// Need to explicitly call `siteorigin_widget_print_styles` because Gutenberg previews don't render a full version of the front end,

--- a/tpl/live-editor-preview.php
+++ b/tpl/live-editor-preview.php
@@ -34,7 +34,8 @@ wp_enqueue_style(
 				) {
 					$data['widgets'] = SiteOrigin_Panels_Admin::single()->process_raw_widgets( $data['widgets'], false, false );
 				}
-				echo siteorigin_panels_render( 'l' . md5( serialize( $data ) ), true, $data );
+				$builder_id = 'l' . md5( serialize( $data ) );
+				echo SiteOrigin_Panels_Admin::render_and_restore_post_globals( $builder_id, true, $data );
 			}
 			?>
 		</div><!-- .entry-content -->


### PR DESCRIPTION
## Summary

- Wrap admin-side Page Builder render calls so WordPress post globals are restored after rendering.
- Apply the wrapper to generated post content, classic/admin previews, live editor preview, layout block AJAX previews, and layout block editor/save validation renders.
- Keep the wrapper signature compatible with `SiteOrigin_Panels_Renderer::render()` by passing `$layout_data` by reference.
- Preserve the renderer's own `$siteorigin_panels_current_post` state as well as WordPress post globals.

## Root Cause

Some widgets can run their own post queries during admin preview/content renders and leave globals such as `$post` pointing at a queried item. Those leaked globals can affect later admin rendering, including permalink-dependent widgets such as carousels.

The same issue can affect later output in admin preview responses. For example, live editor preview renders before `wp_footer()`, and layout block editor/save validation can render Page Builder content outside the original `inc/admin.php` wrapper call sites.

## Follow-up Review Update

After additional review, commit `87659594` expanded the fix to cover the remaining admin/editor render surfaces:

- Made `SiteOrigin_Panels_Admin::render_and_restore_post_globals()` public/static so preview paths outside `inc/admin.php` can use the same wrapper.
- Added `siteorigin_panels_current_post` to the snapshot/restore list to avoid stale renderer state after early returns or failed renders.
- Routed `tpl/live-editor-preview.php` rendering through the wrapper so leaked post globals cannot affect later footer output in the AJAX preview document.
- Routed Layout Block editor and server-side validation renders through the wrapper while leaving normal frontend Layout Block rendering direct.

## Validation

- `php -l inc/admin.php`
- `php -l compat/layout-block.php`
- `php -l tpl/live-editor-preview.php`
- `git diff --check`
- Smoke test confirmed normal restore, exception restore, `siteorigin_panels_current_post` restoration, and by-reference `$layout_data` propagation.
- Manual retest by Andrew confirmed the original warning fix looked okay before publishing.

## Manual Tests

- Corp demo Sandbox page: add only Cards Carousel, save, confirm page slug/permalink and DB `post_name` remain the page's slug.
- Classic editor/Page Builder preview and builder content AJAX with Cards Carousel.
- Block editor Layout Block AJAX preview with Cards Carousel.
- Layout Block save/server-side validation with Cards Carousel.
- Live editor preview with Cards Carousel, checking for footer/preview oddities.