### PR TITLE
Fix builder rendering failures when stored widget or row style is null (#1366)

### DIFF
--- a/inc/styles-admin.php
+++ b/inc/styles-admin.php
@@ -586,11 +586,15 @@ class SiteOrigin_Panels_Styles_Admin {
 					);
 				}
 
-				if ( empty( $panels_data['widgets'][ $i ]['panels_info']['style'] ) ) {
-					continue;
+				if ( isset( $panels_data['widgets'][ $i ]['panels_info']['style'] ) ) {
+					if ( is_null( $panels_data['widgets'][ $i ]['panels_info']['style'] ) || ! is_array( $panels_data['widgets'][ $i ]['panels_info']['style'] ) ) {
+						unset( $panels_data['widgets'][ $i ]['panels_info']['style'] );
+					} elseif ( empty( $panels_data['widgets'][ $i ]['panels_info']['style'] ) ) {
+						continue;
+					} else {
+						$panels_data['widgets'][ $i ]['panels_info']['style'] = $this->sanitize_style_fields( 'widget', $panels_data['widgets'][ $i ]['panels_info']['style'] );
+					}
 				}
-
-				$panels_data['widgets'][ $i ]['panels_info']['style'] = $this->sanitize_style_fields( 'widget', $panels_data['widgets'][ $i ]['panels_info']['style'] );
 			}
 		}
 
@@ -603,20 +607,30 @@ class SiteOrigin_Panels_Styles_Admin {
 					);
 				}
 
-				if ( empty( $panels_data['grids'][ $i ]['style'] ) ) {
-					continue;
+				if ( isset( $panels_data['grids'][ $i ]['style'] ) ) {
+					if ( is_null( $panels_data['grids'][ $i ]['style'] ) || ! is_array( $panels_data['grids'][ $i ]['style'] ) ) {
+						unset( $panels_data['grids'][ $i ]['style'] );
+					} elseif ( empty( $panels_data['grids'][ $i ]['style'] ) ) {
+						continue;
+					} else {
+						$panels_data['grids'][ $i ]['style'] = $this->sanitize_style_fields( 'row', $panels_data['grids'][ $i ]['style'] );
+					}
 				}
-				$panels_data['grids'][ $i ]['style'] = $this->sanitize_style_fields( 'row', $panels_data['grids'][ $i ]['style'] );
 			}
 		}
 
 		if ( ! empty( $panels_data['grid_cells'] ) ) {
 			// And finally, the cells
 			for ( $i = 0; $i < count( $panels_data['grid_cells'] ); $i ++ ) {
-				if ( empty( $panels_data['grid_cells'][ $i ]['style'] ) ) {
-					continue;
+				if ( isset( $panels_data['grid_cells'][ $i ]['style'] ) ) {
+					if ( is_null( $panels_data['grid_cells'][ $i ]['style'] ) || ! is_array( $panels_data['grid_cells'][ $i ]['style'] ) ) {
+						unset( $panels_data['grid_cells'][ $i ]['style'] );
+					} elseif ( empty( $panels_data['grid_cells'][ $i ]['style'] ) ) {
+						continue;
+					} else {
+						$panels_data['grid_cells'][ $i ]['style'] = $this->sanitize_style_fields( 'cell', $panels_data['grid_cells'][ $i ]['style'] );
+					}
 				}
-				$panels_data['grid_cells'][ $i ]['style'] = $this->sanitize_style_fields( 'cell', $panels_data['grid_cells'][ $i ]['style'] );
 			}
 		}
 

--- a/js/siteorigin-panels/model/builder.js
+++ b/js/siteorigin-panels/model/builder.js
@@ -91,7 +91,7 @@ module.exports = Backbone.Model.extend({
 			_.each( rows, function ( row, i ) {
 				var rowAttrs = {};
 
-				if ( ! _.isUndefined( data.grids[i].style ) ) {
+				if ( ! _.isUndefined( data.grids[i].style ) && ! _.isNull( data.grids[i].style ) && _.isObject( data.grids[i].style ) ) {
 					rowAttrs.style = data.grids[i].style;
 				}
 
@@ -130,7 +130,7 @@ module.exports = Backbone.Model.extend({
 					values: widgetData
 				} );
 
-				if ( ! _.isUndefined( panels_info.style ) ) {
+				if ( ! _.isUndefined( panels_info.style ) && ! _.isNull( panels_info.style ) && _.isObject( panels_info.style ) ) {
 					newWidget.set( 'style', panels_info.style );
 				}
 

--- a/js/siteorigin-panels/model/cell.js
+++ b/js/siteorigin-panels/model/cell.js
@@ -16,6 +16,10 @@ module.exports = Backbone.Model.extend( {
 	 * Set up the cell model
 	 */
 	initialize: function () {
+		if ( ! _.isObject( this.get( 'style' ) ) || _.isNull( this.get( 'style' ) ) ) {
+			this.set( 'style', {} );
+		}
+
 		this.set( 'widgets', new panels.collection.widgets() );
 		this.on( 'destroy', this.onDestroy, this );
 	},

--- a/js/siteorigin-panels/model/row.js
+++ b/js/siteorigin-panels/model/row.js
@@ -12,15 +12,19 @@ module.exports = Backbone.Model.extend( {
 	 * Initialize the row model
 	 */
 	initialize: function () {
+		if ( ! _.isObject( this.get( 'style' ) ) || _.isNull( this.get( 'style' ) ) ) {
+			this.set( 'style', {} );
+		}
+
 		if ( _.isEmpty(this.get('cells') ) ) {
 			this.set('cells', new panels.collection.cells());
-		}
-		else {
+		} else {
 			// Make sure that the cells have this row set as their parent
 			this.get('cells').each( function( cell ){
 				cell.row = this;
 			}.bind( this ) );
 		}
+
 		this.on( 'destroy', this.onDestroy, this );
 	},
 

--- a/js/siteorigin-panels/model/widget.js
+++ b/js/siteorigin-panels/model/widget.js
@@ -28,6 +28,10 @@ module.exports = Backbone.Model.extend( {
 	indexes: null,
 
 	initialize: function () {
+		if ( ! _.isObject( this.get( 'style' ) ) || _.isNull( this.get( 'style' ) ) ) {
+			this.set( 'style', {} );
+		}
+
 		var widgetClass = this.get( 'class' );
 		if ( _.isUndefined( panelsOptions.widgets[widgetClass] ) || ! panelsOptions.widgets[widgetClass].installed ) {
 			this.set( 'missing', true );

--- a/js/siteorigin-panels/view/row.js
+++ b/js/siteorigin-panels/view/row.js
@@ -180,9 +180,10 @@ module.exports = Backbone.View.extend( {
 	 */
 	toggleVisibilityFade: function() {
 		var styles = this.model.attributes.style;
-		if ( typeof styles == 'undefined' ) {
+		if ( typeof styles == 'undefined' || styles === null || typeof styles !== 'object' ) {
 			return;
 		}
+
 		if (
 			this.checkIfStyleExists( styles, 'disable_row' ) ||
 			this.checkIfStyleExists( styles, 'disable_desktop' ) ||

--- a/js/siteorigin-panels/view/widget.js
+++ b/js/siteorigin-panels/view/widget.js
@@ -157,9 +157,10 @@ module.exports = Backbone.View.extend( {
 	 */
 	toggleVisibilityFade: function() {
 		var styles = this.model.attributes.style;
-		if ( typeof styles == 'undefined' ) {
+		if ( typeof styles == 'undefined' || styles === null || typeof styles !== 'object' ) {
 			return;
 		}
+
 		if (
 			this.checkIfStyleExists( styles, 'disable_widget' ) ||
 			this.checkIfStyleExists( styles, 'disable_desktop' ) ||


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-panels/issues/1366

- Frontend View Guards (widget.js, row.js): Prevent runtime exceptions in toggleVisibilityFade() when encountering null or non-object style values. (bea0fba2c3477bc89b52fced75305c6efa9e1c63)
- Model Loading (builder.js, cell.js, row.js, widget.js): Guard against assigning stored null styles and normalise uninitialized or invalid styles to {} during model instantiation. (08469963270042dde921f2b052d7a98d7c426877)
- Backend Sanitisation (styles-admin.php): Unset/remove null style entries during sanitize_all() so that corrupted style values do not survive save operations. (6b3d3341a88d3463f327f7b4144a62d2d01a0869)