### PR TITLE
EmbeddedVideo: only rewrite video URL on change

### DIFF
--- a/widgets/widgets.php
+++ b/widgets/widgets.php
@@ -1088,7 +1088,9 @@ class SiteOrigin_Panels_Widgets_EmbeddedVideo extends WP_Widget {
 
 	public function update( $new, $old ) {
 
-		if ( ! empty( $new['video'] ) ) {
+		// Only rewrite the video when it actually changed, so an untouched
+		// widget's stored value stays byte-identical across saves.
+		if ( ! empty( $new['video'] ) && ( empty( $old['video'] ) || $new['video'] !== $old['video'] ) ) {
 			$new['video'] = str_replace( 'https://', 'http://', $new['video'] );
 			$new['video'] = esc_url( $new['video'] );
 		}


### PR DESCRIPTION
## Problem

`SiteOrigin_Panels_Widgets_EmbeddedVideo::update()` force-rewrote `https`→`http` and re-`esc_url()`'d the video value on **every** save. Now that the stored-XSS fix makes `process_raw_widgets` run `update()` on every save (against stored data, not just user edits), this churned the stored value of untouched widgets and could **downgrade `https` URLs to `http`**.

## Fix

Only run the rewrite / `esc_url()` when the video value has **actually changed**; leave it byte-identical when unchanged (`widgets/widgets.php`). This makes `update()` idempotent for this widget — a save against stored data is now a no-op.

## Blast radius

This is the Page-Builder-side companion to the shared-field idempotency work in so-widgets-bundle. The SWB PR fixes the base fields (`posts`, `multiple-media`, select-family) — which also resolves the corruption for third-party widgets consuming those shared fields (e.g. WPinked's "Widgets for SiteOrigin" blog widget, confirmed locally to use the standard `posts` field). This PR covers the EmbeddedVideo case specific to Page Builder's bundled widget.

## Companion PR

so-widgets-bundle sanitizer idempotency: https://github.com/siteorigin/so-widgets-bundle/pull/2316

The two PRs are **independent and mergeable in any order** (different repos, different fields).