### PR TITLE
Block Editor: fix initSortable and wp.media inside the canvas iframe

### DIFF
--- a/js/siteorigin-panels/view/builder.js
+++ b/js/siteorigin-panels/view/builder.js
@@ -440,9 +440,11 @@ module.exports = Backbone.View.extend( {
 		var builderID = builderView.$el.attr( 'id' );
 		var container = 'parent';
 
-		if ( ! $( 'body' ).hasClass( 'wp-customizer' ) && $( 'body' ).attr( 'class' ).match( /version-([0-9-]+)/ )[0].replace( /\D/g,'' ) < 59 ) {
-			wpVersion = '#wpwrap';
-		}
+		// A dead branch here set the sortable container to '#wpwrap' below
+		// WordPress 5.9, which is now the declared minimum. It never took effect
+		// anyway: it assigned to an undeclared `wpVersion` while the sortable reads
+		// `container`. It also threw in the block editor canvas, whose body has no
+		// version-* class, aborting sortable setup entirely.
 
 		// Create the sortable element for rows.
 		this.rowsSortable = this.$( '.so-rows-container:not(.sow-row-color)' ).sortable( {

--- a/js/siteorigin-panels/view/styles.js
+++ b/js/siteorigin-panels/view/styles.js
@@ -153,14 +153,63 @@ module.exports = Backbone.View.extend( {
 		// Set up the image select fields
 		this.$( '.style-field-image' ).each( function () {
 			var frame = null;
+			var frameMedia = null;
 			var $s = $( this );
+
+			// Inside the block editor canvas the styles form runs in an iframe
+			// that has no wp.media of its own. The Widgets Bundle solves this for
+			// its own media fields by reaching for window.top.wp.media
+			// (base/inc/fields/js/media-field.js:26). Same approach here: prefer
+			// the local one, fall back to the top window.
+			// Usable means callable AND carrying attachment(), because both are
+			// used below. A partially initialised wp.media can satisfy a bare
+			// truthiness check and then throw.
+			var usableMedia = function( candidate ) {
+				return typeof candidate === 'function' &&
+					typeof candidate.attachment === 'function' ?
+					candidate :
+					null;
+			};
+
+			var soMedia = function() {
+				var local = typeof wp !== 'undefined' && wp ? usableMedia( wp.media ) : null;
+
+				if ( local ) {
+					return local;
+				}
+
+				try {
+					if ( window.top && window.top.wp ) {
+						return usableMedia( window.top.wp.media );
+					}
+				} catch ( e ) {
+					// Cross-origin top window. Nothing we can do.
+				}
+
+				return null;
+			};
 
 			$s.find( '.so-image-selector' ).on( 'click', function( e ) {
 				e.preventDefault();
 
 				if ( frame === null ) {
+					// Resolve once and keep it for this frame's lifetime, so the
+					// select handler below cannot pick up a different API than the
+					// one the frame was built from.
+					frameMedia = soMedia();
+
+					if ( ! frameMedia ) {
+						// Neither window has a usable media API. Say so rather than
+						// leaving the control silently inert.
+						if ( window.console && typeof window.console.warn === 'function' ) {
+							console.warn( 'SiteOrigin Page Builder: the media library is unavailable in this context, so the image selector cannot open.' );
+						}
+
+						return;
+					}
+
 					// Create the media frame.
-					frame = wp.media( {
+					frame = frameMedia( {
 						// Set the title of the modal.
 						title: panelsOptions.add_media,
 
@@ -182,7 +231,7 @@ module.exports = Backbone.View.extend( {
 						var selection = frame.state().get( 'selection' );
 						var selectedImage = $s.find( '.so-image-selector > input' ).val();
 						if ( selectedImage ) {
-							selection.add( wp.media.attachment( selectedImage ) );
+							selection.add( frameMedia.attachment( selectedImage ) );
 						}
 					} );
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Page Builder by SiteOrigin ===
 Tags: page builder, website builder, responsive design, drag and drop, visual editor
-Requires at least: 4.7
+Requires at least: 5.9
 Tested up to: 7.0
 Requires PHP: 7.0.0
 Stable tag: trunk


### PR DESCRIPTION
Two independent fixes for Page Builder running inside the block editor canvas iframe. Both surfaced while chasing the dead Open Builder button, which is fixed separately in siteorigin/so-widgets-bundle#2344.

## 1. `initSortable()` threw in the canvas — closes #1350

`view/builder.js` carried a pre-5.9 branch that read the WordPress version off the body class:

```js
$( 'body' ).attr( 'class' ).match( /version-([0-9-]+)/ )[0]
```

Inside the canvas the body carries no `version-*` class, so `.match()` returned `null` and `[0]` threw. That aborted sortable setup and left rows and cells uninitialised.

**Removed rather than repaired, because it never took effect in the first place.** Two independent reasons:

- It assigned to an undeclared `wpVersion` while the sortable actually reads `container`, so `'#wpwrap'` was never applied on any WordPress version.
- Its comparison stripped non-digits, so `version-5-8-1` became `581`, which is not `< 59`. The branch could not fire even on the versions it targeted.

Also bumps `Requires at least` from 4.7 to 5.9 — the version that branch was written for. Below 5.9 is no longer supported, so there is nothing for the branch to do even in principle.

## 2. Style image controls threw where `wp.media` is absent

Row and cell style image controls called `wp.media` directly (`view/styles.js`). Inside the canvas the form runs in an iframe with no `wp.media`, so clicking an image control threw.

Now prefers the local `wp.media` and falls back to `window.top.wp.media` — the same approach Widgets Bundle already uses for its own media fields (`base/inc/fields/js/media-field.js:26`). Validates that what it resolves is callable and exposes `.attachment` before using it, and returns early rather than throwing if neither is reachable. The resolved frame is captured once for the frame's lifetime.

## Verified

Built from this branch (`2.36.0-canvas2`) and installed alongside the Widgets Bundle fix on WordPress 7.0.3. Cold cache, full reproduction — logged out, logged back in, DevTools "Disable cache" on:

- Open Builder opens the Page Builder dialog and it renders with existing content intact
- Row and cell controls reachable, no `wp.media` throw
- No console errors from either change

Building this repo requires the old toolchain: `nvm use 10.18.1`, then `cd build && npx gulp build:release -v <version>` (`node-sass@4.14.1` has no arm64 binary and `gulp@3.9` breaks on Node 12+).

## Not verified

- Sortable behaviour on the **oldest supported WordPress** after the `Requires at least` bump to 5.9.
- The `wp.media` fallback in the **Site Editor** specifically, as opposed to the post editor.
- Row resizing end to end. #1350 notes the dialog is already visible when the old code threw, so the visible symptom was limited to handlers registered after it — including row resizing. Worth a direct check.

## Merge order

Merge this before #1354. That PR is cut from `develop`, so until this fix lands it hits the same pre-existing `initSortable` canvas crash removed here; with this merged first, #1354 rebases cleanly.

## Related

- siteorigin/so-widgets-bundle#2341 — the Open Builder root cause, and siteorigin/so-widgets-bundle#2344 for its fix
- #1351 — widget lists render with bullets in the canvas. Cosmetic, independent, not addressed here.

