### PR TITLE
Restore Page Builder style field sizing

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -2769,6 +2769,36 @@
 			}
 		}
 
+		.style-section-fields .style-field-wrapper .style-field .style-input-wrapper {
+			input[type="date"],
+			input[type="datetime-local"],
+			input[type="datetime"],
+			input[type="email"],
+			input[type="month"],
+			input[type="number"],
+			input[type="password"],
+			input[type="search"],
+			input[type="tel"],
+			input[type="text"],
+			input[type="time"],
+			input[type="url"],
+			input[type="week"] {
+				min-height: 30px;
+				padding: 0 8px;
+			}
+
+			select {
+				border-color: #8c8f94;
+				border-radius: 3px;
+				color: #2c3338;
+				font-size: 14px;
+				line-height: 2;
+				max-width: 25rem;
+				min-height: 30px;
+				padding: 0 24px 0 8px;
+			}
+		}
+
 		.style-input-wrapper {
 			.clearfix();
 


### PR DESCRIPTION
## Summary
- Restore compact Page Builder visual style field sizing for text-like inputs affected by the WordPress 7 admin form control rules.
- Restore Page Builder visual style selects to the WordPress 6-era select dimensions and colors within the style form only.
- Scope the reset to `.so-visual-styles .style-section-fields .style-field-wrapper .style-field .style-input-wrapper` so it applies to generated Page Builder style fields without touching unrelated admin controls.

## Why
WordPress 7 core admin CSS increases text-like inputs and selects to 40px high. That impacts Page Builder style dialogs, where the existing style form layout expects the previous compact field sizing.

## Validation
- `git diff --check -- css/admin.less`
- `build/node_modules/.bin/lessc css/admin.less /tmp/siteorigin-admin.css`
- Confirmed generated selectors target Page Builder style field markup, including text inputs and selects.

## Human testing
- Open a widget style dialog and check Widget ID / Widget Class text fields.
- Check style select fields such as image size, measurement units, and other style dropdowns.
- Repeat in the classic editor dialog and Layout Block/block editor context if possible.