### PR TITLE
Dialogs: Remove List Markers and Indentation in the Block Editor Canvas

### DIFF
--- a/css/admin.less
+++ b/css/admin.less
@@ -972,6 +972,28 @@
 	}
 }
 
+// The block editor canvas iframe does not load wp-admin/css/common.css, which
+// resets admin lists with `ul{list-style:none}` and `ul,ol{padding:0}`. The
+// editor's own reset reverts both, so dialog/menu lists get browser bullets AND
+// left indentation. Replicate common.css's reset here, scoped to dialog/menu
+// chrome containers only — never .so-content widget forms, whose lists
+// (arbitrary WP_Widget::form() HTML) are left untouched.
+.so-panels-dialog .so-sidebar,
+.so-panels-dialog .so-toolbar,
+.so-dropdown-wrapper,
+.so-panels-contextual-menu {
+	ul {
+		list-style: none;
+		padding: 0;
+	}
+}
+
+.so-panels-dialog .widget-type-list,
+.so-panels-dialog .so-directory-items-filters ul {
+	list-style: none;
+	padding: 0;
+}
+
 .so-panels-dialog,
 .block-editor-page,
 .wp-customizer {


### PR DESCRIPTION
Fixes #1351.

Page Builder's dialog and menu lists render with bullet markers and left indentation inside the block editor canvas iframe (the Add Widget picker, dialog toolbar dropdowns, directory filters, and the right-click row menu).

## Cause

The canvas iframe doesn't get wp-admin's list reset. The block-library editor stylesheet reverts list styling on lists in the canvas — `:where(.editor-styles-wrapper) ul { list-style-type: revert; padding: revert }` (`wp-includes/css/dist/block-library/reset.css`) — restoring the browser-default markers and indentation. In the classic admin, `wp-admin/css/common.css` neutralises these with `ul { list-style: none }` and `ul, ol { padding: 0 }`, but those rules don't win inside the canvas. Page Builder's dialog CSS is present in the canvas (cloned in by the editor) but never carried a list reset of its own.

## Fix

Replicate common.css's reset (`list-style: none; padding: 0`) in `css/admin.less`, scoped to the dialog/menu **chrome** containers:

- `.so-panels-dialog .so-sidebar`, `.so-panels-dialog .so-toolbar`, `.so-dropdown-wrapper`, `.so-panels-contextual-menu` (their `ul`s)
- `.so-panels-dialog .widget-type-list`, `.so-panels-dialog .so-directory-items-filters ul`

Scoped to chrome only — **not** `.so-content` widget forms, whose `<ul>`s (arbitrary `WP_Widget::form()` markup) are left untouched. A class-scoped rule beats the zero-specificity `:where()` reset.

Already-handled lists are unaffected: the in-builder row dropdown (existing `.siteorigin-panels-layout-block-container ul` reset) and the dialog sidebar tabs (existing `.so-sidebar-tabs` reset).

## Verified

In the block editor canvas: the Add Widget dialog list, toolbar dropdowns, and right-click row menu render with no bullets and flush (no indentation), matching the classic admin — confirmed by computed style (`list-style-type: none`, `padding-left: 0`) on the live `.widget-type-list`. Widget-form lists keep their markers. No change in the classic admin or on the front end (admin-only stylesheet).

## Related

Same block-editor-canvas family as #1350. Not the same as the separately-filed oversized-font issue (#1359).
