### PR TITLE
Layout Block: trust-on-write signature for render-time sanitization

### DIFF
--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -132,6 +132,23 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 		}
 		$panels_data = $attributes['panelsData'];
 		$panels_data = $this->sanitize_panels_data( $panels_data );
+		if ( ! $this->return_layout ) {
+			// Save-time validation: current_user_can() runs in the real
+			// save-time request context (the author's session), which is the
+			// only place capability-gated sanitization is meaningful.
+			if ( ! current_user_can( 'unfiltered_html' ) ) {
+				// Floor: the signature must not depend on any individual
+				// field/widget sanitizer being "healthy" this request (some
+				// SiteOrigin Widgets Bundle field sanitizers can silently pass
+				// through unvalidated when their options registry isn't
+				// hydrated on a given request — see so-widgets-bundle PR
+				// #2316). wp_kses_post() needs no hydrated registry and is
+				// idempotent, so it's a safe universal floor independent of
+				// that failure mode.
+				$panels_data['widgets'] = SiteOrigin_Panels_Admin::kses_deep( $panels_data['widgets'] );
+			}
+			$panels_data['sanitize_signature'] = $this->sign_panels_data( $panels_data );
+		}
 		$builder_id = isset( $attributes['builder_id'] ) ? $attributes['builder_id'] : uniqid( 'gb' . get_the_ID() . '-' );
 
 		// Support for custom CSS classes

--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -188,10 +188,49 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 	}
 
 	private function sanitize_panels_data( $panels_data ) {
+		// Strip any inbound signature so a client-forged 'sanitize_signature'
+		// key can never survive into what gets processed or later re-signed.
+		unset( $panels_data['sanitize_signature'] );
 		$panels_data['widgets'] = SiteOrigin_Panels_Admin::single()->process_raw_widgets( $panels_data['widgets'], false, true );
 		$panels_data = SiteOrigin_Panels_Styles_Admin::single()->sanitize_all( $panels_data );
 
 		return $panels_data;
+	}
+
+	/**
+	 * Compute the HMAC signature certifying that $panels_data is the exact
+	 * output of a save-time capability-gated sanitize run.
+	 *
+	 * @param array $panels_data Sanitized panels data (any existing signature
+	 *                           key is ignored).
+	 * @return string HMAC-SHA256 hex digest.
+	 */
+	private function sign_panels_data( $panels_data ) {
+		unset( $panels_data['sanitize_signature'] );
+		// Version bump policy: bump 'panels:1' -> 'panels:2' ONLY for future
+		// security-tightening changes to sanitization semantics, NEVER for
+		// idempotency/bugfix changes. A bump invalidates every existing
+		// signature, falling all previously-signed content back to strict
+		// re-sanitization until each post is individually re-saved by its real
+		// author (no safe bulk/cron re-signing exists, because capability-gated
+		// sanitization is only meaningful under the real author's session).
+		$version = apply_filters( 'siteorigin_panels_sanitize_version', 'panels:1' );
+		return hash_hmac( 'sha256', $version . '|' . wp_json_encode( $panels_data ), wp_salt( 'auth' ) );
+	}
+
+	/**
+	 * Verify that $panels_data carries a valid save-time signature.
+	 *
+	 * Fails closed: any missing, malformed, or non-matching signature returns
+	 * false, sending the caller down the strict sanitize path.
+	 *
+	 * @param array $panels_data Panels data possibly carrying 'sanitize_signature'.
+	 * @return bool
+	 */
+	private function verify_panels_data( $panels_data ) {
+		return ! empty( $panels_data['sanitize_signature'] )
+			&& is_string( $panels_data['sanitize_signature'] )
+			&& hash_equals( $this->sign_panels_data( $panels_data ), $panels_data['sanitize_signature'] );
 	}
 
 	public function override_container( $container ) {

--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -131,11 +131,26 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 			'</div>';
 		}
 		$panels_data = $attributes['panelsData'];
-		$panels_data = $this->sanitize_panels_data( $panels_data );
-		if ( ! $this->return_layout ) {
-			// Save-time validation: current_user_can() runs in the real
-			// save-time request context (the author's session), which is the
-			// only place capability-gated sanitization is meaningful.
+		if ( $this->return_layout ) {
+			// Normal render (front-end or editor preview): trust only data
+			// carrying a valid save-time signature. Skips BOTH
+			// process_raw_widgets()'s update() calls AND sanitize_all() — never
+			// re-execute sanitizers against their own stored output; this
+			// codebase has repeatedly found that unsafe (see so-widgets-bundle
+			// PR #2316: posts field wiped to array(), multiple-media PHP 8
+			// TypeError, select/icon/font fields reset valid values to default —
+			// all from re-running sanitizers against already-sanitized stored
+			// data). The trusted path is safe specifically BECAUSE it never
+			// re-executes anything, not because re-running would be a no-op.
+			$panels_data = $this->prepare_render_panels_data( $panels_data );
+		} else {
+			// Save-time validation (sanitize_block()): strict, capability-gated,
+			// sanitize then sign.
+			$panels_data = $this->sanitize_panels_data( $panels_data );
+
+			// current_user_can() runs in the real save-time request context
+			// (the author's session), which is the only place capability-gated
+			// sanitization is meaningful.
 			if ( ! current_user_can( 'unfiltered_html' ) ) {
 				// Floor: the signature must not depend on any individual
 				// field/widget sanitizer being "healthy" this request (some
@@ -212,6 +227,34 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 		$panels_data = SiteOrigin_Panels_Styles_Admin::single()->sanitize_all( $panels_data );
 
 		return $panels_data;
+	}
+
+	/**
+	 * Prepare panels_data for rendering, trusting only validly-signed data.
+	 *
+	 * @param array $panels_data Panels data from the stored block attribute.
+	 * @return array
+	 */
+	private function prepare_render_panels_data( $panels_data ) {
+		if ( $this->verify_panels_data( $panels_data ) ) {
+			// Verified: this exact array is the persisted output of a
+			// save-time sanitize run. Structural processing only (class
+			// resolution, panels_info assembly, raw-flag strip) — do NOT
+			// call update() or sanitize_all() again. process_raw_widgets()'s
+			// $trusted param skips the update()/kses_deep sanitize branches
+			// while keeping class resolution, escape_classes, and raw-flag
+			// unset intact.
+			$panels_data['widgets'] = SiteOrigin_Panels_Admin::single()
+				->process_raw_widgets( $panels_data['widgets'], false, true, false, true );
+			return $panels_data; // sanitize_all() deliberately NOT called here
+		}
+
+		// Unsigned, tampered, or pre-existing content with no signature yet:
+		// exactly today's strict path. Never sign here — this call can run
+		// with an admin VIEWER's capabilities over content an unprivileged
+		// AUTHOR supplied, and signing in this branch would launder attacker
+		// content as trusted.
+		return $this->sanitize_panels_data( $panels_data );
 	}
 
 	/**

--- a/compat/layout-block.php
+++ b/compat/layout-block.php
@@ -337,7 +337,10 @@ class SiteOrigin_Panels_Compat_Layout_Block {
 				continue;
 			}
 
-			$panels_data = $this->sanitize_panels_data( $panels_data );
+			// Use the same trust/strict classification as render_layout_block()'s
+			// render branch so the CSS generated here matches the HTML rendered
+			// for the same panels_data on the same request.
+			$panels_data = $this->prepare_render_panels_data( $panels_data );
 			$builder_id = isset( $block['attrs']['builder_id'] ) ? $block['attrs']['builder_id'] : 'gb' . get_the_ID() . '-' . md5( serialize( $panels_data ) ) . '-';
 
 			SiteOrigin_Panels::renderer()->render(

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1049,10 +1049,18 @@ class SiteOrigin_Panels_Admin {
 	 * @param array $old_widgets
 	 * @param bool  $escape_classes Should the class names be escaped.
 	 * @param bool  $force
+	 * @param bool  $trusted        Legal ONLY when the caller has independently
+	 *                              verified (e.g. via HMAC signature) that $widgets is
+	 *                              the exact output of a prior call to this same
+	 *                              function under real capability-gated sanitization.
+	 *                              Never set based on inference/heuristics/call-site
+	 *                              identity alone. When true, skips update()/kses_deep
+	 *                              sanitization execution but still runs class
+	 *                              resolution, raw-flag unset, and escape_classes.
 	 *
 	 * @return array
 	 */
-	public function process_raw_widgets( $widgets, $old_widgets = array(), $escape_classes = false, $force = false ) {
+	public function process_raw_widgets( $widgets, $old_widgets = array(), $escape_classes = false, $force = false, $trusted = false ) {
 		if ( empty( $widgets ) || ! is_array( $widgets ) ) {
 			return array();
 		}
@@ -1091,30 +1099,37 @@ class SiteOrigin_Panels_Admin {
 			// stored-XSS fix for panels_data.
 			$the_widget = SiteOrigin_Panels::get_widget_instance( $info['class'] );
 
-			if ( ! empty( $the_widget ) &&
-				 method_exists( $the_widget, 'update' ) ) {
-				if (
-					! empty( $old_widgets_by_id ) &&
-					! empty( $widget[ 'panels_info' ][ 'widget_id' ] ) &&
-					! empty( $old_widgets_by_id[ $widget[ 'panels_info' ][ 'widget_id' ] ] )
-				) {
-					$old_widget = $old_widgets_by_id[ $widget[ 'panels_info' ][ 'widget_id' ] ];
-				} else {
-					$old_widget = $widget;
+			// $trusted = true is legal ONLY when the caller has independently
+			// verified (e.g. via HMAC signature) that $widgets is the exact output
+			// of a prior call to this same function under real capability-gated
+			// sanitization; callers must never set it based on inference,
+			// heuristics, or the identity of the calling code path alone.
+			if ( ! $trusted ) {
+				if ( ! empty( $the_widget ) &&
+					 method_exists( $the_widget, 'update' ) ) {
+					if (
+						! empty( $old_widgets_by_id ) &&
+						! empty( $widget[ 'panels_info' ][ 'widget_id' ] ) &&
+						! empty( $old_widgets_by_id[ $widget[ 'panels_info' ][ 'widget_id' ] ] )
+					) {
+						$old_widget = $old_widgets_by_id[ $widget[ 'panels_info' ][ 'widget_id' ] ];
+					} else {
+						$old_widget = $widget;
+					}
+
+					/** @var WP_Widget $the_widget */
+					$instance = $the_widget->update( $widget, $old_widget );
+					$instance = apply_filters( 'widget_update_callback', $instance, $widget, $old_widget, $the_widget );
+
+					$widget = $instance;
+				} elseif ( ! current_user_can( 'unfiltered_html' ) ) {
+					// Defense in depth: the widget class did not resolve to something with
+					// an update() method, so its own sanitizer cannot run. For users
+					// lacking unfiltered_html, recursively wp_kses_post() every string
+					// field so unsanitized markup can never be persisted, even for an
+					// unknown or missing widget class.
+					$widget = self::kses_deep( $widget );
 				}
-
-				/** @var WP_Widget $the_widget */
-				$instance = $the_widget->update( $widget, $old_widget );
-				$instance = apply_filters( 'widget_update_callback', $instance, $widget, $old_widget, $the_widget );
-
-				$widget = $instance;
-			} elseif ( ! current_user_can( 'unfiltered_html' ) ) {
-				// Defense in depth: the widget class did not resolve to something with
-				// an update() method, so its own sanitizer cannot run. For users
-				// lacking unfiltered_html, recursively wp_kses_post() every string
-				// field so unsanitized markup can never be persisted, even for an
-				// unknown or missing widget class.
-				$widget = self::kses_deep( $widget );
 			}
 
 			// The raw flag is only ever a transient editor hint and must never be
@@ -1138,11 +1153,13 @@ class SiteOrigin_Panels_Admin {
 	 * Used as a defense-in-depth fallback in process_raw_widgets() for widget
 	 * instances whose class cannot be resolved to a widget with an update()
 	 * method, ensuring unprivileged users can never persist unsanitized markup.
+	 * Also used by SiteOrigin_Panels_Compat_Layout_Block as a universal
+	 * sanitization floor before signing panels_data at save time.
 	 *
 	 * @param mixed $value Scalar or (nested) array to sanitize.
 	 * @return mixed The sanitized value, preserving structure.
 	 */
-	private static function kses_deep( $value ) {
+	public static function kses_deep( $value ) {
 		if ( is_array( $value ) ) {
 			foreach ( $value as $key => $item ) {
 				$value[ $key ] = self::kses_deep( $item );

--- a/tests/LayoutBlockRenderTrustSignatureTest.php
+++ b/tests/LayoutBlockRenderTrustSignatureTest.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace SiteOrigin\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Widget stub whose update() sanitizes its content the way a real
+ * capability-gated widget (e.g. WP_Widget_Custom_HTML) would. Declared as a
+ * named class (rather than an anonymous class) so the file stays parseable by
+ * older PHP parsers in the build toolchain.
+ */
+class LayoutBlockTrustSanitizingWidgetStub {
+	public function update( $new, $old ) {
+		$new['content'] = preg_replace(
+			'/\s*on\w+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i',
+			'',
+			(string) $new['content']
+		);
+
+		return $new;
+	}
+}
+
+/**
+ * Widget stub whose update() mutates content in a detectable, one-way manner
+ * (appends '-SANITIZED') and counts invocations, so tests can prove whether
+ * sanitization ran zero, one, or two times against the same data.
+ */
+class LayoutBlockTrustMarkerWidgetStub {
+	public $update_calls = 0;
+
+	public function update( $new, $old ) {
+		$this->update_calls++;
+		$new['content'] = (string) $new['content'] . '-SANITIZED';
+
+		return $new;
+	}
+}
+
+/**
+ * Regression tests for the Layout Block render-time trust signature
+ * (SiteOrigin_Panels_Compat_Layout_Block::prepare_render_panels_data()).
+ *
+ * Properties locked by this test:
+ * (a) Unsigned (or forged-signature) panels_data sent to the render path is
+ *     ALWAYS strictly re-sanitized — the stored-XSS fix's invariant holds at
+ *     the new prepare_render_panels_data() entry point.
+ * (b) Validly-signed panels_data renders byte-identical, with NO second
+ *     execution of widget update() sanitizers, regardless of the CURRENT
+ *     viewer's capabilities — the trust decision is capability-independent.
+ * (c) Any tampering after signing invalidates the signature and fails closed
+ *     back to the strict sanitize path.
+ *
+ * NOTE: This test is intentionally self-contained, following the conventions
+ * of tests/SavePostRawFlagSanitizationTest.php: no shared base class,
+ * phpunit.xml, or composer autoload exists on this branch. To keep the file
+ * parseable by the build toolchain's bundled php-parser it avoids arrow
+ * functions and anonymous classes; the `: void` return types on
+ * setUp()/tearDown() are required by PHPUnit 12.
+ */
+class LayoutBlockRenderTrustSignatureTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		// Minimal WP function stubs used by the code under test.
+		Functions\when( '__' )->returnArg();
+
+		// apply_filters: return the value being filtered unchanged. This also
+		// covers the 'siteorigin_panels_sanitize_version' tag, which passes
+		// through its 'panels:1' default — a stable, deterministic version
+		// string for signing.
+		Functions\when( 'apply_filters' )->alias(
+			function ( $tag, $value = null ) {
+				return $value;
+			}
+		);
+
+		// wp_kses_post(): emulate the relevant behaviour — strip on* event
+		// handler attributes carrying the XSS payload.
+		Functions\when( 'wp_kses_post' )->alias(
+			function ( $value ) {
+				return preg_replace( '/\s*on\w+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', (string) $value );
+			}
+		);
+
+		// wp_json_encode(): PHP's native json_encode is a faithful stand-in.
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		// wp_salt(): fixed test salt — no real WP install/AUTH_KEY exists in
+		// this unit context. hash_hmac()/hash_equals() are pure PHP core
+		// functions and are deliberately NOT stubbed.
+		Functions\when( 'wp_salt' )->justReturn( 'test-salt-value' );
+
+		$this->require_classes();
+	}
+
+	protected function tearDown(): void {
+		\SiteOrigin_Panels::$instance_resolver = null;
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Load inc/admin.php and compat/layout-block.php plus the stub
+	 * collaborators they depend on, once per process.
+	 */
+	private function require_classes() {
+		if ( ! class_exists( 'SiteOrigin_Panels', false ) ) {
+			// Stub the SiteOrigin_Panels facade. get_widget_instance() is
+			// re-pointed per-test via the static $instance_resolver closure.
+			eval(
+				'class SiteOrigin_Panels {'
+				. ' public static $instance_resolver = null;'
+				. ' public static function get_widget_instance( $class ) {'
+				. '   return self::$instance_resolver ? call_user_func( self::$instance_resolver, $class ) : null;'
+				. ' }'
+				. '}'
+			);
+		}
+
+		// SiteOrigin_Panels_Admin::single() runs the real constructor, which
+		// instantiates these collaborator singletons and includes the
+		// installer when SiteOrigin_Installer is absent. Stub them so the
+		// constructor can run without pulling in the whole admin stack.
+		$collaborators = array(
+			'SiteOrigin_Panels_Admin_Widget_Dialog',
+			'SiteOrigin_Panels_Admin_Widgets_Bundle',
+			'SiteOrigin_Panels_Admin_Layouts',
+			'SiteOrigin_Panels_Admin_Dashboard',
+		);
+
+		foreach ( $collaborators as $collaborator ) {
+			if ( ! class_exists( $collaborator, false ) ) {
+				eval(
+					'class ' . $collaborator . ' {'
+					. ' public static function single() {'
+					. '   static $single;'
+					. '   return empty( $single ) ? $single = new self() : $single;'
+					. ' }'
+					. '}'
+				);
+			}
+		}
+
+		if ( ! class_exists( 'SiteOrigin_Installer', false ) ) {
+			// Presence alone stops the admin constructor including the real
+			// installer bootstrap file.
+			eval( 'class SiteOrigin_Installer {}' );
+		}
+
+		if ( ! class_exists( 'SiteOrigin_Panels_Styles_Admin', false ) ) {
+			// sanitize_all() is out of scope here; identity passthrough lets
+			// the tests observe process_raw_widgets()' behaviour directly.
+			eval(
+				'class SiteOrigin_Panels_Styles_Admin {'
+				. ' public static function single() {'
+				. '   static $single;'
+				. '   return empty( $single ) ? $single = new self() : $single;'
+				. ' }'
+				. ' public function sanitize_all( $panels_data ) {'
+				. '   return $panels_data;'
+				. ' }'
+				. '}'
+			);
+		}
+
+		// Stubs for the WP base bits the classes reference at include time.
+		if ( ! function_exists( 'add_action' ) ) {
+			Functions\when( 'add_action' )->justReturn( true );
+		}
+
+		if ( ! function_exists( 'add_filter' ) ) {
+			Functions\when( 'add_filter' )->justReturn( true );
+		}
+
+		if ( ! class_exists( 'SiteOrigin_Panels_Admin', false ) ) {
+			require_once dirname( __DIR__ ) . '/inc/admin.php';
+		}
+
+		if ( ! class_exists( 'SiteOrigin_Panels_Compat_Layout_Block', false ) ) {
+			require_once dirname( __DIR__ ) . '/compat/layout-block.php';
+		}
+	}
+
+	/**
+	 * Build the Layout Block compat instance WITHOUT running its real
+	 * constructor (which registers WP hooks out of scope for a unit test).
+	 */
+	private function layout_block() {
+		$reflection = new \ReflectionClass( \SiteOrigin_Panels_Compat_Layout_Block::class );
+
+		return $reflection->newInstanceWithoutConstructor();
+	}
+
+	/**
+	 * Invoke a private method on the Layout Block compat instance.
+	 */
+	private function invoke( $object, $method, array $args ) {
+		$reflection = new \ReflectionMethod( get_class( $object ), $method );
+		$reflection->setAccessible( true );
+
+		return $reflection->invokeArgs( $object, $args );
+	}
+
+	private const PAYLOAD = '<img src=x onerror=alert(1)>';
+	private const CLEANED = '<img src=x>';
+
+	// --- (a) Unsigned/forged payloads must always take the strict path. ------
+
+	public function test_unsigned_payload_takes_strict_path() {
+		$stub = new LayoutBlockTrustSanitizingWidgetStub();
+		\SiteOrigin_Panels::$instance_resolver = function () use ( $stub ) {
+			return $stub;
+		};
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$panels_data = array(
+			'widgets' => array(
+				array(
+					'content'     => self::PAYLOAD,
+					'panels_info' => array( 'class' => 'LayoutBlockTrustSanitizingWidget' ),
+				),
+			),
+		);
+
+		$result = $this->invoke( $this->layout_block(), 'prepare_render_panels_data', array( $panels_data ) );
+
+		$this->assertSame(
+			self::CLEANED,
+			$result['widgets'][0]['content'],
+			'A payload with no signature must be strictly re-sanitized on render.'
+		);
+	}
+
+	public function test_forged_signature_takes_strict_path_and_is_stripped() {
+		$stub = new LayoutBlockTrustSanitizingWidgetStub();
+		\SiteOrigin_Panels::$instance_resolver = function () use ( $stub ) {
+			return $stub;
+		};
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$panels_data = array(
+			'widgets' => array(
+				array(
+					'content'     => self::PAYLOAD,
+					'panels_info' => array( 'class' => 'LayoutBlockTrustSanitizingWidget' ),
+				),
+			),
+			'sanitize_signature' => 'forged-garbage-signature',
+		);
+
+		$result = $this->invoke( $this->layout_block(), 'prepare_render_panels_data', array( $panels_data ) );
+
+		$this->assertSame(
+			self::CLEANED,
+			$result['widgets'][0]['content'],
+			'A forged signature must never bypass strict re-sanitization.'
+		);
+		$this->assertArrayNotHasKey(
+			'sanitize_signature',
+			$result,
+			'The strict path must strip the inbound forged signature key.'
+		);
+	}
+
+	// --- (b) Validly-signed data renders unmodified, capability-independent. -
+
+	public function test_signed_payload_renders_unmodified_without_resanitization() {
+		$stub = new LayoutBlockTrustMarkerWidgetStub();
+		\SiteOrigin_Panels::$instance_resolver = function () use ( $stub ) {
+			return $stub;
+		};
+		// The viewer lacks unfiltered_html for BOTH the save simulation and
+		// the render call: trust must be independent of the CURRENT viewer's
+		// capability. This is the exact bug being fixed — previously an
+		// unprivileged viewer triggered re-sanitization on every render.
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$panels_data = array(
+			'widgets' => array(
+				array(
+					'content'     => 'trusted-content',
+					'panels_info' => array( 'class' => 'LayoutBlockTrustMarkerWidget' ),
+				),
+			),
+		);
+
+		$block = $this->layout_block();
+
+		// Simulate the original save: strict sanitize, then sign — mirroring
+		// render_layout_block()'s save-time branch.
+		$signed = $this->invoke( $block, 'sanitize_panels_data', array( $panels_data ) );
+		$this->assertSame(
+			'trusted-content-SANITIZED',
+			$signed['widgets'][0]['content'],
+			'update() must run during the save-time sanitize.'
+		);
+		$this->assertSame( 1, $stub->update_calls, 'update() runs exactly once during save.' );
+
+		$signed['sanitize_signature'] = $this->invoke( $block, 'sign_panels_data', array( $signed ) );
+
+		// Render for an unprivileged viewer.
+		$result = $this->invoke( $block, 'prepare_render_panels_data', array( $signed ) );
+
+		$this->assertSame(
+			'trusted-content-SANITIZED',
+			$result['widgets'][0]['content'],
+			'Signed content must render byte-identical to what was signed — no second -SANITIZED suffix.'
+		);
+		$this->assertSame(
+			1,
+			$stub->update_calls,
+			'update() must NOT run again on the trusted render path.'
+		);
+	}
+
+	// --- (c) Tampering invalidates the signature and fails closed. -----------
+
+	public function test_tampered_payload_fails_verification_and_resanitizes() {
+		$stub = new LayoutBlockTrustMarkerWidgetStub();
+		\SiteOrigin_Panels::$instance_resolver = function () use ( $stub ) {
+			return $stub;
+		};
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$panels_data = array(
+			'widgets' => array(
+				array(
+					'content'     => 'trusted-content',
+					'panels_info' => array( 'class' => 'LayoutBlockTrustMarkerWidget' ),
+				),
+			),
+		);
+
+		$block = $this->layout_block();
+
+		// Produce a validly-signed payload, as in test (b).
+		$signed = $this->invoke( $block, 'sanitize_panels_data', array( $panels_data ) );
+		$signed['sanitize_signature'] = $this->invoke( $block, 'sign_panels_data', array( $signed ) );
+		$this->assertSame( 1, $stub->update_calls );
+
+		// Tamper with a field WITHOUT updating the signature.
+		$signed['widgets'][0]['content'] .= 'X';
+		$tampered_value = $signed['widgets'][0]['content'];
+
+		$result = $this->invoke( $block, 'prepare_render_panels_data', array( $signed ) );
+
+		$this->assertNotSame(
+			$tampered_value,
+			$result['widgets'][0]['content'],
+			'Tampered content must not pass through unmodified — verification must fail closed.'
+		);
+		$this->assertSame(
+			'trusted-content-SANITIZEDX-SANITIZED',
+			$result['widgets'][0]['content'],
+			'The strict fallback must have re-run update() against the tampered value.'
+		);
+		$this->assertSame(
+			2,
+			$stub->update_calls,
+			'update() must run a second time when verification fails.'
+		);
+		$this->assertArrayNotHasKey(
+			'sanitize_signature',
+			$result,
+			'The strict path must strip the now-invalid signature key.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary
Fixes a regression where the Block Editor's Layout Block re-ran capability-gated sanitization (`process_raw_widgets()` → `wp_kses_post()`) on **every front-end render**, not just at save. This made legitimate `<iframe>`/`<script>` embeds (e.g. a JotForm contact form) added via this block render correctly for logged-in admins (who have `unfiltered_html`) but **completely blank for logged-out/anonymous visitors** on every page load.

## Design
HMAC "trust-on-write": sign sanitized `panelsData` at save time (with a mandatory `kses_deep()` floor for non-`unfiltered_html` authors), verify the signature at render time, and skip re-sanitization only when it verifies. Any failure (missing/invalid signature, tampering, salt rotation, legacy unsigned content) fails closed to today's strict re-sanitize behavior — never fails open.

The original Contributor-level stored-XSS fix (`eaab65c7`, #1339) is fully preserved: save-time content always goes through the strict path unconditionally; nothing about that fix is weakened or bypassed.

## Commits (6, atomic)
1. Add `$trusted` parameter to `process_raw_widgets()`, make `kses_deep()` public
2. Strip inbound forged signature key, add HMAC sign/verify helpers
3. Sign `panels_data` at save time with mandatory `kses_deep` floor
4. Add `prepare_render_panels_data()`, route render branch through signature trust check
5. Route `maybe_generate_layout_block_css()` through the trusted render path (avoids CSS/HTML mismatch)
6. Regression tests: unsigned/malicious payload still stripped; validly-signed payload renders unmodified regardless of viewer capability; tampered signature fails closed

## ⚠️ Release-order dependency — please read before merging
Companion PR: siteorigin/so-widgets-bundle#2318 — contributes sowb's own sanitization-version component to the shared `siteorigin_panels_sanitize_version` filter this PR introduces. **That PR should merge/release before or together with this one.** If this PR ships first and sites start signing under `panels:1` alone, a later sowb update adds `;sowb:1` to the composed version string and invalidates every existing signature site-wide (fail-closed — no vulnerability — but the blank-embed symptom this PR fixes will resurface until each affected post is individually re-saved by its author). Same effect if Widgets Bundle is deactivated/reactivated on a site that already has both filters active. Expected behavior, not a bug — worth flagging to support in advance.

## Out of scope (tracked as follow-ups, not in this PR)
- `wp_block` (reusable blocks) are never save-validated today (`rest_pre_insert_wp_block` isn't hooked) — a real, separate gap, not introduced or fixed here.
- Widening save-surface coverage via `wp_insert_post_data` (covers XML-RPC/cron/direct `wp_insert_post()`).
- Debug-mode logging to distinguish "no signature" (normal, legacy content) from "signature present but mismatched" (tampering or canonicalization drift) at render time.
- Integration test for the `serialize_blocks()`/`parse_blocks()` signature round-trip specifically (current tests exercise the signing/verification logic directly via Reflection, not the full block-comment round trip).

## Human QA checklist (please run through before merging)
- [ ] In the Block Editor, add a Layout Block with a Custom HTML widget containing a real `<iframe>`+`<script>` embed (e.g. JotForm), save as an Administrator
- [ ] View the published page **logged out / in a private window** — confirm the embed now renders (this is the bug being fixed)
- [ ] Edit the same post as a Contributor-level test account (or simulate via the included regression tests) — confirm raw script/iframe content still cannot be persisted unsanitized (the original XSS fix must still hold)
- [ ] Confirm `docs/plans/current.md` is NOT part of this diff (plan files are a workspace artifact, never committed)
- [ ] Coordinate release timing with siteorigin/so-widgets-bundle#2318 per the dependency note above

## Test plan
- [x] `git log --oneline develop..HEAD` — 6 atomic commits, one per step
- [x] Pipeline reviewer: APPROVE
- [x] Independent design review (Fable): 2 rounds, converged
- [ ] Merge coordination: hold until ready to release with or after siteorigin/so-widgets-bundle#2318