### PR TITLE
Copy Content: Keep Shortcodes Intact in the Post Content Mirror

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -359,10 +359,17 @@ class SiteOrigin_Panels_Admin {
 
 			SiteOrigin_Panels_Post_Content_Filters::add_filters();
 			$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-			$post_content = self::render_and_restore_post_globals( $layout_id, false, $panels_data );
-			$post_css = SiteOrigin_Panels::renderer()->generate_css( $layout_id, $panels_data );
-			SiteOrigin_Panels_Post_Content_Filters::remove_filters();
-			unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
+
+			try {
+				$post_content = self::render_and_restore_post_globals( $layout_id, false, $panels_data );
+				$post_css = SiteOrigin_Panels::renderer()->generate_css( $layout_id, $panels_data );
+			} finally {
+				// A widget that throws mid-render must not leave the content
+				// render filters active or the shortcode registry suspended
+				// for the rest of the request.
+				SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+				unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
+			}
 
 			// Update the post_content.
 			$post->post_content = $post_content;
@@ -1604,9 +1611,13 @@ class SiteOrigin_Panels_Admin {
 		// Create a version of the builder data for post content.
 		SiteOrigin_Panels_Post_Content_Filters::add_filters();
 		$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-		echo self::render_and_restore_post_globals( (int) $_POST['post_id'], false, $panels_data );
-		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
-		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
+
+		try {
+			echo self::render_and_restore_post_globals( (int) $_POST['post_id'], false, $panels_data );
+		} finally {
+			SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+			unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
+		}
 
 		wp_die();
 	}
@@ -1656,9 +1667,13 @@ class SiteOrigin_Panels_Admin {
 		// Create a version of the builder data for post content.
 		SiteOrigin_Panels_Post_Content_Filters::add_filters();
 		$GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] = true;
-		$return['post_content'] = self::render_and_restore_post_globals( (int) $_POST['post_id'], false, $panels_data );
-		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
-		unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
+
+		try {
+			$return['post_content'] = self::render_and_restore_post_globals( (int) $_POST['post_id'], false, $panels_data );
+		} finally {
+			SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+			unset( $GLOBALS[ 'SITEORIGIN_PANELS_POST_CONTENT_RENDER' ] );
+		}
 
 		$return['preview'] = $this->generate_panels_preview( (int) $_POST['post_id'], $panels_data );
 

--- a/inc/post-content-filters.php
+++ b/inc/post-content-filters.php
@@ -7,9 +7,37 @@
  */
 class SiteOrigin_Panels_Post_Content_Filters {
 	/**
+	 * Backup of the registered shortcodes while shortcode execution is
+	 * suspended for a post content render. Null when not suspended.
+	 */
+	private static $shortcode_tags_backup = null;
+
+	/**
+	 * How many balanced add_filters()/remove_filters() scopes are currently
+	 * open. Only the outermost scope decides whether shortcodes are suspended,
+	 * backs the registry up, and restores it; nested scopes inherit that
+	 * decision without re-consulting the opt-out filter.
+	 */
+	private static $suspend_depth = 0;
+
+	/**
+	 * Whether the outermost open scope actually suspended shortcodes. False
+	 * while the opt-out filter declined suspension for this render.
+	 */
+	private static $suspend_active = false;
+
+	/**
 	 * Add filters that include data-* attributes on Page Builder divs
 	 */
 	public static function add_filters( $is_block_editor = false ) {
+		// Suspension runs first: it applies a public filter whose callbacks
+		// can throw, and the callers' try/finally cleanup only starts after
+		// add_filters() returns - so nothing may be registered before the one
+		// call that can fail.
+		if ( ! $is_block_editor ) {
+			self::suspend_shortcodes();
+		}
+
 		add_filter( 'siteorigin_panels_row_attributes', 'SiteOrigin_Panels_Post_Content_Filters::row_attributes', 99, 2 );
 		add_filter( 'siteorigin_panels_cell_attributes', 'SiteOrigin_Panels_Post_Content_Filters::cell_attributes', 99, 2 );
 		add_filter( 'siteorigin_panels_widget_attributes', 'SiteOrigin_Panels_Post_Content_Filters::widget_attributes', 99, 2 );
@@ -26,7 +54,107 @@ class SiteOrigin_Panels_Post_Content_Filters {
 
 		if ( ! $is_block_editor ) {
 			SiteOrigin_Panels_Widget_Shortcode::remove_filters();
+			self::restore_shortcodes();
 		}
+	}
+
+	/**
+	 * Suspend shortcode execution for the duration of a post content render.
+	 *
+	 * The post content copy is a mirror of the layout, not a snapshot of one
+	 * render. If shortcodes are executed while it's generated, their output is
+	 * baked into post_content — a Ninja Forms or similar form shortcode, for
+	 * example, is stored as its rendered placeholder markup, which then
+	 * displays broken (without the plugin's JS/CSS) anywhere the mirror is
+	 * shown instead of a live Page Builder render. Baked output also defeats
+	 * plugins that scan post_content with has_shortcode() to decide whether
+	 * to enqueue their front end assets.
+	 *
+	 * Emptying $shortcode_tags makes every do_shortcode() call during the
+	 * render a no-op, so widgets (the WP Text widget, the SiteOrigin Editor
+	 * widget, etc.) keep raw shortcodes intact in the mirror, and they run
+	 * normally through the_content when the mirror itself is displayed. A
+	 * shortcode registered while the render is running would repopulate the
+	 * registry and become executable, so the pre_do_shortcode_tag filter
+	 * short-circuits those too, returning the original shortcode text.
+	 */
+	private static function suspend_shortcodes() {
+		if ( self::$suspend_depth > 0 ) {
+			// Suspension is already active. Nested scopes must always pair
+			// with their remove_filters() call, so count them without
+			// consulting the opt-out filter — a mid-render change in its
+			// result must not desync the depth accounting.
+			self::$suspend_depth++;
+
+			return;
+		}
+
+		// Consult the opt-out filter before touching any state: a throwing
+		// filter callback must leave nothing to clean up, because the caller's
+		// try/finally only starts after add_filters() returns.
+		$suspend = (bool) apply_filters( 'siteorigin_panels_post_content_keep_shortcodes', true );
+
+		// The scope opens whether or not suspension engages, so a nested
+		// render inherits this decision instead of re-consulting the filter -
+		// an opted-out outer render must not gain suspension from a nested one.
+		self::$suspend_depth = 1;
+		self::$suspend_active = $suspend;
+
+		if ( ! $suspend ) {
+			return;
+		}
+
+		self::$shortcode_tags_backup = isset( $GLOBALS['shortcode_tags'] ) ? $GLOBALS['shortcode_tags'] : array();
+		$GLOBALS['shortcode_tags'] = array();
+		add_filter( 'pre_do_shortcode_tag', array( __CLASS__, 'keep_shortcode_intact' ), PHP_INT_MAX, 4 );
+	}
+
+	/**
+	 * Short-circuits any shortcode that reaches do_shortcode_tag() while the
+	 * registry is suspended, returning the original shortcode text unchanged.
+	 * Only a shortcode registered during the render can get this far.
+	 *
+	 * @param false|string $return The short-circuit value.
+	 * @param string       $tag    The shortcode tag.
+	 * @param array|string $attr   The shortcode attributes.
+	 * @param array        $m      The regex match for the shortcode.
+	 *
+	 * @return string The original, unexecuted shortcode text.
+	 */
+	public static function keep_shortcode_intact( $return, $tag, $attr, $m ) {
+		return $m[0];
+	}
+
+	private static function restore_shortcodes() {
+		if ( self::$suspend_depth === 0 ) {
+			return;
+		}
+
+		self::$suspend_depth--;
+
+		if ( self::$suspend_depth > 0 ) {
+			// A nested scope closed; the outermost scope restores.
+			return;
+		}
+
+		if ( ! self::$suspend_active ) {
+			// The outermost scope closed, but this render opted out of
+			// suspension - there is nothing to restore.
+			return;
+		}
+
+		self::$suspend_active = false;
+
+		remove_filter( 'pre_do_shortcode_tag', array( __CLASS__, 'keep_shortcode_intact' ), PHP_INT_MAX );
+
+		// Keep any shortcodes registered during the render, but let the
+		// original registrations win. Array union rather than array_merge:
+		// digit-only shortcode tags are valid and PHP stores them as integer
+		// keys, which array_merge would silently renumber from zero.
+		$GLOBALS['shortcode_tags'] = self::$shortcode_tags_backup + (
+			is_array( $GLOBALS['shortcode_tags'] ) ? $GLOBALS['shortcode_tags'] : array()
+		);
+		self::$shortcode_tags_backup = null;
 	}
 
 	/**

--- a/inc/widget-shortcode.php
+++ b/inc/widget-shortcode.php
@@ -6,6 +6,7 @@ class SiteOrigin_Panels_Widget_Shortcode {
 		'SiteOrigin_Panels_Widgets_Layout',
 		'WP_Widget_Black_Studio_TinyMCE',
 		'WP_Widget_Text',
+		'WP_Widget_Custom_HTML',
 	);
 
 	public static function init() {

--- a/tests/PostContentShortcodeSuspensionTest.php
+++ b/tests/PostContentShortcodeSuspensionTest.php
@@ -1,0 +1,431 @@
+<?php
+
+use SiteOrigin\Tests\SiteOriginTests;
+use Brain\Monkey\Functions;
+
+// Load the REAL classes under test. The copy-content parity suite uses a
+// counting shim for SiteOrigin_Panels_Post_Content_Filters, which is why it
+// runs in its own suite; this suite exercises the real implementation.
+if ( ! class_exists( 'SiteOrigin_Panels_Widget_Shortcode', false ) ) {
+	require __DIR__ . '/../inc/widget-shortcode.php';
+}
+
+if ( ! class_exists( 'SiteOrigin_Panels_Post_Content_Filters', false ) ) {
+	require __DIR__ . '/../inc/post-content-filters.php';
+}
+
+/**
+ * Tests for shortcode suspension during post content (copy-content) renders.
+ *
+ * The post content mirror must keep raw shortcodes intact rather than baking
+ * their rendered output into post_content. Executed shortcode output in the
+ * mirror both displays broken wherever the mirror is shown instead of a live
+ * Page Builder render (e.g. a Ninja Forms placeholder stored without the
+ * plugin's JS/CSS ever being enqueued), and defeats plugins that scan
+ * post_content with has_shortcode() to decide whether to enqueue assets.
+ *
+ * SiteOrigin_Panels_Post_Content_Filters::add_filters() therefore empties the
+ * global $shortcode_tags registry for the duration of the render — making
+ * every do_shortcode() call a no-op that returns its input unchanged — and
+ * remove_filters() restores the registry.
+ */
+class PostContentShortcodeSuspensionTest extends SiteOriginTests {
+	protected function setUp(): void {
+		parent::setUp();
+
+		// The real Widget_Shortcode::add_filters()/remove_filters() call
+		// add_filter()/remove_filter(); Brain Monkey stubs these.
+		Functions\when( 'add_filter' )->justReturn( true );
+		Functions\when( 'remove_filter' )->justReturn( true );
+		Functions\when( 'apply_filters' )->alias(
+			fn( $tag, $value ) => $value
+		);
+
+		$this->reset_backup();
+		$GLOBALS['shortcode_tags'] = array( 'ninja_forms' => 'nf_callback' );
+	}
+
+	protected function tearDown(): void {
+		$this->reset_backup();
+		unset( $GLOBALS['shortcode_tags'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Reset the private static state so it can't leak between tests.
+	 */
+	private function reset_backup() {
+		$ref = new ReflectionProperty( SiteOrigin_Panels_Post_Content_Filters::class, 'shortcode_tags_backup' );
+		$ref->setAccessible( true );
+		$ref->setValue( null, null );
+
+		$depth = new ReflectionProperty( SiteOrigin_Panels_Post_Content_Filters::class, 'suspend_depth' );
+		$depth->setAccessible( true );
+		$depth->setValue( null, 0 );
+
+		$active = new ReflectionProperty( SiteOrigin_Panels_Post_Content_Filters::class, 'suspend_active' );
+		$active->setAccessible( true );
+		$active->setValue( null, false );
+	}
+
+	public function test_add_filters_suspends_shortcodes_and_remove_filters_restores() {
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+
+		$this->assertSame(
+			array(),
+			$GLOBALS['shortcode_tags'],
+			'Shortcode registry must be empty during a post content render so do_shortcode() leaves shortcodes intact.'
+		);
+
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		$this->assertSame(
+			array( 'ninja_forms' => 'nf_callback' ),
+			$GLOBALS['shortcode_tags'],
+			'Shortcode registry must be restored after the post content render.'
+		);
+	}
+
+	public function test_block_editor_render_does_not_suspend_shortcodes() {
+		SiteOrigin_Panels_Post_Content_Filters::add_filters( true );
+
+		$this->assertSame(
+			array( 'ninja_forms' => 'nf_callback' ),
+			$GLOBALS['shortcode_tags'],
+			'Block editor preview renders are live previews; shortcodes must still execute.'
+		);
+
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters( true );
+
+		$this->assertSame( array( 'ninja_forms' => 'nf_callback' ), $GLOBALS['shortcode_tags'] );
+	}
+
+	public function test_shortcodes_registered_during_render_survive_restore() {
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+
+		// A widget lazily registers a shortcode while rendering, and also
+		// tries to claim a tag that was registered before the render.
+		$GLOBALS['shortcode_tags']['lazy'] = 'lazy_callback';
+		$GLOBALS['shortcode_tags']['ninja_forms'] = 'usurper_callback';
+
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		$this->assertSame(
+			'lazy_callback',
+			$GLOBALS['shortcode_tags']['lazy'],
+			'Shortcodes registered during the render must survive the restore.'
+		);
+		$this->assertSame(
+			'nf_callback',
+			$GLOBALS['shortcode_tags']['ninja_forms'],
+			'Original registrations must win over re-registrations made during the render.'
+		);
+	}
+
+	public function test_late_registered_shortcodes_cannot_execute_while_suspended() {
+		$filters = array();
+		Functions\when( 'add_filter' )->alias( function ( $tag, $cb, $priority = 10, $accepted_args = 1 ) use ( &$filters ) {
+			$filters[ $tag ] = array( 'cb' => $cb, 'priority' => $priority, 'args' => $accepted_args );
+
+			return true;
+		} );
+		// Removal requires the same callback identity and priority, as
+		// WordPress's remove_filter() does - a removal naming the wrong
+		// callback must leak the guard, not silently clear it.
+		Functions\when( 'remove_filter' )->alias( function ( $tag, $cb = null, $priority = 10 ) use ( &$filters ) {
+			if (
+				isset( $filters[ $tag ] ) &&
+				$filters[ $tag ]['priority'] === $priority &&
+				$filters[ $tag ]['cb'] === $cb
+			) {
+				unset( $filters[ $tag ] );
+			}
+
+			return true;
+		} );
+
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+
+		// A shortcode registered mid-render repopulates the registry, so the
+		// registry alone no longer protects it. The pre_do_shortcode_tag
+		// short-circuit must be in place at the latest priority (a later
+		// callback at the same priority could still override; higher cannot),
+		// receiving all four arguments - with WordPress's default of one, the
+		// callback would fatal for want of $m.
+		$this->assertArrayHasKey( 'pre_do_shortcode_tag', $filters,
+			'The execution guard must be registered for the whole suspended scope.' );
+		$this->assertSame( PHP_INT_MAX, $filters['pre_do_shortcode_tag']['priority'],
+			'The guard must register at the latest priority.' );
+		$this->assertSame( 4, $filters['pre_do_shortcode_tag']['args'],
+			'The guard needs all four arguments; the default of one would fatal on $m.' );
+
+		$m = array( '[late_tag foo="bar"]', '', 'late_tag', ' foo="bar"', '', '', '' );
+		$this->assertSame(
+			'[late_tag foo="bar"]',
+			call_user_func( $filters['pre_do_shortcode_tag']['cb'], false, 'late_tag', array( 'foo' => 'bar' ), $m ),
+			'A late-registered shortcode reaching do_shortcode_tag() must come back as its original text.'
+		);
+
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		$this->assertArrayNotHasKey( 'pre_do_shortcode_tag', $filters,
+			'The execution guard must be removed, at its own priority, when the outermost scope closes.' );
+	}
+
+	public function test_a_throwing_opt_out_callback_leaves_no_state_behind() {
+		$added = array();
+		Functions\when( 'add_filter' )->alias( function ( $tag ) use ( &$added ) {
+			$added[] = $tag;
+
+			return true;
+		} );
+		Functions\when( 'apply_filters' )->alias( function ( $tag, $value ) {
+			if ( 'siteorigin_panels_post_content_keep_shortcodes' === $tag ) {
+				throw new RuntimeException( 'filter callback threw' );
+			}
+
+			return $value;
+		} );
+
+		// The caller's try/finally starts only after add_filters() returns,
+		// so a throw from the opt-out filter must leave nothing to clean up:
+		// no open scope, no emptied registry, no backup.
+		try {
+			SiteOrigin_Panels_Post_Content_Filters::add_filters();
+			$this->fail( 'The filter exception must propagate.' );
+		} catch ( RuntimeException $e ) {
+		}
+
+		$this->assertSame(
+			array( 'ninja_forms' => 'nf_callback' ),
+			$GLOBALS['shortcode_tags'],
+			'A throwing opt-out callback must not leave the registry suspended.'
+		);
+
+		$depth = new ReflectionProperty( SiteOrigin_Panels_Post_Content_Filters::class, 'suspend_depth' );
+		$depth->setAccessible( true );
+		$this->assertSame( 0, $depth->getValue(), 'No scope may remain open after the throw.' );
+
+		$this->assertSame(
+			array(),
+			$added,
+			'No WordPress filter may be registered before the throwable opt-out consult.'
+		);
+	}
+
+	public function test_opted_out_render_is_inherited_by_nested_scopes() {
+		$allow = false;
+		Functions\when( 'apply_filters' )->alias(
+			function ( $tag, $value ) use ( &$allow ) {
+				return 'siteorigin_panels_post_content_keep_shortcodes' === $tag ? $allow : $value;
+			}
+		);
+
+		$GLOBALS['shortcode_tags'] = array( 'existing' => 'existing_callback' );
+
+		// The outer render opts out; the filter then flips to true before a
+		// nested scope opens. The nested scope must inherit the outer
+		// decision, never start a suspension of its own.
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+		$allow = true;
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+
+		$this->assertSame(
+			array( 'existing' => 'existing_callback' ),
+			$GLOBALS['shortcode_tags'],
+			'A nested scope inside an opted-out render must not suspend shortcodes.'
+		);
+
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		$this->assertSame(
+			array( 'existing' => 'existing_callback' ),
+			$GLOBALS['shortcode_tags'],
+			'The registry must be untouched after an opted-out render closes.'
+		);
+	}
+
+	public function test_digit_only_shortcode_tags_survive_the_restore_unrenamed() {
+		// Digit-only tags are valid shortcode names and PHP stores them as
+		// integer keys, which a renumbering merge would silently corrupt.
+		$GLOBALS['shortcode_tags']['123'] = 'digit_callback';
+
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+		$GLOBALS['shortcode_tags']['456'] = 'late_digit_callback';
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		$this->assertSame(
+			'digit_callback',
+			$GLOBALS['shortcode_tags'][123] ?? null,
+			'A digit-only tag registered before the render must keep its key through the restore.'
+		);
+		$this->assertSame(
+			'late_digit_callback',
+			$GLOBALS['shortcode_tags'][456] ?? null,
+			'A digit-only tag registered during the render must keep its key too.'
+		);
+		$this->assertArrayNotHasKey( 0, $GLOBALS['shortcode_tags'],
+			'The restore must never renumber integer keys from zero.' );
+	}
+
+	public function test_nested_scope_counts_even_when_the_opt_out_filter_flips_mid_render() {
+		$calls = 0;
+		Functions\when( 'apply_filters' )->alias(
+			function ( $tag, $value ) use ( &$calls ) {
+				if ( $tag !== 'siteorigin_panels_post_content_keep_shortcodes' ) {
+					return $value;
+				}
+				$calls++;
+
+				// True for the outer scope; false if consulted again.
+				return $calls === 1;
+			}
+		);
+
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+		// The nested scope must be counted without consulting the filter, so
+		// a flipped filter result cannot desync the depth accounting.
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		$this->assertSame(
+			array(),
+			$GLOBALS['shortcode_tags'],
+			'The inner scope closing must not restore while the outer suspending scope is still open.'
+		);
+
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		$this->assertSame( array( 'ninja_forms' => 'nf_callback' ), $GLOBALS['shortcode_tags'] );
+	}
+
+	public function test_keep_shortcodes_filter_opts_out_of_suspension() {
+		Functions\when( 'apply_filters' )->alias(
+			fn( $tag, $value ) => $tag === 'siteorigin_panels_post_content_keep_shortcodes' ? false : $value
+		);
+
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+
+		$this->assertSame(
+			array( 'ninja_forms' => 'nf_callback' ),
+			$GLOBALS['shortcode_tags'],
+			'Sites can opt back into baking shortcode output via the filter.'
+		);
+
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		$this->assertSame( array( 'ninja_forms' => 'nf_callback' ), $GLOBALS['shortcode_tags'] );
+	}
+
+	public function test_nested_scopes_stay_suspended_until_the_outermost_closes() {
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+
+		// Closing the inner scope must NOT restore; the outer render is
+		// still in progress.
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		$this->assertSame(
+			array(),
+			$GLOBALS['shortcode_tags'],
+			'Shortcodes must stay suspended while an outer render scope is still open.'
+		);
+
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		$this->assertSame(
+			array( 'ninja_forms' => 'nf_callback' ),
+			$GLOBALS['shortcode_tags'],
+			'The outermost scope closing must restore the original registry.'
+		);
+	}
+
+	public function test_excess_remove_filters_is_a_no_op() {
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		// An unbalanced extra remove must not corrupt the registry or the
+		// suspension state for a later render.
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+
+		$this->assertSame( array( 'ninja_forms' => 'nf_callback' ), $GLOBALS['shortcode_tags'] );
+
+		SiteOrigin_Panels_Post_Content_Filters::add_filters();
+		$this->assertSame( array(), $GLOBALS['shortcode_tags'] );
+		SiteOrigin_Panels_Post_Content_Filters::remove_filters();
+		$this->assertSame( array( 'ninja_forms' => 'nf_callback' ), $GLOBALS['shortcode_tags'] );
+	}
+
+	public function test_custom_html_widget_is_treated_as_a_text_widget() {
+		$this->assertContains(
+			'WP_Widget_Custom_HTML',
+			SiteOrigin_Panels_Widget_Shortcode::$text_widgets,
+			'The Custom HTML widget must keep its raw markup (and raw shortcodes) in the post content mirror rather than being replaced by a [siteorigin_widget] wrapper.'
+		);
+	}
+
+	// --- widget_html(): the mirror's widget substitution layer ---------------
+
+	public function test_widget_html_lets_the_custom_html_widget_render_its_own_markup() {
+		$GLOBALS['SITEORIGIN_PANELS_POST_CONTENT_RENDER'] = true;
+
+		$widget = new WP_Widget_Custom_HTML();
+		$html = SiteOrigin_Panels_Widget_Shortcode::widget_html(
+			'',
+			$widget,
+			array(),
+			array( 'content' => '<h2>Contact</h2>[ninja_forms id=1]' )
+		);
+
+		unset( $GLOBALS['SITEORIGIN_PANELS_POST_CONTENT_RENDER'] );
+
+		$this->assertSame(
+			'',
+			$html,
+			'widget_html() must return empty for the Custom HTML widget so the renderer falls through to the real widget() output, keeping raw markup and shortcodes in the mirror.'
+		);
+	}
+
+	public function test_widget_html_still_wraps_non_text_widgets_in_a_widget_shortcode() {
+		$GLOBALS['SITEORIGIN_PANELS_POST_CONTENT_RENDER'] = true;
+
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'esc_textarea' )->returnArg();
+		Functions\when( 'apply_filters' )->alias(
+			fn( $tag, $value ) => $value
+		);
+
+		$widget = new PostContentSuspension_OtherWidgetDouble();
+		$html = SiteOrigin_Panels_Widget_Shortcode::widget_html(
+			'',
+			$widget,
+			array(),
+			array( 'some_setting' => 'value' )
+		);
+
+		unset( $GLOBALS['SITEORIGIN_PANELS_POST_CONTENT_RENDER'] );
+
+		$this->assertStringStartsWith(
+			'[siteorigin_widget class="PostContentSuspension_OtherWidgetDouble"]',
+			$html,
+			'Non-text widgets must still be represented by a [siteorigin_widget] wrapper in the mirror.'
+		);
+		$this->assertStringEndsWith( '[/siteorigin_widget]', $html );
+	}
+}
+
+/**
+ * get_class() doubles for widget_html() tests. The real WP_Widget classes are
+ * not available outside WordPress; widget_html() only inspects the class name,
+ * so an empty class carrying core's exact name stands in for the real widget.
+ */
+if ( ! class_exists( 'WP_Widget_Custom_HTML', false ) ) {
+	class WP_Widget_Custom_HTML {
+	}
+}
+
+class PostContentSuspension_OtherWidgetDouble {
+}

--- a/tests/copy-content/CopyContentParityTest.php
+++ b/tests/copy-content/CopyContentParityTest.php
@@ -17,9 +17,14 @@ class CopyContent_RendererSpy {
 	public $css_args    = array();
 	public $render_return = '<div class="rendered">HTML</div>';
 	public $css_return    = '.panel { color: red; }';
+	public $render_throws = null;
 
 	public function render( $layout_id, $enqueue_css = false, $panels_data = false ) {
 		$this->render_args = array( $layout_id, $enqueue_css, $panels_data );
+
+		if ( $this->render_throws !== null ) {
+			throw $this->render_throws;
+		}
 
 		return $this->render_return;
 	}
@@ -258,5 +263,34 @@ class CopyContentParityTest extends SiteOriginTests {
 
 		$this->assertNotNull( $wpdb->updated_with, 'direct_db path must write via $wpdb->update().' );
 		$this->assertSame( '<div class="rendered">HTML</div>', $wpdb->updated_with[1]['post_content'] );
+	}
+
+	// --- render filters and globals are cleaned up when a widget throws -------
+
+	public function test_render_exception_still_removes_filters_and_render_global() {
+		CopyContent_RendererSpy::$instance->render_throws = new RuntimeException( 'widget exploded' );
+		Functions\expect( 'wp_update_post' )->never();
+
+		$post = $this->post( 10 );
+		$thrown = null;
+
+		try {
+			$this->admin()->copy_content_to_post( $post, 10, array( 'widgets' => array( 'w' ) ) );
+		} catch ( RuntimeException $e ) {
+			$thrown = $e;
+		}
+
+		$this->assertNotNull( $thrown, 'The render exception must propagate, not be swallowed.' );
+		$this->assertSame( 1, SiteOrigin_Panels_Post_Content_Filters::$added );
+		$this->assertSame(
+			1,
+			SiteOrigin_Panels_Post_Content_Filters::$removed,
+			'remove_filters() must run even when the render throws, so the shortcode registry and content filters cannot leak into the rest of the request.'
+		);
+		$this->assertArrayNotHasKey(
+			'SITEORIGIN_PANELS_POST_CONTENT_RENDER',
+			$GLOBALS,
+			'The content render global must not leak when the render throws.'
+		);
 	}
 }


### PR DESCRIPTION
Re-lands #1372, which was merged and then reverted on `develop` (8dbbf5ba) so it could get a proper review before release. Fixes #1370.

**What it changes.** During the Copy Content render, Page Builder empties the shortcode registry, so every widget from every plugin keeps raw `[shortcode]` text in the `post_content` copy instead of baked output. Core Text widget shortcodes have baked into the mirror since 2017. This reverses that for everyone, with `siteorigin_panels_post_content_keep_shortcodes` as the opt-out.

**Why it exists.** A form shortcode baked into the mirror displayed as a dead form wherever the mirror was shown, and the form plugin's `has_shortcode()` check never found its shortcode, so its assets didn't load.

**The history.** @AlexGStapleton asked for shortcodes to stay intact in the copy in #361 and #362. Greg's answer was a per-widget flag, which the Editor widget used for seven years. so-widgets-bundle@16abcb6a (1.58.11, March 2024) moved `do_shortcode` outside that guard for the Block Editor, and the Editor widget started baking. so-widgets-bundle#2364, already on develop, puts it back and covers the reporter's case on its own.

**The question for review.** Is the global version worth the surface area? The risk is anything reading `post_content` raw and expecting HTML: headless or REST consumers, a search indexer with shortcode expansion off, an email plugin. Front-end rendering is untouched.

Tests: 14-method `PostContentShortcodeSuspensionTest` plus a `CopyContentParityTest` exception-safety case. All five suites pass. Verified live on a local site through the classic editor save path.

Companion: so-widgets-bundle#2366 (draft) makes the Editor widget honour the opt-out filter. Merge it only if this lands.
