### PR TITLE
Dialogs: carry wp-core-ui so admin controls style in the block editor

### DIFF
--- a/js/siteorigin-panels/view/dialog.js
+++ b/js/siteorigin-panels/view/dialog.js
@@ -7,7 +7,11 @@ module.exports = Backbone.View.extend( {
 	tabbed: false,
 	rendered: false,
 	builder: false,
-	className: 'so-panels-dialog-wrapper',
+	// wp-core-ui is what WordPress scopes its admin button and form styling to.
+	// The block editor canvas is an iframe whose body does not carry it, and the
+	// dialog is appended to that body, so without this its controls fall back to
+	// browser defaults.
+	className: 'so-panels-dialog-wrapper wp-core-ui',
 	dialogClass: '',
 	dialogIcon: 'add-widget',
 	parentDialog: false,


### PR DESCRIPTION
> ### 🧪 Ready-to-test build — install this
> **[siteorigin-panels.2.36.0-pr1353-1354.zip](https://siteorigin.com/wp-content/uploads/2026/08/siteorigin-panels.2.36.0-pr1353-1354.zip)**
>
> This PR can't be tested on its own — cut from `develop`, it still hits the pre-existing `initSortable` canvas crash. The zip above is **this PR combined with #1353**, so you can install one plugin and test the dialog `wp-core-ui` styling in the block editor with nothing to build. Merge order stays **#1353 → #1354**.

---

Page Builder's dialog controls render as raw browser buttons inside the block editor canvas. Fixes siteorigin/so-widgets-bundle#2343.

## Cause

WordPress scopes its admin control styling under `.wp-core-ui`:

```css
.wp-core-ui .button, .wp-core-ui .button-primary, .wp-core-ui .button-secondary
```

The parent admin page carries that class on `<body>`. The block editor canvas is an iframe whose body does not — it is `block-editor-iframe__body editor-styles-wrapper post-type-post admin-color-modern wp-embed-responsive`. `view/dialog.js:89` appends the dialog to that body, so nothing in the dialog has a `.wp-core-ui` ancestor.

The stylesheets are present in the canvas the whole time — `buttons-css`, `forms-css` and `editor-buttons-css` all load there, and iterating the canvas's `document.styleSheets` finds the `.button` rules. They simply cannot match.

## The change

One line: `wp-core-ui` on the dialog wrapper's `className`. Backbone applies it at construction, and every dialog type (`widget`, `row`, `prebuilt`, `widgets`, `history`, `builder`) extends that view, so one change covers them all.

No effect in the classic admin, where an ancestor already carries the class — the rules are `.wp-core-ui .button`, so a nearer second ancestor changes neither matching nor specificity.

## Why not put it on the canvas body

That was the obvious alternative and it is not safe. The canvas also renders the user's **post content**, and core's rules are not limited to `.button`:

| Selector | File |
|---|---|
| `.wp-core-ui select` (+ `:hover`, `:focus`, `:active`, `.disabled`) | `wp-admin/css/forms.css:340,358,363,369,374` |
| `.wp-core-ui button::-moz-focus-inner` | `wp-includes/css/buttons.css:64` |
| `.wp-core-ui input[type="reset"]` | `wp-includes/css/buttons.css:133` |

`forms-css` is confirmed present in the canvas, so those are live. And Widgets Bundle ships a bare `.button` in a **front-end** template — `widgets/google-map/tpl/js-map.php:15`, `<button class="btn button">` — which would pick up admin chrome in the editor preview, along with every `<select>` in any block.

## Verified in the block editor canvas

Dialog primary button, before → after:

| | before | after |
|---|---|---|
| `background-color` | `rgb(239, 239, 239)` | `rgb(56, 88, 233)` |
| `border` | `2px outset rgb(0, 0, 0)` | `1px solid rgb(56, 88, 233)` |
| `border-radius` | `0px` | `2px` |

Plus:

- Every dialog wrapper in the canvas carries the class.
- Sweep for `.button, .button-primary, .button-secondary` with no `.wp-core-ui` ancestor returns `[]`.
- **Content is untouched.** A `<button class="button">` and a `<select>` injected into the canvas content area compute byte-identically before and after, and gain no `.wp-core-ui` ancestor. The canvas `<body>` remains unclassed.
- Classic admin dialogs unchanged.

Confirmed by the maintainer in the block editor and the classic admin.

## Testing note

This branch is cut from `develop`, so on its own it still carries the pre-existing `initSortable` crash in the canvas (`view/builder.js:443` reads `$( 'body' ).attr( 'class' ).match( /version-([0-9-]+)/ )[0]`, which throws where the body has no `version-*` class). That is fixed separately by #1353. Manual testing was done against a build combining both; if #1353 lands first this rebases cleanly.

## Not included

- **The live editor.** Initially in scope on the assumption it had the same problem. Measured: it opens in the **top** document, whose body already has `wp-core-ui`, so its buttons were never broken. The commit was dropped rather than ship a no-op with a misleading message. Worth revisiting only if a future change puts the live editor inside the canvas — the widget-block path already renders its toolbar button, and only lacks a preview URL to make it reachable.
- **#1351**, dialog lists rendering with bullet markers. Same family, different cause: the canvas does not load `wp-admin/css/common.css` and its bare `ul{list-style:none}`. `wp-core-ui` does not scope that rule, so this fix does not address it.

