### PR TITLE
Respect Yoast sitemap image filters

### DIFF
--- a/compat/yoast.php
+++ b/compat/yoast.php
@@ -41,6 +41,12 @@ if ( defined( 'WPSEO_FILE' ) ) {
 			extension_loaded( 'xml' ) &&
 			class_exists( 'DOMDocument' )
 		) {
+			$post = get_post( $post_id );
+
+			if ( empty( $post ) ) {
+				return $images;
+			}
+
 			$content = SiteOrigin_Panels::renderer()->render(
 				$post_id,
 				false
@@ -55,9 +61,23 @@ if ( defined( 'WPSEO_FILE' ) ) {
 				$src = $img->getAttribute( 'src' );
 
 				if ( ! empty( $src ) && $src == esc_url( $src ) ) {
-					$images[] = array(
-						'src'   => $src,
+					$src = apply_filters( 'wpseo_xml_sitemap_img_src', $src, $post );
+
+					$image = apply_filters(
+						'wpseo_xml_sitemap_img',
+						array(
+							'src' => $src,
+						),
+						$post
 					);
+
+					if (
+						is_array( $image ) &&
+						! empty( $image['src'] ) &&
+						is_string( $image['src'] )
+					) {
+						$images[] = $image;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Pass Page Builder-rendered sitemap images through Yoast's `wpseo_xml_sitemap_img_src` and `wpseo_xml_sitemap_img` filters before appending them.
- Preserve filtered image URLs that are valid non-empty strings, including URLs with raw query arguments.

## Why

Page Builder adds rendered widget images through Yoast's `wpseo_sitemap_urlimages` extension point. Those images were appended directly, which bypassed Yoast's documented per-image filter path. As a result, snippets such as `add_filter( 'wpseo_xml_sitemap_img', '__return_false' );` removed Yoast-detected images but not images added from Page Builder content.

## Impact

Sites using Yoast SEO can now use Yoast's documented image sitemap filters consistently for Page Builder and SiteOrigin Widgets Bundle images.

## Validation

- `php -l compat/yoast.php`
- `git diff --check -- compat/yoast.php`
- Smoke test: `wpseo_xml_sitemap_img` returning `false` suppresses Page Builder images.
- Smoke test: `wpseo_xml_sitemap_img_src` can rewrite a URL with raw `&` query args and the filtered URL is preserved.